### PR TITLE
[Feat] 경험 관리 API 연동

### DIFF
--- a/src/app/api/client.ts
+++ b/src/app/api/client.ts
@@ -2,8 +2,9 @@ import type { ApiErrorPayload, ApiResponse } from './types';
 
 const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
 
-// API query string으로 붙일 params 객체의 타입
-type QueryParams = Record<string, string | number | boolean | null | undefined>;
+type QueryParamValue = string | number | boolean | null | undefined;
+type QueryParams = Record<string, QueryParamValue>;
+type ApiMethodOptions = Omit<ApiRequestOptions, 'body' | 'method'>;
 
 // 함수들이 받을 요청 옵션 타입
 interface ApiRequestOptions extends Omit<RequestInit, 'body'> {
@@ -71,7 +72,7 @@ function buildHeaders(body: unknown, headers?: HeadersInit) {
 }
 
 // API 응답을 파싱해서 data만 반환하고, 에러는 ApiError로 던지는 함수
-async function parseApiResponse<T>(response: Response): Promise<T | null> {
+async function parseApiResponse<T>(response: Response): Promise<T> {
   const payload = (await response.json()) as ApiResponse<T>;
 
   if (!response.ok || payload.code !== 'SUCCESS') {
@@ -99,19 +100,19 @@ async function request<T>(path: string, options: ApiRequestOptions = {}) {
 
 // 편의를 위해 메서드별로 export 하는 객체
 export const api = {
-  get<T>(path: string, options?: Omit<ApiRequestOptions, 'body' | 'method'>) {
+  get<T>(path: string, options?: ApiMethodOptions) {
     return request<T>(path, { ...options, method: 'GET' });
   },
-  post<T>(path: string, body?: unknown, options?: Omit<ApiRequestOptions, 'body' | 'method'>) {
+  post<T>(path: string, body?: unknown, options?: ApiMethodOptions) {
     return request<T>(path, { ...options, method: 'POST', body });
   },
-  put<T>(path: string, body?: unknown, options?: Omit<ApiRequestOptions, 'body' | 'method'>) {
+  put<T>(path: string, body?: unknown, options?: ApiMethodOptions) {
     return request<T>(path, { ...options, method: 'PUT', body });
   },
-  patch<T>(path: string, body?: unknown, options?: Omit<ApiRequestOptions, 'body' | 'method'>) {
+  patch<T>(path: string, body?: unknown, options?: ApiMethodOptions) {
     return request<T>(path, { ...options, method: 'PATCH', body });
   },
-  delete<T>(path: string, options?: Omit<ApiRequestOptions, 'body' | 'method'>) {
+  delete<T>(path: string, options?: ApiMethodOptions) {
     return request<T>(path, { ...options, method: 'DELETE' });
   },
 };

--- a/src/app/api/client.ts
+++ b/src/app/api/client.ts
@@ -75,14 +75,18 @@ function buildHeaders(body: unknown, headers?: HeadersInit) {
 async function parseApiResponse<T>(response: Response): Promise<T> {
   let payload: ApiResponse<T> | null = null;
 
-  try {
-    const contentType = response.headers.get('Content-Type');
+  const contentType = response.headers.get('Content-Type');
 
+  try {
     if (contentType?.includes('application/json')) {
       payload = (await response.json()) as ApiResponse<T>;
     }
   } catch {
-    payload = null;
+    throw new ApiError({
+      status: response.status,
+      code: 'INVALID_RESPONSE',
+      message: '서버 응답을 해석하지 못했습니다.',
+    });
   }
 
   if (!response.ok || !payload || payload.code !== 'SUCCESS') {
@@ -99,11 +103,29 @@ async function parseApiResponse<T>(response: Response): Promise<T> {
 // 최종적으로 fetch를 호출하고 응답을 파싱해주는 메인 함수
 async function request<T>(path: string, options: ApiRequestOptions = {}) {
   const { params, body, headers, ...init } = options;
-  const response = await fetch(buildUrl(path, params), {
-    ...init,
-    body: buildBody(body),
-    headers: buildHeaders(body, headers),
-  });
+  const url = buildUrl(path, params);
+  const requestBody = buildBody(body);
+  const requestHeaders = buildHeaders(body, headers);
+
+  let response: Response;
+
+  try {
+    response = await fetch(url, {
+      ...init,
+      body: requestBody,
+      headers: requestHeaders,
+    });
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw error;
+    }
+
+    throw new ApiError({
+      status: 0,
+      code: 'NETWORK_ERROR',
+      message: '네트워크 오류로 요청을 완료하지 못했습니다.',
+    });
+  }
 
   return parseApiResponse<T>(response);
 }

--- a/src/app/api/client.ts
+++ b/src/app/api/client.ts
@@ -1,0 +1,117 @@
+import type { ApiErrorPayload, ApiResponse } from './types';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+// API query string으로 붙일 params 객체의 타입
+type QueryParams = Record<string, string | number | boolean | null | undefined>;
+
+// 함수들이 받을 요청 옵션 타입
+interface ApiRequestOptions extends Omit<RequestInit, 'body'> {
+  // fetch 옵션 + API client 전용 params/body 옵션
+  params?: QueryParams;
+  body?: unknown;
+}
+
+// API 요청이 실패했을 때 던질 커스텀 에러 클래스
+export class ApiError extends Error {
+  status: number;
+  code: string;
+
+  constructor({ status, code, message }: ApiErrorPayload) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.code = code;
+  }
+}
+
+// TODO: 로그인 구현 전까지 localStorage의 임시 accessToken을 사용한다.
+function getAccessToken() {
+  if (typeof window === 'undefined') return null;
+  return window.localStorage.getItem('accessToken');
+}
+
+// API 요청 보낼 최종 URL을 만들어주는 함수
+function buildUrl(path: string, params?: QueryParams) {
+  if (!API_BASE_URL) {
+    throw new Error('NEXT_PUBLIC_API_BASE_URL is not set.');
+  }
+
+  const url = new URL(path, API_BASE_URL);
+
+  Object.entries(params ?? {}).forEach(([key, value]) => {
+    if (value == null) return;
+    url.searchParams.set(key, String(value));
+  });
+
+  return url.toString();
+}
+
+// API 요청 body를 fetch에 넣을 수 있는 형태로 바꿔주는 함수
+function buildBody(body: unknown) {
+  if (body == null) return undefined; // body가 없으면 undefined 반환
+  if (body instanceof FormData) return body; // FormData는 stringify하면 안 됨
+  return JSON.stringify(body);
+}
+
+// API 요청에 붙일 header들을 만들어주는 함수
+function buildHeaders(body: unknown, headers?: HeadersInit) {
+  const nextHeaders = new Headers(headers);
+  const accessToken = getAccessToken();
+
+  if (accessToken) {
+    nextHeaders.set('Authorization', `Bearer ${accessToken}`);
+  }
+
+  if (body != null && !(body instanceof FormData) && !nextHeaders.has('Content-Type')) {
+    nextHeaders.set('Content-Type', 'application/json');
+  }
+
+  return nextHeaders;
+}
+
+// API 응답을 파싱해서 data만 반환하고, 에러는 ApiError로 던지는 함수
+async function parseApiResponse<T>(response: Response): Promise<T | null> {
+  const payload = (await response.json()) as ApiResponse<T>;
+
+  if (!response.ok || payload.code !== 'SUCCESS') {
+    throw new ApiError({
+      status: payload.status ?? response.status,
+      code: payload.code ?? 'UNKNOWN_ERROR',
+      message: payload.message ?? '요청 처리 중 오류가 발생했습니다.',
+    });
+  }
+
+  return payload.data;
+}
+
+// 최종적으로 fetch를 호출하고 응답을 파싱해주는 메인 함수
+async function request<T>(path: string, options: ApiRequestOptions = {}) {
+  const { params, body, headers, ...init } = options;
+  const response = await fetch(buildUrl(path, params), {
+    ...init,
+    body: buildBody(body),
+    headers: buildHeaders(body, headers),
+  });
+
+  return parseApiResponse<T>(response);
+}
+
+// 편의를 위해 메서드별로 export 하는 객체
+export const api = {
+  get<T>(path: string, options?: Omit<ApiRequestOptions, 'body' | 'method'>) {
+    return request<T>(path, { ...options, method: 'GET' });
+  },
+  post<T>(path: string, body?: unknown, options?: Omit<ApiRequestOptions, 'body' | 'method'>) {
+    return request<T>(path, { ...options, method: 'POST', body });
+  },
+  put<T>(path: string, body?: unknown, options?: Omit<ApiRequestOptions, 'body' | 'method'>) {
+    return request<T>(path, { ...options, method: 'PUT', body });
+  },
+  patch<T>(path: string, body?: unknown, options?: Omit<ApiRequestOptions, 'body' | 'method'>) {
+    return request<T>(path, { ...options, method: 'PATCH', body });
+  },
+  delete<T>(path: string, options?: Omit<ApiRequestOptions, 'body' | 'method'>) {
+    return request<T>(path, { ...options, method: 'DELETE' });
+  },
+};

--- a/src/app/api/client.ts
+++ b/src/app/api/client.ts
@@ -73,13 +73,23 @@ function buildHeaders(body: unknown, headers?: HeadersInit) {
 
 // API 응답을 파싱해서 data만 반환하고, 에러는 ApiError로 던지는 함수
 async function parseApiResponse<T>(response: Response): Promise<T> {
-  const payload = (await response.json()) as ApiResponse<T>;
+  let payload: ApiResponse<T> | null = null;
 
-  if (!response.ok || payload.code !== 'SUCCESS') {
+  try {
+    const contentType = response.headers.get('Content-Type');
+
+    if (contentType?.includes('application/json')) {
+      payload = (await response.json()) as ApiResponse<T>;
+    }
+  } catch {
+    payload = null;
+  }
+
+  if (!response.ok || !payload || payload.code !== 'SUCCESS') {
     throw new ApiError({
-      status: payload.status ?? response.status,
-      code: payload.code ?? 'UNKNOWN_ERROR',
-      message: payload.message ?? '요청 처리 중 오류가 발생했습니다.',
+      status: payload?.status ?? response.status,
+      code: payload?.code ?? 'UNKNOWN_ERROR',
+      message: payload?.message ?? '요청 처리 중 오류가 발생했습니다.',
     });
   }
 

--- a/src/app/api/experience/index.ts
+++ b/src/app/api/experience/index.ts
@@ -1,0 +1,19 @@
+import { api } from '@/app/api/client';
+
+import type { ExperienceDetailResponse, ExperienceListResponse, PieceType } from './types';
+
+export type GetExperiencesParams = {
+  type?: PieceType;
+  cursor?: number | null;
+  size?: number;
+};
+
+export function getExperiences(params?: GetExperiencesParams) {
+  return api.get<ExperienceListResponse>('/api/v1/experiences', {
+    params,
+  });
+}
+
+export function getExperienceDetail(experienceId: number) {
+  return api.get<ExperienceDetailResponse>(`/api/v1/experiences/${experienceId}`);
+}

--- a/src/app/api/experience/types.ts
+++ b/src/app/api/experience/types.ts
@@ -1,0 +1,87 @@
+export type PieceType = 'ACTIVITY' | 'CAREER' | 'EDUCATION' | 'ETC';
+
+export type TagCategory = 'TECH' | 'COMPETENCY';
+
+type ISODateString = string;
+
+export interface TagResponse {
+  category: TagCategory;
+  field: string;
+}
+
+export interface ExperienceCardResponse {
+  pieceId: number;
+  experienceId: number;
+  type: PieceType;
+  title: string;
+  oneLineIntro: string;
+  startDate: ISODateString;
+  endDate: ISODateString;
+  tags: TagResponse[];
+}
+
+export interface ExperienceListResponse {
+  hasNext: boolean;
+  nextCursor: number | null;
+  experiences: ExperienceCardResponse[];
+}
+
+export interface ActivityDetail {
+  name: string;
+  teamNum: number;
+  role: string;
+  contributionRate: number;
+  startDate: ISODateString;
+  endDate: ISODateString;
+}
+
+export interface CareerDetail {
+  name: string;
+  company: string;
+  employmentStatus: string;
+  startDate: ISODateString;
+  endDate: ISODateString;
+}
+
+export interface EducationDetail {
+  organizationName: string;
+  name: string;
+  startDate: ISODateString;
+  endDate: ISODateString;
+}
+
+export interface EtcDetail {
+  startDate: ISODateString;
+  endDate: ISODateString;
+}
+
+interface ExperienceDetailBase {
+  pieceId: number;
+  experienceId: number;
+  title: string;
+  oneLineIntro: string;
+  tags: TagResponse[];
+  situation: string;
+  task: string;
+  act: string;
+  result: string;
+  taken: string;
+}
+
+export type ExperienceDetailResponse =
+  | (ExperienceDetailBase & {
+      type: 'ACTIVITY';
+      detail: ActivityDetail;
+    })
+  | (ExperienceDetailBase & {
+      type: 'CAREER';
+      detail: CareerDetail;
+    })
+  | (ExperienceDetailBase & {
+      type: 'EDUCATION';
+      detail: EducationDetail;
+    })
+  | (ExperienceDetailBase & {
+      type: 'ETC';
+      detail: EtcDetail;
+    });

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -2,7 +2,7 @@ export interface ApiResponse<T> {
   status: number;
   code: string;
   message: string;
-  data: T | null;
+  data: T;
 }
 
 export interface ApiErrorPayload {

--- a/src/app/api/types.ts
+++ b/src/app/api/types.ts
@@ -1,0 +1,12 @@
+export interface ApiResponse<T> {
+  status: number;
+  code: string;
+  message: string;
+  data: T | null;
+}
+
+export interface ApiErrorPayload {
+  status: number;
+  code: string;
+  message: string;
+}

--- a/src/app/experience/[experienceId]/_components/ExperienceDetailPageContent.tsx
+++ b/src/app/experience/[experienceId]/_components/ExperienceDetailPageContent.tsx
@@ -1,23 +1,28 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
+import * as React from 'react';
 
 import { ExperienceDetailContent } from '@/app/experience/_components/ExperienceDetailContent';
-import type { ExperienceItem } from '@/app/experience/_components/ExperienceCardGrid';
+import { mapExperienceDetailToItem } from '@/app/experience/_utils/mapExperienceResponse';
+import { EmptyState } from '@/components/common/EmptyState';
 import { ExpandIcon } from '@/components/common/icons/ExpandIcon';
 import { XIcon } from '@/components/common/icons/XIcon';
+import { useExperienceDetail } from '@/hooks/experience/useExperiences';
 
 interface ExperienceDetailPageContentProps {
-  experience: ExperienceItem;
+  experienceId: number;
 }
 
-export function ExperienceDetailPageContent({ experience }: ExperienceDetailPageContentProps) {
+export function ExperienceDetailPageContent({ experienceId }: ExperienceDetailPageContentProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const category = searchParams.get('category');
+  const { data, isError, isPending } = useExperienceDetail(experienceId);
+  const experience = React.useMemo(() => (data ? mapExperienceDetailToItem(data) : null), [data]);
 
   const handleCollapseToPanel = () => {
-    const params = new URLSearchParams({ selected: experience.id });
+    const params = new URLSearchParams({ selected: String(experienceId) });
 
     if (category) {
       params.set('category', category);
@@ -55,7 +60,22 @@ export function ExperienceDetailPageContent({ experience }: ExperienceDetailPage
           </button>
         </header>
 
-        <ExperienceDetailContent experience={experience} variant="page" scrollable={false} />
+        {/* TODO: 상세 페이지 로딩/에러 UI가 확정되면 임시 EmptyState를 교체한다. */}
+        {isPending ? (
+          <div className="flex flex-1 items-center justify-center">
+            <EmptyState title="경험을 불러오는 중이에요" illustrationLabel="경험 상세 로딩 중" />
+          </div>
+        ) : isError || !experience ? (
+          <div className="flex flex-1 items-center justify-center">
+            <EmptyState
+              title="경험을 불러오지 못했어요"
+              description="잠시 후 다시 시도해주세요"
+              illustrationLabel="경험 상세 오류"
+            />
+          </div>
+        ) : (
+          <ExperienceDetailContent experience={experience} variant="page" scrollable={false} />
+        )}
       </div>
     </div>
   );

--- a/src/app/experience/[experienceId]/page.tsx
+++ b/src/app/experience/[experienceId]/page.tsx
@@ -2,7 +2,6 @@ import { notFound } from 'next/navigation';
 import { Suspense } from 'react';
 
 import { ExperienceDetailPageContent } from '@/app/experience/[experienceId]/_components/ExperienceDetailPageContent';
-import { experienceMockData } from '@/app/experience/_constants/experienceMockData';
 
 export default async function ExperienceDetailPage({
   params,
@@ -10,15 +9,15 @@ export default async function ExperienceDetailPage({
   params: Promise<{ experienceId: string }>;
 }) {
   const { experienceId } = await params;
-  const experience = experienceMockData.find((item) => item.id === experienceId);
+  const numericExperienceId = Number(experienceId);
 
-  if (!experience) {
+  if (!Number.isFinite(numericExperienceId)) {
     notFound();
   }
 
   return (
     <Suspense>
-      <ExperienceDetailPageContent experience={experience} />
+      <ExperienceDetailPageContent experienceId={numericExperienceId} />
     </Suspense>
   );
 }

--- a/src/app/experience/[experienceId]/page.tsx
+++ b/src/app/experience/[experienceId]/page.tsx
@@ -11,7 +11,7 @@ export default async function ExperienceDetailPage({
   const { experienceId } = await params;
   const numericExperienceId = Number(experienceId);
 
-  if (!Number.isFinite(numericExperienceId)) {
+  if (!Number.isInteger(numericExperienceId) || numericExperienceId <= 0) {
     notFound();
   }
 

--- a/src/app/experience/_components/ExperienceBoard.tsx
+++ b/src/app/experience/_components/ExperienceBoard.tsx
@@ -10,9 +10,12 @@ import {
 import type { ExperienceCategory } from '@/app/experience/_components/ExperienceCategoryTab';
 import { ExperienceCategoryTabs } from '@/app/experience/_components/ExperienceCategoryTabs';
 import { ExperienceDetailPanel } from '@/app/experience/_components/ExperienceDetailPanel';
-import { mapExperienceCardToItem } from '@/app/experience/_utils/mapExperienceResponse';
+import {
+  mapExperienceCardToItem,
+  mapExperienceDetailToItem,
+} from '@/app/experience/_utils/mapExperienceResponse';
 import { EmptyState } from '@/components/common/EmptyState';
-import { useExperiences } from '@/hooks/experience/useExperiences';
+import { useExperienceDetail, useExperiences } from '@/hooks/experience/useExperiences';
 import { cn } from '@/lib/utils';
 
 export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
@@ -54,6 +57,14 @@ export function ExperienceBoard({
   );
   const [panelOpen, setPanelOpen] = React.useState(Boolean(selectedExperienceIdFromQuery));
   const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const selectedExperienceNumericId = selectedExperienceId ? Number(selectedExperienceId) : null;
+  const { data: selectedExperienceDetail } = useExperienceDetail(
+    Number.isFinite(selectedExperienceNumericId) ? selectedExperienceNumericId : null,
+  );
+  const selectedExperienceDetailItem = React.useMemo(
+    () => (selectedExperienceDetail ? mapExperienceDetailToItem(selectedExperienceDetail) : null),
+    [selectedExperienceDetail],
+  );
 
   React.useEffect(() => {
     setExperienceOrderMap((currentOrderMap) => {
@@ -114,6 +125,7 @@ export function ExperienceBoard({
   const selectedExperience = filteredExperiences.find(
     (experience) => experience.id === selectedExperienceId,
   );
+  const panelExperience = selectedExperienceDetailItem ?? selectedExperience;
 
   const handleCategoryChange = (category: ExperienceCategory) => {
     if (closeTimerRef.current) {
@@ -164,11 +176,11 @@ export function ExperienceBoard({
   };
 
   const handlePanelExpand = () => {
-    if (!selectedExperience) {
+    if (!panelExperience) {
       return;
     }
 
-    router.push(`/experience/${selectedExperience.id}?category=${selectedCategory}`);
+    router.push(`/experience/${panelExperience.id}?category=${selectedCategory}`);
   };
 
   return (
@@ -211,9 +223,9 @@ export function ExperienceBoard({
           />
         </div>
       )}
-      {selectedExperience && (
+      {panelExperience && (
         <ExperienceDetailPanel
-          experience={selectedExperience}
+          experience={panelExperience}
           open={panelOpen}
           onExpand={handlePanelExpand}
           onClose={handlePanelClose}

--- a/src/app/experience/_components/ExperienceBoard.tsx
+++ b/src/app/experience/_components/ExperienceBoard.tsx
@@ -14,6 +14,7 @@ import {
   mapExperienceCardToItem,
   mapExperienceDetailToItem,
 } from '@/app/experience/_utils/mapExperienceResponse';
+import type { PieceType } from '@/app/api/experience/types';
 import { EmptyState } from '@/components/common/EmptyState';
 import { useExperienceDetail, useInfiniteExperiences } from '@/hooks/experience/useExperiences';
 import { cn } from '@/lib/utils';
@@ -25,6 +26,12 @@ export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
 type ExperienceOrderMap = Record<ExperienceCategory, string[]>;
 
 const sortableCategories: ExperienceCategory[] = ['all', 'activity', 'career', 'education', 'etc'];
+const pieceTypeByCategory: Record<Exclude<ExperienceCategory, 'all'>, PieceType> = {
+  activity: 'ACTIVITY',
+  career: 'CAREER',
+  education: 'EDUCATION',
+  etc: 'ETC',
+};
 
 function isExperienceCategory(category: string | null): category is ExperienceCategory {
   return sortableCategories.includes(category as ExperienceCategory);
@@ -37,12 +44,6 @@ export function ExperienceBoard({
 }: ExperienceBoardProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { data, fetchNextPage, hasNextPage, isError, isFetchingNextPage, isPending } =
-    useInfiniteExperiences();
-  const experiences = React.useMemo(
-    () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
-    [data],
-  );
   const selectedExperienceIdFromQuery = searchParams.get('selected') ?? initialSelectedExperienceId;
   const selectedCategoryFromQuery = searchParams.get('category');
   const initialSelectedCategory = isExperienceCategory(selectedCategoryFromQuery)
@@ -52,6 +53,14 @@ export function ExperienceBoard({
     React.useState<ExperienceCategory>(initialSelectedCategory);
   const [selectedExperienceId, setSelectedExperienceId] = React.useState<string | undefined>(
     selectedExperienceIdFromQuery,
+  );
+  const selectedPieceType =
+    selectedCategory === 'all' ? undefined : pieceTypeByCategory[selectedCategory];
+  const { data, fetchNextPage, hasNextPage, isError, isFetchingNextPage, isPending } =
+    useInfiniteExperiences(selectedPieceType ? { type: selectedPieceType } : undefined);
+  const experiences = React.useMemo(
+    () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
+    [data],
   );
   const [experienceOrderMap, setExperienceOrderMap] = React.useState(() =>
     createExperienceOrderMap(experiences),

--- a/src/app/experience/_components/ExperienceBoard.tsx
+++ b/src/app/experience/_components/ExperienceBoard.tsx
@@ -10,11 +10,12 @@ import {
 import type { ExperienceCategory } from '@/app/experience/_components/ExperienceCategoryTab';
 import { ExperienceCategoryTabs } from '@/app/experience/_components/ExperienceCategoryTabs';
 import { ExperienceDetailPanel } from '@/app/experience/_components/ExperienceDetailPanel';
+import { mapExperienceCardToItem } from '@/app/experience/_utils/mapExperienceResponse';
 import { EmptyState } from '@/components/common/EmptyState';
+import { useExperiences } from '@/hooks/experience/useExperiences';
 import { cn } from '@/lib/utils';
 
 export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
-  experiences: ExperienceItem[];
   initialSelectedExperienceId?: string;
 }
 
@@ -27,13 +28,17 @@ function isExperienceCategory(category: string | null): category is ExperienceCa
 }
 
 export function ExperienceBoard({
-  experiences,
   initialSelectedExperienceId,
   className,
   ...props
 }: ExperienceBoardProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { data, isError, isPending } = useExperiences();
+  const experiences = React.useMemo(
+    () => data?.experiences.map(mapExperienceCardToItem) ?? [],
+    [data],
+  );
   const selectedExperienceIdFromQuery = searchParams.get('selected') ?? initialSelectedExperienceId;
   const selectedCategoryFromQuery = searchParams.get('category');
   const initialSelectedCategory = isExperienceCategory(selectedCategoryFromQuery)
@@ -176,7 +181,20 @@ export function ExperienceBoard({
         selectedCategory={selectedCategory}
         onCategoryChange={handleCategoryChange}
       />
-      {filteredExperiences.length > 0 ? (
+      {/* TODO: 로딩/에러 상태 전용 UI가 확정되면 임시 EmptyState를 교체한다. */}
+      {isPending ? (
+        <div className="flex flex-1 items-center justify-center">
+          <EmptyState title="경험을 불러오는 중이에요" illustrationLabel="경험 목록 로딩 중" />
+        </div>
+      ) : isError ? (
+        <div className="flex flex-1 items-center justify-center">
+          <EmptyState
+            title="경험을 불러오지 못했어요"
+            description="잠시 후 다시 시도해주세요"
+            illustrationLabel="경험 목록 오류"
+          />
+        </div>
+      ) : filteredExperiences.length > 0 ? (
         <ExperienceCardGrid
           experiences={filteredExperiences}
           selectedExperienceId={selectedExperienceId}

--- a/src/app/experience/_components/ExperienceBoard.tsx
+++ b/src/app/experience/_components/ExperienceBoard.tsx
@@ -15,7 +15,7 @@ import {
   mapExperienceDetailToItem,
 } from '@/app/experience/_utils/mapExperienceResponse';
 import { EmptyState } from '@/components/common/EmptyState';
-import { useExperienceDetail, useExperiences } from '@/hooks/experience/useExperiences';
+import { useExperienceDetail, useInfiniteExperiences } from '@/hooks/experience/useExperiences';
 import { cn } from '@/lib/utils';
 
 export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
@@ -37,9 +37,9 @@ export function ExperienceBoard({
 }: ExperienceBoardProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { data, isError, isPending } = useExperiences();
+  const { data, isError, isPending } = useInfiniteExperiences();
   const experiences = React.useMemo(
-    () => data?.experiences.map(mapExperienceCardToItem) ?? [],
+    () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
     [data],
   );
   const selectedExperienceIdFromQuery = searchParams.get('selected') ?? initialSelectedExperienceId;

--- a/src/app/experience/_components/ExperienceBoard.tsx
+++ b/src/app/experience/_components/ExperienceBoard.tsx
@@ -37,7 +37,8 @@ export function ExperienceBoard({
 }: ExperienceBoardProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const { data, isError, isPending } = useInfiniteExperiences();
+  const { data, fetchNextPage, hasNextPage, isError, isFetchingNextPage, isPending } =
+    useInfiniteExperiences();
   const experiences = React.useMemo(
     () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
     [data],
@@ -57,6 +58,8 @@ export function ExperienceBoard({
   );
   const [panelOpen, setPanelOpen] = React.useState(Boolean(selectedExperienceIdFromQuery));
   const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const loadMoreRef = React.useRef<HTMLDivElement>(null);
+  const hasAppliedInitialSelectionRef = React.useRef(false);
   const selectedExperienceNumericId = selectedExperienceId ? Number(selectedExperienceId) : null;
   const { data: selectedExperienceDetail } = useExperienceDetail(
     Number.isFinite(selectedExperienceNumericId) ? selectedExperienceNumericId : null,
@@ -79,7 +82,7 @@ export function ExperienceBoard({
   }, [experiences]);
 
   React.useEffect(() => {
-    if (!selectedExperienceIdFromQuery) {
+    if (hasAppliedInitialSelectionRef.current || !selectedExperienceIdFromQuery) {
       return;
     }
 
@@ -99,6 +102,7 @@ export function ExperienceBoard({
     setSelectedCategory(initialSelectedCategory);
     setSelectedExperienceId(initialSelectedExperience.id);
     setPanelOpen(true);
+    hasAppliedInitialSelectionRef.current = true;
   }, [experiences, initialSelectedCategory, selectedExperienceIdFromQuery]);
 
   React.useEffect(() => {
@@ -108,6 +112,29 @@ export function ExperienceBoard({
       }
     };
   }, []);
+
+  React.useEffect(() => {
+    const loadMoreElement = loadMoreRef.current;
+
+    if (!loadMoreElement || !hasNextPage || isFetchingNextPage) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          void fetchNextPage();
+        }
+      },
+      { rootMargin: '240px 0px' },
+    );
+
+    observer.observe(loadMoreElement);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
 
   const experienceMap = React.useMemo(
     () => new Map(experiences.map((experience) => [experience.id, experience])),
@@ -207,13 +234,20 @@ export function ExperienceBoard({
           />
         </div>
       ) : filteredExperiences.length > 0 ? (
-        <ExperienceCardGrid
-          experiences={filteredExperiences}
-          selectedExperienceId={selectedExperienceId}
-          sortable
-          onExperienceClick={handleExperienceSelect}
-          onExperienceReorder={handleExperienceReorder}
-        />
+        <>
+          <ExperienceCardGrid
+            experiences={filteredExperiences}
+            selectedExperienceId={selectedExperienceId}
+            sortable
+            onExperienceClick={handleExperienceSelect}
+            onExperienceReorder={handleExperienceReorder}
+          />
+          <div ref={loadMoreRef} aria-hidden="true" className="h-1" />
+          {/* TODO: 다음 페이지 로딩 UI가 확정되면 임시 문구를 교체한다. */}
+          {isFetchingNextPage && (
+            <p className="text-center body-3-regular text-tertiary">경험을 더 불러오는 중이에요</p>
+          )}
+        </>
       ) : (
         <div className="flex flex-1 items-center justify-center">
           <EmptyState

--- a/src/app/experience/_components/ExperienceBoard.tsx
+++ b/src/app/experience/_components/ExperienceBoard.tsx
@@ -56,7 +56,7 @@ export function ExperienceBoard({
   );
   const selectedPieceType =
     selectedCategory === 'all' ? undefined : pieceTypeByCategory[selectedCategory];
-  const { data, fetchNextPage, hasNextPage, isError, isFetchingNextPage, isPending } =
+  const { data, fetchNextPage, hasNextPage, isError, isFetching, isFetchingNextPage, isPending } =
     useInfiniteExperiences(selectedPieceType ? { type: selectedPieceType } : undefined);
   const experiences = React.useMemo(
     () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
@@ -70,12 +70,22 @@ export function ExperienceBoard({
   const loadMoreRef = React.useRef<HTMLDivElement>(null);
   const hasAppliedInitialSelectionRef = React.useRef(false);
   const selectedExperienceNumericId = selectedExperienceId ? Number(selectedExperienceId) : null;
-  const { data: selectedExperienceDetail } = useExperienceDetail(
+  const {
+    data: selectedExperienceDetail,
+    isError: isDetailError,
+    isFetching: isDetailFetching,
+    isPending: isDetailPending,
+  } = useExperienceDetail(
     Number.isFinite(selectedExperienceNumericId) ? selectedExperienceNumericId : null,
   );
+  const selectedExperienceDetailMatches =
+    selectedExperienceDetail?.experienceId === selectedExperienceNumericId;
   const selectedExperienceDetailItem = React.useMemo(
-    () => (selectedExperienceDetail ? mapExperienceDetailToItem(selectedExperienceDetail) : null),
-    [selectedExperienceDetail],
+    () =>
+      selectedExperienceDetail && selectedExperienceDetailMatches
+        ? mapExperienceDetailToItem(selectedExperienceDetail)
+        : null,
+    [selectedExperienceDetail, selectedExperienceDetailMatches],
   );
 
   React.useEffect(() => {
@@ -162,6 +172,12 @@ export function ExperienceBoard({
     (experience) => experience.id === selectedExperienceId,
   );
   const panelExperience = selectedExperienceDetailItem ?? selectedExperience;
+  const showDetailLoading =
+    panelOpen &&
+    Boolean(selectedExperienceId) &&
+    (isDetailPending || (isDetailFetching && !selectedExperienceDetailMatches));
+  const showListLoading =
+    isPending || (isFetching && !isFetchingNextPage && filteredExperiences.length === 0);
 
   const handleCategoryChange = (category: ExperienceCategory) => {
     if (closeTimerRef.current) {
@@ -230,7 +246,7 @@ export function ExperienceBoard({
         onCategoryChange={handleCategoryChange}
       />
       {/* TODO: 로딩/에러 상태 전용 UI가 확정되면 임시 EmptyState를 교체한다. */}
-      {isPending ? (
+      {showListLoading ? (
         <div className="flex flex-1 items-center justify-center">
           <EmptyState title="경험을 불러오는 중이에요" illustrationLabel="경험 목록 로딩 중" />
         </div>
@@ -270,6 +286,8 @@ export function ExperienceBoard({
         <ExperienceDetailPanel
           experience={panelExperience}
           open={panelOpen}
+          detailError={isDetailError}
+          detailLoading={showDetailLoading}
           onExpand={handlePanelExpand}
           onClose={handlePanelClose}
         />

--- a/src/app/experience/_components/ExperienceDetailPanel.tsx
+++ b/src/app/experience/_components/ExperienceDetailPanel.tsx
@@ -4,6 +4,7 @@ import * as React from 'react';
 
 import { ExperienceDetailContent } from '@/app/experience/_components/ExperienceDetailContent';
 import type { ExperienceItem } from '@/app/experience/_components/ExperienceCardGrid';
+import { EmptyState } from '@/components/common/EmptyState';
 import { ExpandIcon } from '@/components/common/icons/ExpandIcon';
 import { XIcon } from '@/components/common/icons/XIcon';
 import { cn } from '@/lib/utils';
@@ -17,6 +18,8 @@ export interface ExperienceDetailPanelProps extends Omit<
   onExpand?: () => void;
   onEdit?: () => void;
   onSave?: (experience: Pick<ExperienceItem, 'detail' | 'skillTags' | 'competencyTags'>) => void;
+  detailError?: boolean;
+  detailLoading?: boolean;
   onClose: () => void;
 }
 
@@ -26,6 +29,8 @@ export function ExperienceDetailPanel({
   onExpand,
   onEdit,
   onSave,
+  detailError = false,
+  detailLoading = false,
   onClose,
   className,
   onKeyDown,
@@ -166,12 +171,27 @@ export function ExperienceDetailPanel({
         </button>
       </header>
 
-      <ExperienceDetailContent
-        experience={experience}
-        variant="panel"
-        onEdit={onEdit}
-        onSave={onSave}
-      />
+      {/* TODO: 상세 패널 로딩/에러 UI가 확정되면 임시 EmptyState를 교체한다. */}
+      {detailLoading ? (
+        <div className="flex flex-1 items-center justify-center">
+          <EmptyState title="경험을 불러오는 중이에요" illustrationLabel="경험 상세 로딩 중" />
+        </div>
+      ) : detailError ? (
+        <div className="flex flex-1 items-center justify-center">
+          <EmptyState
+            title="경험을 불러오지 못했어요"
+            description="잠시 후 다시 시도해주세요"
+            illustrationLabel="경험 상세 오류"
+          />
+        </div>
+      ) : (
+        <ExperienceDetailContent
+          experience={experience}
+          variant="panel"
+          onEdit={onEdit}
+          onSave={onSave}
+        />
+      )}
     </aside>
   );
 }

--- a/src/app/experience/_utils/mapExperienceResponse.ts
+++ b/src/app/experience/_utils/mapExperienceResponse.ts
@@ -1,0 +1,121 @@
+import type {
+  ExperienceCardResponse,
+  ExperienceDetailResponse,
+  PieceType,
+  TagResponse,
+} from '@/app/api/experience/types';
+import type { ExperienceItem } from '@/app/experience/_components/ExperienceCardGrid';
+
+type UiExperienceType = ExperienceItem['type'];
+type CommonExperienceFields = Pick<
+  ExperienceCardResponse,
+  'experienceId' | 'type' | 'title' | 'oneLineIntro' | 'tags' | 'startDate' | 'endDate'
+>;
+
+const typeMap: Record<PieceType, UiExperienceType> = {
+  ACTIVITY: 'activity',
+  CAREER: 'career',
+  EDUCATION: 'education',
+  ETC: 'etc',
+};
+
+const emptyDetail: ExperienceItem['detail'] = {
+  situation: '',
+  task: '',
+  action: '',
+  result: '',
+  taken: '',
+};
+
+export function mapExperienceCardToItem(response: ExperienceCardResponse): ExperienceItem {
+  const period = formatPeriod(response.startDate, response.endDate);
+
+  return {
+    ...mapCommonFields(response),
+    detailInfo: [{ label: '기간', value: period }],
+    detail: emptyDetail,
+  };
+}
+
+export function mapExperienceDetailToItem(response: ExperienceDetailResponse): ExperienceItem {
+  return {
+    ...mapCommonFields({
+      experienceId: response.experienceId,
+      type: response.type,
+      title: response.title,
+      oneLineIntro: response.oneLineIntro,
+      startDate: response.detail.startDate,
+      endDate: response.detail.endDate,
+      tags: response.tags,
+    }),
+    detailInfo: getDetailInfo(response),
+    detail: {
+      situation: response.situation,
+      task: response.task,
+      action: response.act,
+      result: response.result,
+      taken: response.taken,
+    },
+  };
+}
+
+function mapCommonFields(response: CommonExperienceFields) {
+  return {
+    id: String(response.experienceId),
+    type: typeMap[response.type],
+    title: response.title,
+    description: response.oneLineIntro,
+    period: formatPeriod(response.startDate, response.endDate),
+    skillTags: getTagsByCategory(response.tags, 'TECH'),
+    competencyTags: getTagsByCategory(response.tags, 'COMPETENCY'),
+  };
+}
+
+function getDetailInfo(response: ExperienceDetailResponse): ExperienceItem['detailInfo'] {
+  const period = formatPeriod(response.detail.startDate, response.detail.endDate);
+
+  switch (response.type) {
+    case 'ACTIVITY':
+      return [
+        { label: '기간', value: period },
+        { label: '팀원 수', value: `${response.detail.teamNum}명` },
+        {
+          label: '내 역할 및 기여도',
+          value: `${response.detail.role}, ${response.detail.contributionRate}%`,
+        },
+      ];
+    case 'CAREER':
+      return [
+        { label: '기간', value: period },
+        { label: '회사/기관/단체명', value: response.detail.company },
+        { label: '고용 형태', value: response.detail.employmentStatus },
+      ];
+    case 'EDUCATION':
+      return [
+        { label: '기간', value: period },
+        { label: '기관명', value: response.detail.organizationName },
+        { label: '수강명', value: response.detail.name },
+      ];
+    case 'ETC':
+      return [{ label: '기간', value: period }];
+  }
+}
+
+function getTagsByCategory(tags: TagResponse[], category: TagResponse['category']) {
+  return tags.filter((tag) => tag.category === category).map((tag) => tag.field);
+}
+
+function formatPeriod(startDate: string, endDate: string) {
+  const start = formatDate(startDate);
+  const end = formatDate(endDate);
+
+  if (startDate.slice(0, 4) === endDate.slice(0, 4)) {
+    return `${start}~${end.slice(5)}`;
+  }
+
+  return `${start}~${end}`;
+}
+
+function formatDate(date: string) {
+  return date.replaceAll('-', '.');
+}

--- a/src/app/experience/page.tsx
+++ b/src/app/experience/page.tsx
@@ -2,7 +2,6 @@ import { Suspense } from 'react';
 
 import { ExperienceBoard } from '@/app/experience/_components/ExperienceBoard';
 import { ExperiencePageHeader } from '@/app/experience/_components/ExperiencePageHeader';
-import { experienceMockData } from '@/app/experience/_constants/experienceMockData';
 
 export default function ExperiencePage() {
   return (
@@ -10,7 +9,7 @@ export default function ExperiencePage() {
       <div className="flex flex-1 flex-col gap-5">
         <ExperiencePageHeader />
         <Suspense>
-          <ExperienceBoard experiences={experienceMockData} />
+          <ExperienceBoard />
         </Suspense>
       </div>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { AppShell } from '@/components/common/AppShell';
 import { nanumSquare } from './fonts';
+import { Providers } from './providers';
 import './globals.css';
 
 export const metadata: Metadata = {
@@ -16,7 +17,9 @@ export default function RootLayout({
   return (
     <html lang="ko" className={`${nanumSquare.className} h-full antialiased`}>
       <body className="min-h-full">
-        <AppShell>{children}</AppShell>
+        <Providers>
+          <AppShell>{children}</AppShell>
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState, type ReactNode } from 'react';
+
+export function Providers({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/src/hooks/experience/useExperiences.ts
+++ b/src/hooks/experience/useExperiences.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { skipToken, useQuery } from '@tanstack/react-query';
+import { skipToken, useInfiniteQuery, useQuery } from '@tanstack/react-query';
 
 import {
   getExperienceDetail,
@@ -13,6 +13,8 @@ export const experienceQueryKeys = {
   lists: () => [...experienceQueryKeys.all, 'list'] as const,
   list: (params?: GetExperiencesParams) =>
     [...experienceQueryKeys.lists(), params ?? null] as const,
+  infiniteList: (params?: GetExperiencesParams) =>
+    [...experienceQueryKeys.lists(), 'infinite', params ?? null] as const,
   details: () => [...experienceQueryKeys.all, 'detail'] as const,
   detail: (experienceId: number | null | undefined) =>
     [...experienceQueryKeys.details(), experienceId ?? null] as const,
@@ -22,6 +24,20 @@ export function useExperiences(params?: GetExperiencesParams) {
   return useQuery({
     queryKey: experienceQueryKeys.list(params),
     queryFn: () => getExperiences(params),
+  });
+}
+
+export function useInfiniteExperiences(params?: GetExperiencesParams) {
+  return useInfiniteQuery({
+    queryKey: experienceQueryKeys.infiniteList(params),
+    queryFn: ({ pageParam }) =>
+      getExperiences({
+        ...params,
+        cursor: pageParam,
+      }),
+    initialPageParam: null as number | null,
+    getNextPageParam: (lastPage) =>
+      lastPage.hasNext && lastPage.nextCursor != null ? lastPage.nextCursor : undefined,
   });
 }
 

--- a/src/hooks/experience/useExperiences.ts
+++ b/src/hooks/experience/useExperiences.ts
@@ -1,0 +1,33 @@
+'use client';
+
+import { skipToken, useQuery } from '@tanstack/react-query';
+
+import {
+  getExperienceDetail,
+  getExperiences,
+  type GetExperiencesParams,
+} from '@/app/api/experience';
+
+export const experienceQueryKeys = {
+  all: ['experiences'] as const,
+  lists: () => [...experienceQueryKeys.all, 'list'] as const,
+  list: (params?: GetExperiencesParams) =>
+    [...experienceQueryKeys.lists(), params ?? null] as const,
+  details: () => [...experienceQueryKeys.all, 'detail'] as const,
+  detail: (experienceId: number | null | undefined) =>
+    [...experienceQueryKeys.details(), experienceId ?? null] as const,
+};
+
+export function useExperiences(params?: GetExperiencesParams) {
+  return useQuery({
+    queryKey: experienceQueryKeys.list(params),
+    queryFn: () => getExperiences(params),
+  });
+}
+
+export function useExperienceDetail(experienceId: number | null | undefined) {
+  return useQuery({
+    queryKey: experienceQueryKeys.detail(experienceId),
+    queryFn: experienceId != null ? () => getExperienceDetail(experienceId) : skipToken,
+  });
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#25 

## 📝작업 내용

경험 관리 페이지 API 연동을 진행했습니다.

- 공통 API client를 추가했습니다.
  - `NEXT_PUBLIC_API_BASE_URL` 기반 요청 URL 생성
  - query params 처리
  - JSON/FormData body 처리
  - `Authorization: Bearer {accessToken}` 헤더 처리
  - 공통 API 응답 파싱 및 `ApiError` 처리

- 경험 API 타입과 요청 함수를 추가했습니다.
  - 경험 목록/상세 응답 타입 정의 
  - 경험 목록 조회
  - 경험 상세 조회

- TanStack Query 기반 경험 조회 훅을 추가했습니다.
  - 경험 목록 조회 훅
  - 경험 상세 조회 훅
  - 무한 스크롤용 경험 목록 조회 훅

- 경험 목록에 무한 스크롤을 적용했습니다.
  - cursor 기반 다음 페이지 요청
  - `hasNext`, `nextCursor` 기반 다음 페이지 판단
 
### 스크린샷 (선택)

https://github.com/user-attachments/assets/ec60eaed-d2e6-4046-93ab-d1e2cfef8261

https://github.com/user-attachments/assets/a14c3ff4-3e33-4b14-8cd6-78383e3ee9a2

## 💬리뷰 요구사항(선택)

- 폴더 구조 이런 식으로 하면 되는지 봐주세요 !
- 로딩/에러/빈 상태 UI는 임시로 처리했습니다.
- 현재 인증은 로그인 연동 전이라 `localStorage.accessToken`을 읽는 임시 방식으로 구현했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Experience pages now fetch data from the live API instead of mock data.
  * Added infinite pagination for experience listings with automatic loading when scrolling.
  * Loading and error states now display in the experience detail panel.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-KKIUM/KKIUM-FE/pull/26?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->