### PR TITLE
[Feat] 모달 컴포넌트 구현

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko" className={`${nanumSquare.className} h-full antialiased`}>
-      <body className="min-h-full p-4">
+      <body className="min-h-full">
         <AppShell>{children}</AppShell>
       </body>
     </html>

--- a/src/components/common/AppShell.tsx
+++ b/src/components/common/AppShell.tsx
@@ -7,10 +7,23 @@ import { cn } from '@/lib/utils';
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const [collapsed] = React.useState(false);
+  const sidebarWidth = collapsed ? '73px' : '252px';
+  const appContentLeft = collapsed ? '89px' : '268px';
+
+  React.useEffect(() => {
+    document.documentElement.style.setProperty('--app-sidebar-width', sidebarWidth);
+    document.documentElement.style.setProperty('--app-content-left', appContentLeft);
+
+    return () => {
+      document.documentElement.style.removeProperty('--app-sidebar-width');
+      document.documentElement.style.removeProperty('--app-content-left');
+    };
+  }, [appContentLeft, sidebarWidth]);
 
   return (
     <div
       className={cn(
+        'min-h-full p-4',
         // sidebar-width는 사이드바 자체 너비, content-left는 left-4 여백까지 포함한 콘텐츠 시작 위치
         collapsed
           ? '[--app-content-left:89px] [--app-sidebar-width:73px]'

--- a/src/components/common/AppShell.tsx
+++ b/src/components/common/AppShell.tsx
@@ -3,12 +3,22 @@
 import * as React from 'react';
 
 import { Sidebar } from '@/components/common/Sidebar';
-import { cn } from '@/lib/utils';
+
+const APP_SHELL_PADDING = '16px';
+const SIDEBAR_WIDTH = {
+  collapsed: '73px',
+  expanded: '252px',
+} as const;
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const [collapsed] = React.useState(false);
-  const sidebarWidth = collapsed ? '73px' : '252px';
-  const appContentLeft = collapsed ? '89px' : '268px';
+  const sidebarWidth = collapsed ? SIDEBAR_WIDTH.collapsed : SIDEBAR_WIDTH.expanded;
+  const appContentLeft = `calc(${sidebarWidth} + ${APP_SHELL_PADDING})`;
+  const appShellStyle = {
+    '--app-shell-padding': APP_SHELL_PADDING,
+    '--app-sidebar-width': sidebarWidth,
+    '--app-content-left': appContentLeft,
+  } as React.CSSProperties;
 
   React.useEffect(() => {
     document.documentElement.style.setProperty('--app-sidebar-width', sidebarWidth);
@@ -22,18 +32,12 @@ export function AppShell({ children }: { children: React.ReactNode }) {
 
   return (
     <div
-      className={cn(
-        'min-h-full p-4',
-        // sidebar-width는 사이드바 자체 너비, content-left는 left-4 여백까지 포함한 콘텐츠 시작 위치
-        collapsed
-          ? '[--app-content-left:89px] [--app-sidebar-width:73px]'
-          : '[--app-content-left:268px] [--app-sidebar-width:252px]',
-      )}
+      style={appShellStyle}
+      // sidebar-width는 사이드바 자체 너비, content-left는 left-4 여백까지 포함한 콘텐츠 시작 위치
+      className="min-h-full p-(--app-shell-padding)"
     >
       <Sidebar collapsed={collapsed} />
-      <main
-        className={cn('min-h-[calc(100vh-32px)] min-w-0', collapsed ? 'ml-[73px]' : 'ml-[252px]')}
-      >
+      <main className="ml-(--app-sidebar-width) min-h-[calc(100vh-(var(--app-shell-padding)*2))] min-w-0">
         {children}
       </main>
     </div>

--- a/src/components/common/AppShell.tsx
+++ b/src/components/common/AppShell.tsx
@@ -9,13 +9,20 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const [collapsed] = React.useState(false);
 
   return (
-    <>
+    <div
+      className={cn(
+        // sidebar-width는 사이드바 자체 너비, content-left는 left-4 여백까지 포함한 콘텐츠 시작 위치
+        collapsed
+          ? '[--app-content-left:89px] [--app-sidebar-width:73px]'
+          : '[--app-content-left:268px] [--app-sidebar-width:252px]',
+      )}
+    >
       <Sidebar collapsed={collapsed} />
       <main
         className={cn('min-h-[calc(100vh-32px)] min-w-0', collapsed ? 'ml-[73px]' : 'ml-[252px]')}
       >
         {children}
       </main>
-    </>
+    </div>
   );
 }

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import * as React from 'react';
+
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { XIcon } from '@/components/common/icons/XIcon';
+import { cn } from '@/lib/utils';
+
+export interface ModalProps extends Omit<React.ComponentProps<typeof Dialog>, 'children'> {
+  children: React.ReactNode;
+  contentClassName?: string;
+  showCloseButton?: boolean;
+}
+
+function Modal({ children, contentClassName, showCloseButton = false, ...props }: ModalProps) {
+  return (
+    <Dialog {...props}>
+      <DialogContent
+        className={cn(
+          'flex w-[calc(100vw-var(--app-content-left,0px)-32px)] max-w-[864px] flex-col items-end justify-end gap-6 overflow-hidden rounded-xl border border-border-default bg-background-w px-[30px] py-5 text-strong ring-0 sm:max-w-[864px]',
+          'left-[calc(var(--app-content-left,0px)+(100vw-var(--app-content-left,0px))/2)]',
+          contentClassName,
+        )}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogClose asChild>
+            <button
+              type="button"
+              aria-label="모달 닫기"
+              className="absolute top-5 right-[30px] flex size-8 cursor-pointer items-center justify-center rounded-sm bg-background-w text-gray-main"
+            >
+              <XIcon className="size-6" />
+            </button>
+          </DialogClose>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+export {
+  Modal,
+  DialogClose as ModalClose,
+  DialogDescription as ModalDescription,
+  DialogTitle as ModalTitle,
+  DialogTrigger as ModalTrigger,
+};

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -25,7 +25,7 @@ function Modal({ children, contentClassName, showCloseButton = false, ...props }
       <DialogContent
         className={cn(
           'flex w-[calc(100vw-var(--app-content-left,0px)-32px)] max-w-[864px] flex-col items-end justify-end gap-6 overflow-hidden rounded-xl border border-border-default bg-background-w px-[30px] py-5 text-strong ring-0 sm:max-w-[864px]',
-          'left-[calc(var(--app-content-left,0px)+(100vw-var(--app-content-left,0px))/2)]',
+          'left-[calc((var(--app-content-left,0px)+100vw)/2)]',
           contentClassName,
         )}
       >

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -24,7 +24,7 @@ function Modal({ children, contentClassName, showCloseButton = false, ...props }
     <Dialog {...props}>
       <DialogContent
         className={cn(
-          'flex w-[calc(100vw-var(--app-content-left,0px)-32px)] max-w-[864px] flex-col items-stretch gap-6 overflow-hidden rounded-xl border border-border-default bg-background-w px-[30px] py-5 text-strong ring-0 sm:max-w-[864px]',
+          'flex max-h-[calc(100dvh-40px)] w-[calc(100vw-var(--app-content-left,0px)-32px)] max-w-[864px] flex-col items-stretch gap-6 overflow-y-auto rounded-xl border border-border-default bg-background-w px-[30px] py-5 text-strong ring-0 sm:max-w-[864px]',
           'left-[calc((var(--app-content-left,0px)+100vw)/2)]',
           contentClassName,
         )}

--- a/src/components/common/Modal.tsx
+++ b/src/components/common/Modal.tsx
@@ -24,7 +24,7 @@ function Modal({ children, contentClassName, showCloseButton = false, ...props }
     <Dialog {...props}>
       <DialogContent
         className={cn(
-          'flex w-[calc(100vw-var(--app-content-left,0px)-32px)] max-w-[864px] flex-col items-end justify-end gap-6 overflow-hidden rounded-xl border border-border-default bg-background-w px-[30px] py-5 text-strong ring-0 sm:max-w-[864px]',
+          'flex w-[calc(100vw-var(--app-content-left,0px)-32px)] max-w-[864px] flex-col items-stretch gap-6 overflow-hidden rounded-xl border border-border-default bg-background-w px-[30px] py-5 text-strong ring-0 sm:max-w-[864px]',
           'left-[calc((var(--app-content-left,0px)+100vw)/2)]',
           contentClassName,
         )}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,0 +1,168 @@
+"use client"
+
+import * as React from "react"
+import { Dialog as DialogPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+import { XIcon } from "lucide-react"
+
+function Dialog({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+}
+
+function DialogTrigger({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+}
+
+function DialogPortal({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+}
+
+function DialogClose({
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+}
+
+function DialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Overlay>) {
+  return (
+    <DialogPrimitive.Overlay
+      data-slot="dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Content> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Content
+        data-slot="dialog-content"
+        className={cn(
+          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close data-slot="dialog-close" asChild>
+            <Button
+              variant="ghost"
+              className="absolute top-2 right-2"
+              size="icon-sm"
+            >
+              <XIcon
+              />
+              <span className="sr-only">Close</span>
+            </Button>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Content>
+    </DialogPortal>
+  )
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="dialog-header"
+      className={cn("flex flex-col gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & {
+  showCloseButton?: boolean
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn(
+        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      {showCloseButton && (
+        <DialogPrimitive.Close asChild>
+          <Button variant="outline">Close</Button>
+        </DialogPrimitive.Close>
+      )}
+    </div>
+  )
+}
+
+function DialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn(
+        "text-base leading-none font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof DialogPrimitive.Description>) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
+}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -30,7 +30,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        'fixed inset-0 isolate z-50 bg-gray-main/20 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        'fixed inset-0 isolate z-50 bg-gray-main/20 duration-100 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=closed]:animate-out data-[state=closed]:fade-out-0',
         className,
       )}
       {...props}
@@ -49,7 +49,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',
           className,
         )}
         {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -69,10 +69,12 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
 function DialogFooter({
   className,
   showFooterCloseButton = false,
+  footerCloseLabel = '닫기',
   children,
   ...props
 }: React.ComponentProps<'div'> & {
   showFooterCloseButton?: boolean;
+  footerCloseLabel?: string;
 }) {
   return (
     <div
@@ -86,7 +88,7 @@ function DialogFooter({
       {children}
       {showFooterCloseButton && (
         <DialogPrimitive.Close asChild>
-          <Button variant="line">Close</Button>
+          <Button variant="line">{footerCloseLabel}</Button>
         </DialogPrimitive.Close>
       )}
     </div>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,34 +1,25 @@
-"use client"
+'use client';
 
-import * as React from "react"
-import { Dialog as DialogPrimitive } from "radix-ui"
+import * as React from 'react';
+import { Dialog as DialogPrimitive } from 'radix-ui';
 
-import { cn } from "@/lib/utils"
-import { Button } from "@/components/ui/button"
-import { XIcon } from "lucide-react"
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
 
-function Dialog({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Root>) {
-  return <DialogPrimitive.Root data-slot="dialog" {...props} />
+function Dialog({ ...props }: React.ComponentProps<typeof DialogPrimitive.Root>) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
 }
 
-function DialogTrigger({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
-  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />
+function DialogTrigger({ ...props }: React.ComponentProps<typeof DialogPrimitive.Trigger>) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
 }
 
-function DialogPortal({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Portal>) {
-  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />
+function DialogPortal({ ...props }: React.ComponentProps<typeof DialogPrimitive.Portal>) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
 }
 
-function DialogClose({
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Close>) {
-  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />
+function DialogClose({ ...props }: React.ComponentProps<typeof DialogPrimitive.Close>) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
 }
 
 function DialogOverlay({
@@ -39,60 +30,40 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
-        className
+        'fixed inset-0 isolate z-50 bg-gray-main/20 duration-100 data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 function DialogContent({
   className,
   children,
-  showCloseButton = true,
   ...props
-}: React.ComponentProps<typeof DialogPrimitive.Content> & {
-  showCloseButton?: boolean
-}) {
+}: React.ComponentProps<typeof DialogPrimitive.Content>) {
   return (
     <DialogPortal>
       <DialogOverlay />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
-          className
+          'fixed top-1/2 left-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-4 rounded-xl bg-popover p-4 text-sm text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none sm:max-w-sm data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95',
+          className,
         )}
         {...props}
       >
         {children}
-        {showCloseButton && (
-          <DialogPrimitive.Close data-slot="dialog-close" asChild>
-            <Button
-              variant="secondary"
-              className="absolute top-2 right-2"
-              size="icon"
-            >
-              <XIcon
-              />
-              <span className="sr-only">Close</span>
-            </Button>
-          </DialogPrimitive.Close>
-        )}
       </DialogPrimitive.Content>
     </DialogPortal>
-  )
+  );
 }
 
-function DialogHeader({ className, ...props }: React.ComponentProps<"div">) {
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
   return (
-    <div
-      data-slot="dialog-header"
-      className={cn("flex flex-col gap-2", className)}
-      {...props}
-    />
-  )
+    <div data-slot="dialog-header" className={cn('flex flex-col gap-2', className)} {...props} />
+  );
 }
 
 function DialogFooter({
@@ -100,15 +71,15 @@ function DialogFooter({
   showCloseButton = false,
   children,
   ...props
-}: React.ComponentProps<"div"> & {
-  showCloseButton?: boolean
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean;
 }) {
   return (
     <div
       data-slot="dialog-footer"
       className={cn(
-        "-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end",
-        className
+        '-mx-4 -mb-4 flex flex-col-reverse gap-2 rounded-b-xl border-t bg-muted/50 p-4 sm:flex-row sm:justify-end',
+        className,
       )}
       {...props}
     >
@@ -119,23 +90,17 @@ function DialogFooter({
         </DialogPrimitive.Close>
       )}
     </div>
-  )
+  );
 }
 
-function DialogTitle({
-  className,
-  ...props
-}: React.ComponentProps<typeof DialogPrimitive.Title>) {
+function DialogTitle({ className, ...props }: React.ComponentProps<typeof DialogPrimitive.Title>) {
   return (
     <DialogPrimitive.Title
       data-slot="dialog-title"
-      className={cn(
-        "text-base leading-none font-medium",
-        className
-      )}
+      className={cn('title-1-bold text-[#050505]', className)}
       {...props}
     />
-  )
+  );
 }
 
 function DialogDescription({
@@ -146,12 +111,12 @@ function DialogDescription({
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn(
-        "text-sm text-muted-foreground *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
-        className
+        'body-2-regular text-gray-700 *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground',
+        className,
       )}
       {...props}
     />
-  )
+  );
 }
 
 export {
@@ -165,4 +130,4 @@ export {
   DialogPortal,
   DialogTitle,
   DialogTrigger,
-}
+};

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -68,11 +68,11 @@ function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
 
 function DialogFooter({
   className,
-  showCloseButton = false,
+  showFooterCloseButton = false,
   children,
   ...props
 }: React.ComponentProps<'div'> & {
-  showCloseButton?: boolean;
+  showFooterCloseButton?: boolean;
 }) {
   return (
     <div
@@ -84,7 +84,7 @@ function DialogFooter({
       {...props}
     >
       {children}
-      {showCloseButton && (
+      {showFooterCloseButton && (
         <DialogPrimitive.Close asChild>
           <Button variant="line">Close</Button>
         </DialogPrimitive.Close>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -70,9 +70,9 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close data-slot="dialog-close" asChild>
             <Button
-              variant="ghost"
+              variant="secondary"
               className="absolute top-2 right-2"
-              size="icon-sm"
+              size="icon"
             >
               <XIcon
               />
@@ -115,7 +115,7 @@ function DialogFooter({
       {children}
       {showCloseButton && (
         <DialogPrimitive.Close asChild>
-          <Button variant="outline">Close</Button>
+          <Button variant="line">Close</Button>
         </DialogPrimitive.Close>
       )}
     </div>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -111,7 +111,7 @@ function DialogDescription({
     <DialogPrimitive.Description
       data-slot="dialog-description"
       className={cn(
-        'body-2-regular text-gray-700 *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground',
+        'body-2-regular text-gray-700 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground',
         className,
       )}
       {...props}

--- a/src/stories/Modal.stories.tsx
+++ b/src/stories/Modal.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Modal, ModalDescription, ModalTitle } from '@/components/common/Modal';
+
+const meta = {
+  title: 'Common/Modal',
+  component: Modal,
+  tags: ['autodocs'],
+  args: {
+    children: null,
+    defaultOpen: true,
+    showCloseButton: false,
+  },
+  argTypes: {
+    showCloseButton: { control: 'boolean' },
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-dvh bg-background-default">
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Modal>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Playground: Story = {
+  render: (args) => (
+    <Modal {...args}>
+      <div className="flex w-full flex-col gap-0.5">
+        <ModalTitle>자료 추가하기</ModalTitle>
+        <ModalDescription>모달 내부 내용은 페이지에서 자유롭게 구성합니다.</ModalDescription>
+      </div>
+
+      <div className="flex h-[240px] w-full items-center justify-center rounded-lg bg-gray-100 body-2-regular text-secondary">
+        페이지별 콘텐츠 영역
+      </div>
+    </Modal>
+  ),
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

#11 

## 📝작업 내용

shadcn Dialog 기반 공통 Modal 컴포넌트를 구현했습니다. 모달을 사이드바를 제외한 앱 콘텐츠 영역 기준으로 중앙 정렬되도록 처리했습니다.

### 스크린샷 (선택)

<img width="1822" height="1100" alt="스크린샷 2026-05-08 오후 4 50 19" src="https://github.com/user-attachments/assets/e9c3e283-2b50-40ee-bf9e-0f085c73abb1" />

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable Modal with optional close controls and modal primitive exports.
  * Dialog footer can optionally render a close action with customizable label.

* **Documentation**
  * Added a Storybook story showcasing the Modal with an interactive playground.

* **Refactor**
  * Adjusted global layout and spacing behavior (including root body padding) for improved visual consistency and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->