### PR TITLE
[Feat] 경험 카드 드래그앤드롭 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "chromatic": "pnpm dlx chromatic"
   },
   "dependencies": {
+    "@dnd-kit/helpers": "^0.4.0",
+    "@dnd-kit/react": "^0.4.0",
     "@tanstack/react-query": "^5.97.0",
     "@xyflow/react": "^12.10.2",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/helpers':
+        specifier: ^0.4.0
+        version: 0.4.0
+      '@dnd-kit/react':
+        specifier: ^0.4.0
+        version: 0.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@tanstack/react-query':
         specifier: ^5.97.0
         version: 5.97.0(react@19.2.4)
@@ -272,6 +278,30 @@ packages:
     engines: {node: '>=20.0.0', yarn: '>=1.22.18'}
     peerDependencies:
       storybook: ^0.0.0-0 || ^10.1.0 || ^10.1.0-0 || ^10.2.0-0 || ^10.3.0-0 || ^10.4.0-0
+
+  '@dnd-kit/abstract@0.4.0':
+    resolution: {integrity: sha512-loEEJxKT5oLOLeRBJVTO9qpgvvW/Qq902xO20v1JMbpANuN/NLurUdpxIwNpVz+RtOSyzznnbc7lO7psmOhc9A==}
+
+  '@dnd-kit/collision@0.4.0':
+    resolution: {integrity: sha512-oOHHUkH1h9Vl2m8TwLw/mPHA7Blf+s0PYcRoLNWNBVxDzugJKZo8WdpU58EMu9qkqyQGrR/YTOozGiMPhlqZ5Q==}
+
+  '@dnd-kit/dom@0.4.0':
+    resolution: {integrity: sha512-mJDKt0BtlHXetZyrvZXh6++aycleIbYWH/OVC4nlszDh8NvW7q8dfsxFllR5RtLKLcykLaI4o545Figfks/HZQ==}
+
+  '@dnd-kit/geometry@0.4.0':
+    resolution: {integrity: sha512-d1n+CU54V/qF/g792bmJK2oR4f5jOL7Pls2IfC+j9f5UBECpjsYbcPZ/krom/z8LgieqvMh1qrUkdcBjJJ7vpg==}
+
+  '@dnd-kit/helpers@0.4.0':
+    resolution: {integrity: sha512-9YOKevD6zOwKVvV4k3fQL//NF+UaN92sfqPpJhT0/7Jq5PLtfD+CTpzmFAjTt5o1qQpFj3xqjWnQl25ooW62wQ==}
+
+  '@dnd-kit/react@0.4.0':
+    resolution: {integrity: sha512-J2/N4CpQf98zJBZhMljDNsc+QR4VtUKU9BRO1+Di4OGaB1qafMC4qZ11xKXOkjw+d7h82FRSXmXCo0c8+VWaWg==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@dnd-kit/state@0.4.0':
+    resolution: {integrity: sha512-vVdwOY9VsYdMNa7Z0xQhTXlzHqCcCugGuoM1kzvZhnZ0tYVPRdmIhWfeO6Y2ZoN92JwYAyJRRNl4ICkEe2mneg==}
 
   '@dotenvx/dotenvx@1.61.0':
     resolution: {integrity: sha512-utL3cpZoFzflyqUkjYbxYujI6STBTmO5LFn4bbin/NZnRWN6wQ7eErhr3/Vpa5h/jicPFC6kTa42r940mQftJQ==}
@@ -851,6 +881,9 @@ packages:
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
+
+  '@preact/signals-core@1.14.2':
+    resolution: {integrity: sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==}
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -5060,6 +5093,50 @@ snapshots:
       - '@chromatic-com/cypress'
       - '@chromatic-com/playwright'
 
+  '@dnd-kit/abstract@0.4.0':
+    dependencies:
+      '@dnd-kit/geometry': 0.4.0
+      '@dnd-kit/state': 0.4.0
+      tslib: 2.8.1
+
+  '@dnd-kit/collision@0.4.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.4.0
+      '@dnd-kit/geometry': 0.4.0
+      tslib: 2.8.1
+
+  '@dnd-kit/dom@0.4.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.4.0
+      '@dnd-kit/collision': 0.4.0
+      '@dnd-kit/geometry': 0.4.0
+      '@dnd-kit/state': 0.4.0
+      tslib: 2.8.1
+
+  '@dnd-kit/geometry@0.4.0':
+    dependencies:
+      '@dnd-kit/state': 0.4.0
+      tslib: 2.8.1
+
+  '@dnd-kit/helpers@0.4.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.4.0
+      tslib: 2.8.1
+
+  '@dnd-kit/react@0.4.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@dnd-kit/abstract': 0.4.0
+      '@dnd-kit/dom': 0.4.0
+      '@dnd-kit/state': 0.4.0
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      tslib: 2.8.1
+
+  '@dnd-kit/state@0.4.0':
+    dependencies:
+      '@preact/signals-core': 1.14.2
+      tslib: 2.8.1
+
   '@dotenvx/dotenvx@1.61.0':
     dependencies:
       commander: 11.1.0
@@ -5520,6 +5597,8 @@ snapshots:
   '@oxc-project/types@0.124.0': {}
 
   '@polka/url@1.0.0-next.29': {}
+
+  '@preact/signals-core@1.14.2': {}
 
   '@radix-ui/number@1.1.1': {}
 

--- a/src/app/experience/_components/ExperienceBoard.tsx
+++ b/src/app/experience/_components/ExperienceBoard.tsx
@@ -16,11 +16,30 @@ export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
   experiences: ExperienceItem[];
 }
 
+type ExperienceOrderMap = Record<ExperienceCategory, string[]>;
+
+const sortableCategories: ExperienceCategory[] = ['all', 'activity', 'career', 'education', 'etc'];
+
 export function ExperienceBoard({ experiences, className, ...props }: ExperienceBoardProps) {
   const [selectedCategory, setSelectedCategory] = React.useState<ExperienceCategory>('all');
   const [selectedExperienceId, setSelectedExperienceId] = React.useState<string>();
+  const [experienceOrderMap, setExperienceOrderMap] = React.useState(() =>
+    createExperienceOrderMap(experiences),
+  );
   const [panelOpen, setPanelOpen] = React.useState(false);
   const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    setExperienceOrderMap((currentOrderMap) => {
+      const nextOrderMap = syncExperienceOrderMap(currentOrderMap, experiences);
+
+      if (areExperienceOrderMapsEqual(currentOrderMap, nextOrderMap)) {
+        return currentOrderMap;
+      }
+
+      return nextOrderMap;
+    });
+  }, [experiences]);
 
   React.useEffect(() => {
     return () => {
@@ -30,10 +49,18 @@ export function ExperienceBoard({ experiences, className, ...props }: Experience
     };
   }, []);
 
-  const filteredExperiences =
-    selectedCategory === 'all'
-      ? experiences
-      : experiences.filter((experience) => experience.type === selectedCategory);
+  const experienceMap = React.useMemo(
+    () => new Map(experiences.map((experience) => [experience.id, experience])),
+    [experiences],
+  );
+
+  const filteredExperiences = React.useMemo(
+    () =>
+      experienceOrderMap[selectedCategory]
+        .map((id) => experienceMap.get(id))
+        .filter((experience): experience is ExperienceItem => Boolean(experience)),
+    [experienceMap, experienceOrderMap, selectedCategory],
+  );
 
   const selectedExperience = filteredExperiences.find(
     (experience) => experience.id === selectedExperienceId,
@@ -59,6 +86,16 @@ export function ExperienceBoard({ experiences, className, ...props }: Experience
     setSelectedExperienceId(experience.id);
     setPanelOpen(true);
   };
+
+  const handleExperienceReorder = React.useCallback(
+    (orderedExperienceIds: string[]) => {
+      setExperienceOrderMap((currentOrderMap) => ({
+        ...currentOrderMap,
+        [selectedCategory]: orderedExperienceIds,
+      }));
+    },
+    [selectedCategory],
+  );
 
   const handlePanelClose = () => {
     if (closeTimerRef.current) {
@@ -86,7 +123,9 @@ export function ExperienceBoard({ experiences, className, ...props }: Experience
         <ExperienceCardGrid
           experiences={filteredExperiences}
           selectedExperienceId={selectedExperienceId}
+          sortable
           onExperienceClick={handleExperienceSelect}
+          onExperienceReorder={handleExperienceReorder}
         />
       ) : (
         <div className="flex flex-1 items-center justify-center">
@@ -105,5 +144,53 @@ export function ExperienceBoard({ experiences, className, ...props }: Experience
         />
       )}
     </section>
+  );
+}
+
+function areStringArraysEqual(source: string[], target: string[]) {
+  return source.length === target.length && source.every((item, index) => item === target[index]);
+}
+
+function createExperienceOrderMap(experiences: ExperienceItem[]): ExperienceOrderMap {
+  return {
+    all: experiences.map((experience) => experience.id),
+    activity: getExperienceIdsByCategory(experiences, 'activity'),
+    career: getExperienceIdsByCategory(experiences, 'career'),
+    education: getExperienceIdsByCategory(experiences, 'education'),
+    etc: getExperienceIdsByCategory(experiences, 'etc'),
+  };
+}
+
+function syncExperienceOrderMap(
+  currentOrderMap: ExperienceOrderMap,
+  experiences: ExperienceItem[],
+): ExperienceOrderMap {
+  const defaultOrderMap = createExperienceOrderMap(experiences);
+
+  return sortableCategories.reduce<ExperienceOrderMap>((nextOrderMap, category) => {
+    const nextIds = defaultOrderMap[category];
+    const nextIdSet = new Set(nextIds);
+    const currentIds = currentOrderMap[category];
+    const preservedIds = currentIds.filter((id) => nextIdSet.has(id));
+    const addedIds = nextIds.filter((id) => !currentIds.includes(id));
+
+    nextOrderMap[category] = [...preservedIds, ...addedIds];
+
+    return nextOrderMap;
+  }, {} as ExperienceOrderMap);
+}
+
+function getExperienceIdsByCategory(
+  experiences: ExperienceItem[],
+  category: Exclude<ExperienceCategory, 'all'>,
+) {
+  return experiences
+    .filter((experience) => experience.type === category)
+    .map((experience) => experience.id);
+}
+
+function areExperienceOrderMapsEqual(source: ExperienceOrderMap, target: ExperienceOrderMap) {
+  return sortableCategories.every((category) =>
+    areStringArraysEqual(source[category], target[category]),
   );
 }

--- a/src/app/experience/_components/ExperienceBoard.tsx
+++ b/src/app/experience/_components/ExperienceBoard.tsx
@@ -171,8 +171,9 @@ function syncExperienceOrderMap(
     const nextIds = defaultOrderMap[category];
     const nextIdSet = new Set(nextIds);
     const currentIds = currentOrderMap[category];
+    const currentIdSet = new Set(currentIds);
     const preservedIds = currentIds.filter((id) => nextIdSet.has(id));
-    const addedIds = nextIds.filter((id) => !currentIds.includes(id));
+    const addedIds = nextIds.filter((id) => !currentIdSet.has(id));
 
     nextOrderMap[category] = [...preservedIds, ...addedIds];
 

--- a/src/app/experience/_components/ExperienceCard.tsx
+++ b/src/app/experience/_components/ExperienceCard.tsx
@@ -51,69 +51,81 @@ export interface ExperienceCardProps
   competencyTags: string[];
 }
 
-export function ExperienceCard({
-  type,
-  title,
-  period,
-  skillTags,
-  competencyTags,
-  size,
-  selected,
-  className,
-  onClick,
-  onKeyDown,
-  ...props
-}: ExperienceCardProps) {
-  const isInteractive = Boolean(onClick);
+export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>(
+  function ExperienceCard(
+    {
+      type,
+      title,
+      period,
+      skillTags,
+      competencyTags,
+      size,
+      selected,
+      className,
+      onClick,
+      onKeyDown,
+      ...props
+    },
+    ref,
+  ) {
+    const isInteractive = Boolean(onClick);
 
-  const handleKeyDown: React.KeyboardEventHandler<HTMLElement> = (event) => {
-    onKeyDown?.(event);
+    const handleKeyDown: React.KeyboardEventHandler<HTMLElement> = (event) => {
+      onKeyDown?.(event);
 
-    if (event.defaultPrevented || event.target !== event.currentTarget || !onClick) {
-      return;
-    }
+      if (event.defaultPrevented || event.target !== event.currentTarget || !onClick) {
+        return;
+      }
 
-    if (event.key === 'Enter' || event.key === ' ') {
-      event.preventDefault();
-      onClick(event as unknown as React.MouseEvent<HTMLElement>);
-    }
-  };
+      if (event.key === 'Enter' || event.key === ' ') {
+        event.preventDefault();
+        onClick(event as unknown as React.MouseEvent<HTMLElement>);
+      }
+    };
 
-  return (
-    <article
-      tabIndex={isInteractive ? 0 : undefined}
-      role={isInteractive ? 'button' : undefined}
-      data-slot="experience-card"
-      data-type={type}
-      className={cn(
-        experienceCardVariants({ size, selected, interactive: isInteractive, className }),
-      )}
-      onClick={onClick}
-      onKeyDown={handleKeyDown}
-      {...props}
-    >
-      <div className="flex w-full items-start justify-between">
-        <Image src={iconMap[type]} alt="" width={72} height={72} className="size-[72px] shrink-0" />
-        <ExperienceCardDropdownMenu triggerClassName="shrink-0" />
-      </div>
+    return (
+      <article
+        ref={ref}
+        tabIndex={isInteractive ? 0 : undefined}
+        role={isInteractive ? 'button' : undefined}
+        data-slot="experience-card"
+        data-type={type}
+        className={cn(
+          experienceCardVariants({ size, selected, interactive: isInteractive, className }),
+        )}
+        onClick={onClick}
+        onKeyDown={handleKeyDown}
+        {...props}
+      >
+        <div className="flex w-full items-start justify-between">
+          <Image
+            src={iconMap[type]}
+            alt=""
+            width={72}
+            height={72}
+            className="size-[72px] shrink-0"
+          />
+          <ExperienceCardDropdownMenu triggerClassName="shrink-0" />
+        </div>
 
-      <div className="flex w-full flex-col items-start gap-3">
-        <div className="flex w-full flex-col items-start gap-1">
-          <h2 className="w-full truncate title-1-bold text-gray-main">{title}</h2>
-          <div className="flex items-center gap-[6px] label-3-regular text-gray-700">
-            <span>기간</span>
-            <span>{period}</span>
+        <div className="flex w-full flex-col items-start gap-3">
+          <div className="flex w-full flex-col items-start gap-1">
+            <h2 className="w-full truncate title-1-bold text-gray-main">{title}</h2>
+            <div className="flex items-center gap-[6px] label-3-regular text-gray-700">
+              <span>기간</span>
+              <span>{period}</span>
+            </div>
+          </div>
+
+          <div className="flex flex-col items-start gap-1.5">
+            <TagRow tags={skillTags} tone="skill" />
+            <TagRow tags={competencyTags} tone="competency" />
           </div>
         </div>
-
-        <div className="flex flex-col items-start gap-1.5">
-          <TagRow tags={skillTags} tone="skill" />
-          <TagRow tags={competencyTags} tone="competency" />
-        </div>
-      </div>
-    </article>
-  );
-}
+      </article>
+    );
+  },
+);
 
 function TagRow({
   tags,

--- a/src/app/experience/_components/ExperienceCard.tsx
+++ b/src/app/experience/_components/ExperienceCard.tsx
@@ -49,6 +49,7 @@ export interface ExperienceCardProps
   period: string;
   skillTags: string[];
   competencyTags: string[];
+  disableActivationKeys?: boolean;
 }
 
 export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>(
@@ -64,6 +65,7 @@ export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>
       className,
       onClick,
       onKeyDown,
+      disableActivationKeys = false,
       ...props
     },
     ref,
@@ -78,6 +80,10 @@ export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>
       }
 
       if (event.key === 'Enter' || event.key === ' ') {
+        if (disableActivationKeys) {
+          return;
+        }
+
         event.preventDefault();
         onClick(event as unknown as React.MouseEvent<HTMLElement>);
       }

--- a/src/app/experience/_components/ExperienceCardDropdownMenu.tsx
+++ b/src/app/experience/_components/ExperienceCardDropdownMenu.tsx
@@ -38,6 +38,7 @@ export function ExperienceCardDropdownMenu({
           )}
           onClick={(event) => event.stopPropagation()}
           onKeyDown={(event) => event.stopPropagation()}
+          onPointerDown={(event) => event.stopPropagation()}
         >
           <MoreVerticalIcon className="size-6" />
         </button>

--- a/src/app/experience/_components/ExperienceCardGrid.tsx
+++ b/src/app/experience/_components/ExperienceCardGrid.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
+import { arrayMove } from '@dnd-kit/helpers';
+import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react';
+import { isSortable } from '@dnd-kit/react/sortable';
 
 import { ExperienceCard } from '@/app/experience/_components/ExperienceCard';
+import { SortableExperienceCard } from '@/app/experience/_components/SortableExperienceCard';
 import type { ExperienceCategory } from '@/app/experience/_components/ExperienceCategoryTab';
 import { cn } from '@/lib/utils';
 
@@ -28,35 +32,80 @@ export interface ExperienceItem {
 export interface ExperienceCardGridProps extends React.ComponentProps<'div'> {
   experiences: ExperienceItem[];
   selectedExperienceId?: string;
+  sortable?: boolean;
   onExperienceClick?: (experience: ExperienceItem) => void;
+  onExperienceReorder?: (experienceIds: string[]) => void;
 }
 
 export function ExperienceCardGrid({
   experiences,
   selectedExperienceId,
+  sortable = false,
   onExperienceClick,
+  onExperienceReorder,
   className,
   ...props
 }: ExperienceCardGridProps) {
-  return (
+  const handleDragEnd = React.useCallback(
+    (event: DragEndEvent) => {
+      if (event.canceled) {
+        return;
+      }
+
+      const { source } = event.operation;
+
+      if (!isSortable(source)) {
+        return;
+      }
+
+      const { initialIndex, index } = source;
+
+      if (initialIndex === index) {
+        return;
+      }
+
+      const nextExperiences = arrayMove(experiences, initialIndex, index);
+
+      onExperienceReorder?.(nextExperiences.map((experience) => experience.id));
+    },
+    [experiences, onExperienceReorder],
+  );
+
+  const grid = (
     <div
       data-slot="experience-card-grid"
       className={cn('grid w-full grid-cols-2 gap-x-4 gap-y-5 min-[1720px]:grid-cols-3', className)}
       {...props}
     >
-      {experiences.map((experience) => (
-        <ExperienceCard
-          key={experience.id}
-          type={experience.type}
-          title={experience.title}
-          period={experience.period}
-          skillTags={experience.skillTags}
-          competencyTags={experience.competencyTags}
-          selected={selectedExperienceId === experience.id}
-          className="max-w-none"
-          onClick={() => onExperienceClick?.(experience)}
-        />
-      ))}
+      {experiences.map((experience, index) =>
+        sortable ? (
+          <SortableExperienceCard
+            key={experience.id}
+            experience={experience}
+            index={index}
+            selected={selectedExperienceId === experience.id}
+            onClick={onExperienceClick}
+          />
+        ) : (
+          <ExperienceCard
+            key={experience.id}
+            type={experience.type}
+            title={experience.title}
+            period={experience.period}
+            skillTags={experience.skillTags}
+            competencyTags={experience.competencyTags}
+            selected={selectedExperienceId === experience.id}
+            className="max-w-none"
+            onClick={() => onExperienceClick?.(experience)}
+          />
+        ),
+      )}
     </div>
   );
+
+  if (!sortable) {
+    return grid;
+  }
+
+  return <DragDropProvider onDragEnd={handleDragEnd}>{grid}</DragDropProvider>;
 }

--- a/src/app/experience/_components/SortableExperienceCard.tsx
+++ b/src/app/experience/_components/SortableExperienceCard.tsx
@@ -1,0 +1,41 @@
+import { useSortable } from '@dnd-kit/react/sortable';
+
+import { ExperienceCard } from '@/app/experience/_components/ExperienceCard';
+import type { ExperienceItem } from '@/app/experience/_components/ExperienceCardGrid';
+import { cn } from '@/lib/utils';
+
+export interface SortableExperienceCardProps {
+  experience: ExperienceItem;
+  index: number;
+  selected?: boolean;
+  onClick?: (experience: ExperienceItem) => void;
+}
+
+export function SortableExperienceCard({
+  experience,
+  index,
+  selected = false,
+  onClick,
+}: SortableExperienceCardProps) {
+  const { ref, isDragSource, isDragging } = useSortable({
+    id: experience.id,
+    index,
+    type: 'experience-card',
+    accept: 'experience-card',
+  });
+
+  return (
+    <ExperienceCard
+      ref={ref}
+      data-dragging={isDragging || undefined}
+      type={experience.type}
+      title={experience.title}
+      period={experience.period}
+      skillTags={experience.skillTags}
+      competencyTags={experience.competencyTags}
+      selected={selected}
+      className={cn('max-w-none', isDragSource && 'relative z-10 opacity-90')}
+      onClick={() => onClick?.(experience)}
+    />
+  );
+}

--- a/src/app/experience/_components/SortableExperienceCard.tsx
+++ b/src/app/experience/_components/SortableExperienceCard.tsx
@@ -34,6 +34,7 @@ export function SortableExperienceCard({
       skillTags={experience.skillTags}
       competencyTags={experience.competencyTags}
       selected={selected}
+      disableActivationKeys
       className={cn('max-w-none', isDragSource && 'relative z-10 opacity-90')}
       onClick={() => onClick?.(experience)}
     />


### PR DESCRIPTION
## #️⃣연관된 이슈

#19 

## 📝작업 내용

- `@dnd-kit/react`, `@dnd-kit/helpers` 의존성을 추가했습니다.
- 경험 카드 그리드에 드래그앤드롭 정렬 기능을 추가했습니다.
  - 필터 탭별로 독립적인 카드 순서가 유지되도록 구성했습니다.

### 스크린샷 (선택)

https://github.com/user-attachments/assets/f3b24ab3-4163-4f8a-b280-fe640f329368

## 💬리뷰 요구사항(선택)

- https://dndkit.com/react/quickstart/ `dnd-kit`이 옛날과 방식이 바뀌어서 지원 카드 구현할 때 참고해주세요 !
- 투명도는 90으로 디자이너 분들한테 컨펌받았습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Experience items can now be reordered using drag-and-drop functionality within each category, allowing customization of the display order.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-KKIUM/KKIUM-FE/pull/21)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->