### PR TITLE
[Feat] 추가된 경험 관리 API 연동

### DIFF
--- a/src/app/(pages)/experience/[experienceId]/_components/ExperienceDetailPageContent.tsx
+++ b/src/app/(pages)/experience/[experienceId]/_components/ExperienceDetailPageContent.tsx
@@ -3,12 +3,16 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import * as React from 'react';
 
-import { ExperienceDetailContent } from '@/app/(pages)/experience/_components/ExperienceDetailContent';
+import {
+  ExperienceDetailContent,
+  type ExperienceDetailSaveValue,
+} from '@/app/(pages)/experience/_components/ExperienceDetailContent';
 import { mapExperienceDetailToItem } from '@/app/(pages)/experience/_utils/mapExperienceResponse';
+import { mapExperienceItemToUpdateRequest } from '@/app/(pages)/experience/_utils/mapExperienceItemToUpdateRequest';
 import { EmptyState } from '@/components/common/EmptyState';
 import { ExpandIcon } from '@/components/common/icons/ExpandIcon';
 import { XIcon } from '@/components/common/icons/XIcon';
-import { useExperienceDetail } from '@/hooks/experience/useExperiences';
+import { useExperienceDetail, useUpdateExperience } from '@/hooks/experience/useExperiences';
 
 interface ExperienceDetailPageContentProps {
   experienceId: number;
@@ -19,6 +23,7 @@ export function ExperienceDetailPageContent({ experienceId }: ExperienceDetailPa
   const searchParams = useSearchParams();
   const category = searchParams.get('category');
   const { data, isError, isPending } = useExperienceDetail(experienceId);
+  const updateExperienceMutation = useUpdateExperience();
   const experience = React.useMemo(() => (data ? mapExperienceDetailToItem(data) : null), [data]);
 
   const handleCollapseToPanel = () => {
@@ -33,6 +38,20 @@ export function ExperienceDetailPageContent({ experienceId }: ExperienceDetailPa
 
   const handleBackToExperience = () => {
     router.push('/experience');
+  };
+
+  const handleExperienceSave = async (nextExperience: ExperienceDetailSaveValue) => {
+    if (!experience) {
+      throw new Error('수정할 경험 정보를 확인하지 못했습니다.');
+    }
+
+    await updateExperienceMutation.mutateAsync({
+      experienceId,
+      request: mapExperienceItemToUpdateRequest({
+        ...experience,
+        ...nextExperience,
+      }),
+    });
   };
 
   return (
@@ -74,7 +93,12 @@ export function ExperienceDetailPageContent({ experienceId }: ExperienceDetailPa
             />
           </div>
         ) : (
-          <ExperienceDetailContent experience={experience} variant="page" scrollable={false} />
+          <ExperienceDetailContent
+            experience={experience}
+            variant="page"
+            scrollable={false}
+            onSave={handleExperienceSave}
+          />
         )}
       </div>
     </div>

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -16,7 +16,11 @@ import {
 } from '@/app/(pages)/experience/_utils/mapExperienceResponse';
 import type { PieceType } from '@/app/api/experience/types';
 import { EmptyState } from '@/components/common/EmptyState';
-import { useExperienceDetail, useInfiniteExperiences } from '@/hooks/experience/useExperiences';
+import {
+  useExperienceDetail,
+  useInfiniteExperiences,
+  useUpdateExperienceTitle,
+} from '@/hooks/experience/useExperiences';
 import { cn } from '@/lib/utils';
 
 export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
@@ -58,6 +62,7 @@ export function ExperienceBoard({
     selectedCategory === 'all' ? undefined : pieceTypeByCategory[selectedCategory];
   const { data, fetchNextPage, hasNextPage, isError, isFetching, isFetchingNextPage, isPending } =
     useInfiniteExperiences(selectedPieceType ? { type: selectedPieceType } : undefined);
+  const updateExperienceTitleMutation = useUpdateExperienceTitle();
   const experiences = React.useMemo(
     () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
     [data],
@@ -214,6 +219,22 @@ export function ExperienceBoard({
     [selectedCategory],
   );
 
+  const handleExperienceTitleSave = React.useCallback(
+    async (experience: ExperienceItem, nextTitle: string) => {
+      const experienceId = Number(experience.id);
+
+      if (!Number.isInteger(experienceId) || experienceId <= 0) {
+        throw new Error('수정할 경험 정보를 확인하지 못했습니다.');
+      }
+
+      await updateExperienceTitleMutation.mutateAsync({
+        experienceId,
+        request: { title: nextTitle },
+      });
+    },
+    [updateExperienceTitleMutation],
+  );
+
   const handlePanelClose = () => {
     if (closeTimerRef.current) {
       clearTimeout(closeTimerRef.current);
@@ -266,6 +287,7 @@ export function ExperienceBoard({
             sortable
             onExperienceClick={handleExperienceSelect}
             onExperienceReorder={handleExperienceReorder}
+            onExperienceTitleSave={handleExperienceTitleSave}
           />
           <div ref={loadMoreRef} aria-hidden="true" className="h-1" />
           {/* TODO: 다음 페이지 로딩 UI가 확정되면 임시 문구를 교체한다. */}

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -19,6 +19,7 @@ import { mapExperienceItemToUpdateRequest } from '@/app/(pages)/experience/_util
 import type { PieceType } from '@/app/api/experience/types';
 import { EmptyState } from '@/components/common/EmptyState';
 import {
+  useDeleteExperience,
   useExperienceDetail,
   useInfiniteExperiences,
   useUpdateExperience,
@@ -73,6 +74,7 @@ export function ExperienceBoard({
     selectedCategory === 'all' ? undefined : filterPieceTypeByCategory[selectedCategory];
   const { data, fetchNextPage, hasNextPage, isError, isFetching, isFetchingNextPage, isPending } =
     useInfiniteExperiences(selectedPieceType ? { type: selectedPieceType } : undefined);
+  const deleteExperienceMutation = useDeleteExperience();
   const updateExperienceMutation = useUpdateExperience();
   const updateExperienceOrderMutation = useUpdateExperienceOrder();
   const updateExperienceTitleMutation = useUpdateExperienceTitle();
@@ -274,6 +276,37 @@ export function ExperienceBoard({
     [updateExperienceTitleMutation],
   );
 
+  const handleExperienceDelete = React.useCallback(
+    async (experience: ExperienceItem) => {
+      const experienceId = Number(experience.id);
+
+      if (!Number.isInteger(experienceId) || experienceId <= 0) {
+        throw new Error('삭제할 경험 정보를 확인하지 못했습니다.');
+      }
+
+      await deleteExperienceMutation.mutateAsync(experienceId);
+
+      setExperienceOrderMap((currentOrderMap) =>
+        sortableCategories.reduce<ExperienceOrderMap>((nextOrderMap, category) => {
+          nextOrderMap[category] = currentOrderMap[category].filter((id) => id !== experience.id);
+          return nextOrderMap;
+        }, {} as ExperienceOrderMap),
+      );
+
+      if (selectedExperienceId === experience.id) {
+        if (closeTimerRef.current) {
+          clearTimeout(closeTimerRef.current);
+          closeTimerRef.current = null;
+        }
+
+        setPanelOpen(false);
+        setSelectedExperienceId(undefined);
+        router.replace('/experience', { scroll: false });
+      }
+    },
+    [deleteExperienceMutation, router, selectedExperienceId],
+  );
+
   const handleExperienceDetailSave = React.useCallback(
     async (nextExperience: ExperienceDetailSaveValue) => {
       if (!panelExperience) {
@@ -350,6 +383,7 @@ export function ExperienceBoard({
             selectedExperienceId={selectedExperienceId}
             sortable
             onExperienceClick={handleExperienceSelect}
+            onExperienceDelete={handleExperienceDelete}
             onExperienceReorder={handleExperienceReorder}
             onExperienceTitleSave={handleExperienceTitleSave}
           />

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -120,7 +120,7 @@ export function ExperienceBoard({
 
   React.useEffect(() => {
     setExperienceOrderMap((currentOrderMap) => {
-      const nextOrderMap = syncExperienceOrderMap(currentOrderMap, experiences);
+      const nextOrderMap = syncExperienceOrderMap(currentOrderMap, experiences, selectedCategory);
 
       if (areExperienceOrderMapsEqual(currentOrderMap, nextOrderMap)) {
         return currentOrderMap;
@@ -128,7 +128,7 @@ export function ExperienceBoard({
 
       return nextOrderMap;
     });
-  }, [experiences]);
+  }, [experiences, selectedCategory]);
 
   React.useEffect(() => {
     if (previousKeywordRef.current === keyword) {
@@ -470,10 +470,20 @@ function createExperienceOrderMap(experiences: ExperienceItem[]): ExperienceOrde
 function syncExperienceOrderMap(
   currentOrderMap: ExperienceOrderMap,
   experiences: ExperienceItem[],
+  syncedCategory: ExperienceCategory,
 ): ExperienceOrderMap {
   const defaultOrderMap = createExperienceOrderMap(experiences);
 
+  if (syncedCategory === 'all') {
+    return defaultOrderMap;
+  }
+
   return sortableCategories.reduce<ExperienceOrderMap>((nextOrderMap, category) => {
+    if (category === syncedCategory) {
+      nextOrderMap[category] = defaultOrderMap[category];
+      return nextOrderMap;
+    }
+
     const nextIds = defaultOrderMap[category];
     const nextIdSet = new Set(nextIds);
     const currentIds = currentOrderMap[category];

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -188,6 +188,19 @@ export function ExperienceBoard({
     };
   }, []);
 
+  const experienceMap = React.useMemo(
+    () => new Map(experiences.map((experience) => [experience.id, experience])),
+    [experiences],
+  );
+
+  const filteredExperiences = React.useMemo(
+    () =>
+      experienceOrderMap[selectedCategory]
+        .map((id) => experienceMap.get(id))
+        .filter((experience): experience is ExperienceItem => Boolean(experience)),
+    [experienceMap, experienceOrderMap, selectedCategory],
+  );
+
   React.useEffect(() => {
     const loadMoreElement = loadMoreRef.current;
 
@@ -209,20 +222,7 @@ export function ExperienceBoard({
     return () => {
       observer.disconnect();
     };
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage]);
-
-  const experienceMap = React.useMemo(
-    () => new Map(experiences.map((experience) => [experience.id, experience])),
-    [experiences],
-  );
-
-  const filteredExperiences = React.useMemo(
-    () =>
-      experienceOrderMap[selectedCategory]
-        .map((id) => experienceMap.get(id))
-        .filter((experience): experience is ExperienceItem => Boolean(experience)),
-    [experienceMap, experienceOrderMap, selectedCategory],
-  );
+  }, [fetchNextPage, filteredExperiences.length, hasNextPage, isFetchingNextPage]);
 
   const selectedExperience = filteredExperiences.find(
     (experience) => experience.id === selectedExperienceId,

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -22,6 +22,7 @@ import {
   useExperienceDetail,
   useInfiniteExperiences,
   useUpdateExperience,
+  useUpdateExperienceOrder,
   useUpdateExperienceTitle,
 } from '@/hooks/experience/useExperiences';
 import { cn } from '@/lib/utils';
@@ -33,7 +34,14 @@ export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
 type ExperienceOrderMap = Record<ExperienceCategory, string[]>;
 
 const sortableCategories: ExperienceCategory[] = ['all', 'activity', 'career', 'education', 'etc'];
-const pieceTypeByCategory: Record<Exclude<ExperienceCategory, 'all'>, PieceType> = {
+const orderPieceTypeByCategory: Record<ExperienceCategory, PieceType> = {
+  all: 'ALL',
+  activity: 'ACTIVITY',
+  career: 'CAREER',
+  education: 'EDUCATION',
+  etc: 'ETC',
+};
+const filterPieceTypeByCategory: Record<Exclude<ExperienceCategory, 'all'>, Exclude<PieceType, 'ALL'>> = {
   activity: 'ACTIVITY',
   career: 'CAREER',
   education: 'EDUCATION',
@@ -62,10 +70,11 @@ export function ExperienceBoard({
     selectedExperienceIdFromQuery,
   );
   const selectedPieceType =
-    selectedCategory === 'all' ? undefined : pieceTypeByCategory[selectedCategory];
+    selectedCategory === 'all' ? undefined : filterPieceTypeByCategory[selectedCategory];
   const { data, fetchNextPage, hasNextPage, isError, isFetching, isFetchingNextPage, isPending } =
     useInfiniteExperiences(selectedPieceType ? { type: selectedPieceType } : undefined);
   const updateExperienceMutation = useUpdateExperience();
+  const updateExperienceOrderMutation = useUpdateExperienceOrder();
   const updateExperienceTitleMutation = useUpdateExperienceTitle();
   const experiences = React.useMemo(
     () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
@@ -215,12 +224,38 @@ export function ExperienceBoard({
 
   const handleExperienceReorder = React.useCallback(
     (orderedExperienceIds: string[]) => {
+      const previousOrderIds = experienceOrderMap[selectedCategory];
+      const parsedExperienceIds = orderedExperienceIds.map(Number);
+
+      if (
+        parsedExperienceIds.some(
+          (experienceId) => !Number.isInteger(experienceId) || experienceId <= 0,
+        )
+      ) {
+        return;
+      }
+
       setExperienceOrderMap((currentOrderMap) => ({
         ...currentOrderMap,
         [selectedCategory]: orderedExperienceIds,
       }));
+
+      updateExperienceOrderMutation.mutate(
+        {
+          type: orderPieceTypeByCategory[selectedCategory],
+          experienceIds: parsedExperienceIds,
+        },
+        {
+          onError: () => {
+            setExperienceOrderMap((currentOrderMap) => ({
+              ...currentOrderMap,
+              [selectedCategory]: previousOrderIds,
+            }));
+          },
+        },
+      );
     },
-    [selectedCategory],
+    [experienceOrderMap, selectedCategory, updateExperienceOrderMutation],
   );
 
   const handleExperienceTitleSave = React.useCallback(

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -30,6 +30,7 @@ import { cn } from '@/lib/utils';
 
 export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
   initialSelectedExperienceId?: string;
+  keyword?: string;
 }
 
 type ExperienceOrderMap = Record<ExperienceCategory, string[]>;
@@ -55,6 +56,7 @@ function isExperienceCategory(category: string | null): category is ExperienceCa
 
 export function ExperienceBoard({
   initialSelectedExperienceId,
+  keyword,
   className,
   ...props
 }: ExperienceBoardProps) {
@@ -72,8 +74,15 @@ export function ExperienceBoard({
   );
   const selectedPieceType =
     selectedCategory === 'all' ? undefined : filterPieceTypeByCategory[selectedCategory];
+  const experienceParams = React.useMemo(
+    () => ({
+      ...(selectedPieceType ? { type: selectedPieceType } : {}),
+      ...(keyword ? { keyword } : {}),
+    }),
+    [keyword, selectedPieceType],
+  );
   const { data, fetchNextPage, hasNextPage, isError, isFetching, isFetchingNextPage, isPending } =
-    useInfiniteExperiences(selectedPieceType ? { type: selectedPieceType } : undefined);
+    useInfiniteExperiences(experienceParams);
   const deleteExperienceMutation = useDeleteExperience();
   const updateExperienceMutation = useUpdateExperience();
   const updateExperienceOrderMutation = useUpdateExperienceOrder();

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -145,16 +145,20 @@ export function ExperienceBoard({
     setSelectedExperienceId(undefined);
     setPanelOpen(false);
 
-    const params = new URLSearchParams();
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.delete('selected');
 
     if (selectedCategory !== 'all') {
       params.set('category', selectedCategory);
+    } else {
+      params.delete('category');
     }
 
     router.replace(params.size > 0 ? `/experience?${params.toString()}` : '/experience', {
       scroll: false,
     });
-  }, [keyword, router, selectedCategory]);
+  }, [keyword, router, searchParams, selectedCategory]);
 
   React.useEffect(() => {
     if (hasAppliedInitialSelectionRef.current || !selectedExperienceIdFromQuery) {

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -9,16 +9,19 @@ import {
 } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
 import type { ExperienceCategory } from '@/app/(pages)/experience/_components/ExperienceCategoryTab';
 import { ExperienceCategoryTabs } from '@/app/(pages)/experience/_components/ExperienceCategoryTabs';
+import type { ExperienceDetailSaveValue } from '@/app/(pages)/experience/_components/ExperienceDetailContent';
 import { ExperienceDetailPanel } from '@/app/(pages)/experience/_components/ExperienceDetailPanel';
 import {
   mapExperienceCardToItem,
   mapExperienceDetailToItem,
 } from '@/app/(pages)/experience/_utils/mapExperienceResponse';
+import { mapExperienceItemToUpdateRequest } from '@/app/(pages)/experience/_utils/mapExperienceItemToUpdateRequest';
 import type { PieceType } from '@/app/api/experience/types';
 import { EmptyState } from '@/components/common/EmptyState';
 import {
   useExperienceDetail,
   useInfiniteExperiences,
+  useUpdateExperience,
   useUpdateExperienceTitle,
 } from '@/hooks/experience/useExperiences';
 import { cn } from '@/lib/utils';
@@ -62,6 +65,7 @@ export function ExperienceBoard({
     selectedCategory === 'all' ? undefined : pieceTypeByCategory[selectedCategory];
   const { data, fetchNextPage, hasNextPage, isError, isFetching, isFetchingNextPage, isPending } =
     useInfiniteExperiences(selectedPieceType ? { type: selectedPieceType } : undefined);
+  const updateExperienceMutation = useUpdateExperience();
   const updateExperienceTitleMutation = useUpdateExperienceTitle();
   const experiences = React.useMemo(
     () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
@@ -235,6 +239,31 @@ export function ExperienceBoard({
     [updateExperienceTitleMutation],
   );
 
+  const handleExperienceDetailSave = React.useCallback(
+    async (nextExperience: ExperienceDetailSaveValue) => {
+      if (!panelExperience) {
+        throw new Error('수정할 경험 정보를 확인하지 못했습니다.');
+      }
+
+      const experienceId = Number(panelExperience.id);
+
+      if (!Number.isInteger(experienceId) || experienceId <= 0) {
+        throw new Error('수정할 경험 정보를 확인하지 못했습니다.');
+      }
+
+      const updatedExperience = {
+        ...panelExperience,
+        ...nextExperience,
+      };
+
+      await updateExperienceMutation.mutateAsync({
+        experienceId,
+        request: mapExperienceItemToUpdateRequest(updatedExperience),
+      });
+    },
+    [panelExperience, updateExperienceMutation],
+  );
+
   const handlePanelClose = () => {
     if (closeTimerRef.current) {
       clearTimeout(closeTimerRef.current);
@@ -311,6 +340,7 @@ export function ExperienceBoard({
           detailError={isDetailError}
           detailLoading={showDetailLoading}
           onExpand={handlePanelExpand}
+          onSave={handleExperienceDetailSave}
           onClose={handlePanelClose}
         />
       )}

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -98,6 +98,7 @@ export function ExperienceBoard({
   const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadMoreRef = React.useRef<HTMLDivElement>(null);
   const hasAppliedInitialSelectionRef = React.useRef(false);
+  const previousKeywordRef = React.useRef(keyword);
   const selectedExperienceNumericId = selectedExperienceId ? Number(selectedExperienceId) : null;
   const {
     data: selectedExperienceDetail,
@@ -128,6 +129,32 @@ export function ExperienceBoard({
       return nextOrderMap;
     });
   }, [experiences]);
+
+  React.useEffect(() => {
+    if (previousKeywordRef.current === keyword) {
+      return;
+    }
+
+    previousKeywordRef.current = keyword;
+
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+
+    setSelectedExperienceId(undefined);
+    setPanelOpen(false);
+
+    const params = new URLSearchParams();
+
+    if (selectedCategory !== 'all') {
+      params.set('category', selectedCategory);
+    }
+
+    router.replace(params.size > 0 ? `/experience?${params.toString()}` : '/experience', {
+      scroll: false,
+    });
+  }, [keyword, router, selectedCategory]);
 
   React.useEffect(() => {
     if (hasAppliedInitialSelectionRef.current || !selectedExperienceIdFromQuery) {

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -317,27 +317,34 @@ export function ExperienceBoard({
       const experienceId = Number(experience.id);
 
       if (!Number.isInteger(experienceId) || experienceId <= 0) {
-        throw new Error('삭제할 경험 정보를 확인하지 못했습니다.');
+        window.alert('삭제할 경험 정보를 확인하지 못했습니다.');
+        return;
       }
 
-      await deleteExperienceMutation.mutateAsync(experienceId);
+      try {
+        await deleteExperienceMutation.mutateAsync(experienceId);
 
-      setExperienceOrderMap((currentOrderMap) =>
-        sortableCategories.reduce<ExperienceOrderMap>((nextOrderMap, category) => {
-          nextOrderMap[category] = currentOrderMap[category].filter((id) => id !== experience.id);
-          return nextOrderMap;
-        }, {} as ExperienceOrderMap),
-      );
+        setExperienceOrderMap((currentOrderMap) =>
+          sortableCategories.reduce<ExperienceOrderMap>((nextOrderMap, category) => {
+            nextOrderMap[category] = currentOrderMap[category].filter(
+              (id) => id !== experience.id,
+            );
+            return nextOrderMap;
+          }, {} as ExperienceOrderMap),
+        );
 
-      if (selectedExperienceId === experience.id) {
-        if (closeTimerRef.current) {
-          clearTimeout(closeTimerRef.current);
-          closeTimerRef.current = null;
+        if (selectedExperienceId === experience.id) {
+          if (closeTimerRef.current) {
+            clearTimeout(closeTimerRef.current);
+            closeTimerRef.current = null;
+          }
+
+          setPanelOpen(false);
+          setSelectedExperienceId(undefined);
+          router.replace('/experience', { scroll: false });
         }
-
-        setPanelOpen(false);
-        setSelectedExperienceId(undefined);
-        router.replace('/experience', { scroll: false });
+      } catch (error) {
+        window.alert(error instanceof Error ? error.message : '경험 삭제 중 오류가 발생했습니다.');
       }
     },
     [deleteExperienceMutation, router, selectedExperienceId],

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -493,7 +493,7 @@ function syncExperienceOrderMap(
 
     const nextIds = defaultOrderMap[category];
     const nextIdSet = new Set(nextIds);
-    const currentIds = currentOrderMap[category];
+    const currentIds = currentOrderMap[category] ?? [];
     const currentIdSet = new Set(currentIds);
     const preservedIds = currentIds.filter((id) => nextIdSet.has(id));
     const addedIds = nextIds.filter((id) => !currentIdSet.has(id));

--- a/src/app/(pages)/experience/_components/ExperienceCard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCard.tsx
@@ -44,6 +44,7 @@ export interface ExperienceCardProps
   skillTags: string[];
   competencyTags: string[];
   disableActivationKeys?: boolean;
+  onDelete?: () => Promise<void> | void;
   onTitleSave?: (nextTitle: string) => Promise<void> | void;
 }
 
@@ -61,6 +62,7 @@ export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>
       onClick,
       onKeyDown,
       disableActivationKeys = false,
+      onDelete,
       onTitleSave,
       ...props
     },
@@ -181,7 +183,11 @@ export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>
             height={72}
             className="size-[72px] shrink-0"
           />
-          <ExperienceCardDropdownMenu triggerClassName="shrink-0" onEditTitle={startTitleEdit} />
+          <ExperienceCardDropdownMenu
+            triggerClassName="shrink-0"
+            onEditTitle={startTitleEdit}
+            onDelete={() => void onDelete?.()}
+          />
         </div>
 
         <div className="flex w-full flex-col items-start gap-3">

--- a/src/app/(pages)/experience/_components/ExperienceCard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCard.tsx
@@ -44,6 +44,7 @@ export interface ExperienceCardProps
   skillTags: string[];
   competencyTags: string[];
   disableActivationKeys?: boolean;
+  onTitleSave?: (nextTitle: string) => Promise<void> | void;
 }
 
 export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>(
@@ -60,11 +61,34 @@ export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>
       onClick,
       onKeyDown,
       disableActivationKeys = false,
+      onTitleSave,
       ...props
     },
     ref,
   ) {
     const isInteractive = Boolean(onClick);
+    const [displayTitle, setDisplayTitle] = React.useState(title);
+    const [titleDraft, setTitleDraft] = React.useState(title);
+    const [isEditingTitle, setIsEditingTitle] = React.useState(false);
+    const [isTitleSaving, setIsTitleSaving] = React.useState(false);
+    const titleInputRef = React.useRef<HTMLInputElement>(null);
+    const isCommittingTitleRef = React.useRef(false);
+
+    React.useEffect(() => {
+      if (isEditingTitle) return;
+
+      setDisplayTitle(title);
+      setTitleDraft(title);
+    }, [isEditingTitle, title]);
+
+    React.useEffect(() => {
+      if (!isEditingTitle) return;
+
+      const titleInput = titleInputRef.current;
+
+      titleInput?.focus();
+      titleInput?.setSelectionRange(titleInput.value.length, titleInput.value.length);
+    }, [isEditingTitle]);
 
     const handleKeyDown: React.KeyboardEventHandler<HTMLElement> = (event) => {
       onKeyDown?.(event);
@@ -80,6 +104,58 @@ export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>
 
         event.preventDefault();
         onClick(event as unknown as React.MouseEvent<HTMLElement>);
+      }
+    };
+
+    const startTitleEdit = () => {
+      setTitleDraft(displayTitle);
+      setIsEditingTitle(true);
+    };
+
+    const cancelTitleEdit = () => {
+      setTitleDraft(displayTitle);
+      setIsEditingTitle(false);
+    };
+
+    const commitTitleEdit = async () => {
+      if (isCommittingTitleRef.current) return;
+
+      const nextTitle = titleDraft.trim();
+
+      if (!nextTitle || nextTitle === displayTitle) {
+        cancelTitleEdit();
+        return;
+      }
+
+      isCommittingTitleRef.current = true;
+      setIsTitleSaving(true);
+
+      try {
+        await onTitleSave?.(nextTitle);
+        setDisplayTitle(nextTitle);
+        setTitleDraft(nextTitle);
+        setIsEditingTitle(false);
+      } catch (error) {
+        window.alert(error instanceof Error ? error.message : '제목 수정 중 오류가 발생했습니다.');
+      } finally {
+        isCommittingTitleRef.current = false;
+        setIsTitleSaving(false);
+      }
+    };
+
+    const handleTitleInputKeyDown: React.KeyboardEventHandler<HTMLInputElement> = (event) => {
+      event.stopPropagation();
+
+      if (event.nativeEvent.isComposing) return;
+
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        void commitTitleEdit();
+      }
+
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        cancelTitleEdit();
       }
     };
 
@@ -105,12 +181,27 @@ export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>
             height={72}
             className="size-[72px] shrink-0"
           />
-          <ExperienceCardDropdownMenu triggerClassName="shrink-0" />
+          <ExperienceCardDropdownMenu triggerClassName="shrink-0" onEditTitle={startTitleEdit} />
         </div>
 
         <div className="flex w-full flex-col items-start gap-3">
           <div className="flex w-full flex-col items-start gap-1">
-            <h2 className="w-full truncate title-1-bold text-gray-main">{title}</h2>
+            {isEditingTitle ? (
+              <input
+                ref={titleInputRef}
+                value={titleDraft}
+                aria-label="경험 제목"
+                disabled={isTitleSaving}
+                className="w-full truncate bg-transparent p-0 title-1-bold text-gray-main outline-none disabled:text-tertiary"
+                onBlur={() => void commitTitleEdit()}
+                onChange={(event) => setTitleDraft(event.currentTarget.value)}
+                onClick={(event) => event.stopPropagation()}
+                onKeyDown={handleTitleInputKeyDown}
+                onPointerDown={(event) => event.stopPropagation()}
+              />
+            ) : (
+              <h2 className="w-full truncate title-1-bold text-gray-main">{displayTitle}</h2>
+            )}
             <div className="flex items-center gap-[6px] label-3-regular text-gray-700">
               <span>기간</span>
               <span>{period}</span>

--- a/src/app/(pages)/experience/_components/ExperienceCardDropdownMenu.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCardDropdownMenu.tsx
@@ -26,6 +26,18 @@ export function ExperienceCardDropdownMenu({
   triggerClassName,
   ...props
 }: ExperienceCardDropdownMenuProps) {
+  const handleEditTitleSelect: React.ComponentProps<typeof DropdownMenuItem>['onSelect'] = (
+    event,
+  ) => {
+    event.stopPropagation();
+    onEditTitle?.(event);
+  };
+
+  const handleDeleteSelect: React.ComponentProps<typeof DropdownMenuItem>['onSelect'] = (event) => {
+    event.stopPropagation();
+    onDelete?.(event);
+  };
+
   return (
     <DropdownMenu modal={modal} {...props}>
       <DropdownMenuTrigger asChild>
@@ -43,14 +55,20 @@ export function ExperienceCardDropdownMenu({
           <MoreVerticalIcon className="size-6" />
         </button>
       </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" sideOffset={8}>
-        <DropdownMenuItem className="active:bg-gray-300" onSelect={onEditTitle}>
+      <DropdownMenuContent
+        align="end"
+        sideOffset={8}
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={(event) => event.stopPropagation()}
+        onPointerDown={(event) => event.stopPropagation()}
+      >
+        <DropdownMenuItem className="active:bg-gray-300" onSelect={handleEditTitleSelect}>
           <span>제목 수정하기</span>
           <span className="flex size-8 items-center justify-center">
             <EditIcon className="size-6 text-tertiary" />
           </span>
         </DropdownMenuItem>
-        <DropdownMenuItem className="active:bg-gray-300" onSelect={onDelete}>
+        <DropdownMenuItem className="active:bg-gray-300" onSelect={handleDeleteSelect}>
           <span>삭제</span>
           <span className="flex size-8 items-center justify-center">
             <TrashIcon className="size-6 text-tertiary" />

--- a/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
@@ -35,6 +35,7 @@ export interface ExperienceCardGridProps extends React.ComponentProps<'div'> {
   sortable?: boolean;
   onExperienceClick?: (experience: ExperienceItem) => void;
   onExperienceReorder?: (experienceIds: string[]) => void;
+  onExperienceTitleSave?: (experience: ExperienceItem, nextTitle: string) => Promise<void> | void;
 }
 
 export function ExperienceCardGrid({
@@ -43,6 +44,7 @@ export function ExperienceCardGrid({
   sortable = false,
   onExperienceClick,
   onExperienceReorder,
+  onExperienceTitleSave,
   className,
   ...props
 }: ExperienceCardGridProps) {
@@ -85,6 +87,7 @@ export function ExperienceCardGrid({
             index={index}
             selected={selectedExperienceId === experience.id}
             onClick={onExperienceClick}
+            onTitleSave={onExperienceTitleSave}
           />
         ) : (
           <ExperienceCard
@@ -97,6 +100,7 @@ export function ExperienceCardGrid({
             selected={selectedExperienceId === experience.id}
             className="max-w-none"
             onClick={() => onExperienceClick?.(experience)}
+            onTitleSave={(nextTitle) => onExperienceTitleSave?.(experience, nextTitle)}
           />
         ),
       )}

--- a/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
@@ -45,6 +45,7 @@ export interface ExperienceCardGridProps extends React.ComponentProps<'div'> {
   selectedExperienceId?: string;
   sortable?: boolean;
   onExperienceClick?: (experience: ExperienceItem) => void;
+  onExperienceDelete?: (experience: ExperienceItem) => Promise<void> | void;
   onExperienceReorder?: (experienceIds: string[]) => void;
   onExperienceTitleSave?: (experience: ExperienceItem, nextTitle: string) => Promise<void> | void;
 }
@@ -54,6 +55,7 @@ export function ExperienceCardGrid({
   selectedExperienceId,
   sortable = false,
   onExperienceClick,
+  onExperienceDelete,
   onExperienceReorder,
   onExperienceTitleSave,
   className,
@@ -98,6 +100,7 @@ export function ExperienceCardGrid({
             index={index}
             selected={selectedExperienceId === experience.id}
             onClick={onExperienceClick}
+            onDelete={onExperienceDelete}
             onTitleSave={onExperienceTitleSave}
           />
         ) : (
@@ -111,6 +114,7 @@ export function ExperienceCardGrid({
             selected={selectedExperienceId === experience.id}
             className="max-w-none"
             onClick={() => onExperienceClick?.(experience)}
+            onDelete={() => onExperienceDelete?.(experience)}
             onTitleSave={(nextTitle) => onExperienceTitleSave?.(experience, nextTitle)}
           />
         ),

--- a/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
@@ -20,6 +20,15 @@ export interface ExperienceItem {
     label: string;
     value: string;
   }[];
+  basicDetail: {
+    name?: string;
+    teamNum?: string;
+    role?: string;
+    contributionRate?: string;
+    company?: string;
+    employmentStatus?: string;
+    organizationName?: string;
+  };
   skillTags: string[];
   competencyTags: string[];
   detail: {

--- a/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
@@ -13,6 +13,8 @@ export interface ExperienceItem {
   type: Exclude<ExperienceCategory, 'all'>;
   title: string;
   description: string;
+  startDate: string;
+  endDate: string;
   period: string;
   detailInfo: {
     label: string;

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -27,6 +27,7 @@ const detailFields = [
 ] as const;
 
 type EditableTagGroupKey = 'skill' | 'competency';
+type BasicDetailKey = keyof ExperienceItem['basicDetail'];
 
 export interface ExperienceDetailContentProps extends React.ComponentProps<'div'> {
   experience: ExperienceItem;
@@ -37,7 +38,14 @@ export interface ExperienceDetailContentProps extends React.ComponentProps<'div'
   onSave?: (
     experience: Pick<
       ExperienceItem,
-      'detail' | 'skillTags' | 'competencyTags' | 'startDate' | 'endDate'
+      | 'title'
+      | 'description'
+      | 'basicDetail'
+      | 'detail'
+      | 'skillTags'
+      | 'competencyTags'
+      | 'startDate'
+      | 'endDate'
     >,
   ) => void;
 }
@@ -54,7 +62,10 @@ export function ExperienceDetailContent({
 }: ExperienceDetailContentProps) {
   const category = getExperienceCategoryMeta(experience.type);
   const isPage = variant === 'page';
+  const [title, setTitle] = React.useState(experience.title);
+  const [description, setDescription] = React.useState(experience.description);
   const [detail, setDetail] = React.useState(experience.detail);
+  const [basicDetail, setBasicDetail] = React.useState(experience.basicDetail);
   const [startDate, setStartDate] = React.useState(experience.startDate);
   const [endDate, setEndDate] = React.useState(experience.endDate);
   const [skillTags, setSkillTags] = React.useState(experience.skillTags);
@@ -73,7 +84,10 @@ export function ExperienceDetailContent({
     }
 
     previousExperienceIdRef.current = experience.id;
+    setTitle(experience.title);
+    setDescription(experience.description);
     setDetail(experience.detail);
+    setBasicDetail(experience.basicDetail);
     setStartDate(experience.startDate);
     setEndDate(experience.endDate);
     setSkillTags(experience.skillTags);
@@ -84,12 +98,15 @@ export function ExperienceDetailContent({
     setDatePickerTop(null);
   }, [
     defaultEditing,
+    experience.basicDetail,
     experience.competencyTags,
+    experience.description,
     experience.detail,
     experience.endDate,
     experience.id,
     experience.skillTags,
     experience.startDate,
+    experience.title,
   ]);
 
   React.useEffect(() => {
@@ -146,6 +163,13 @@ export function ExperienceDetailContent({
       }));
     };
 
+  const updateBasicDetail = (key: BasicDetailKey, value: string) => {
+    setBasicDetail((currentBasicDetail) => ({
+      ...currentBasicDetail,
+      [key]: value,
+    }));
+  };
+
   const handleEditClick = () => {
     onEdit?.();
     setIsEditing(true);
@@ -154,7 +178,10 @@ export function ExperienceDetailContent({
 
   const handleSaveEdit = () => {
     onSave?.({
+      title,
+      description,
       detail,
+      basicDetail,
       startDate,
       endDate,
       skillTags,
@@ -177,6 +204,10 @@ export function ExperienceDetailContent({
   };
 
   const periodLabel = formatPeriod(startDate, endDate);
+  const detailInfoItems = React.useMemo(
+    () => getDetailInfoItems(experience.type, basicDetail, periodLabel),
+    [basicDetail, experience.type, periodLabel],
+  );
 
   return (
     <div
@@ -186,13 +217,31 @@ export function ExperienceDetailContent({
     >
       <div className={cn('flex flex-col', isPage ? 'gap-7' : 'gap-6')}>
         <div className="flex min-w-0 items-start justify-between gap-4">
-          <div className="flex min-w-0 flex-col gap-1">
-            <h3 className={cn('text-strong', isPage ? 'heading-2-bold' : 'title-1-bold')}>
-              {experience.title}
-            </h3>
-            <p className={cn('text-quaternary', isPage ? 'body-1-bold' : 'body-3-regular')}>
-              {experience.description}
-            </p>
+          <div className="flex min-w-0 flex-1 flex-col gap-1">
+            {isEditing ? (
+              <InlineTextArea
+                value={title}
+                ariaLabel="제목"
+                className={cn('text-strong', isPage ? 'heading-2-bold' : 'title-1-bold')}
+                onChange={setTitle}
+              />
+            ) : (
+              <h3 className={cn('text-strong', isPage ? 'heading-2-bold' : 'title-1-bold')}>
+                {title}
+              </h3>
+            )}
+            {isEditing ? (
+              <InlineTextArea
+                value={description}
+                ariaLabel="한 줄 설명"
+                className={cn('text-quaternary', isPage ? 'body-1-bold' : 'body-3-regular')}
+                onChange={setDescription}
+              />
+            ) : (
+              <p className={cn('text-quaternary', isPage ? 'body-1-bold' : 'body-3-regular')}>
+                {description}
+              </p>
+            )}
           </div>
 
           {isEditing ? (
@@ -225,19 +274,24 @@ export function ExperienceDetailContent({
             </span>
           </div>
 
-          <dl className="flex flex-col gap-1.5">
-            {experience.detailInfo.map((item) => (
-              <div key={item.label} className="flex items-center gap-4">
-                <dt className={cn('font-bold text-strong', isPage ? 'body-1-bold' : 'body-3-bold')}>
+          <dl className="flex w-full flex-col gap-1.5">
+            {detailInfoItems.map((item) => (
+              <div key={item.label} className="flex w-full items-start gap-4">
+                <dt
+                  className={cn(
+                    'shrink-0 font-bold text-strong',
+                    isPage ? 'body-1-bold' : 'body-3-bold',
+                  )}
+                >
                   {item.label}
                 </dt>
                 <dd
                   className={cn(
-                    'relative flex items-center gap-1 text-secondary',
+                    'relative flex min-w-0 flex-1 items-center gap-1 text-secondary',
                     isPage ? 'body-1-regular' : 'body-3-regular',
                   )}
                 >
-                  {isEditing && item.label === '기간' ? (
+                  {isEditing && item.type === 'period' ? (
                     <div ref={datePickerRootRef} className="relative flex items-center gap-1">
                       <button
                         ref={datePickerButtonRef}
@@ -290,7 +344,16 @@ export function ExperienceDetailContent({
                       )}
                     </div>
                   ) : null}
-                  <span>{item.label === '기간' ? periodLabel : item.value}</span>
+                  {isEditing && item.type === 'field' ? (
+                    <InlineTextArea
+                      value={item.value}
+                      ariaLabel={item.label}
+                      className="text-secondary"
+                      onChange={(value) => updateBasicDetail(item.name, value)}
+                    />
+                  ) : (
+                    <span>{item.type === 'field' ? item.displayValue : item.value}</span>
+                  )}
                 </dd>
               </div>
             ))}
@@ -371,6 +434,132 @@ export function ExperienceDetailContent({
         ))}
       </div>
     </div>
+  );
+}
+
+type EditableDetailInfoItem =
+  | {
+      type: 'period';
+      label: string;
+      value: string;
+    }
+  | {
+      type: 'field';
+      label: string;
+      value: string;
+      displayValue: string;
+      name: BasicDetailKey;
+    };
+
+function getDetailInfoItems(
+  type: ExperienceItem['type'],
+  basicDetail: ExperienceItem['basicDetail'],
+  periodLabel: string,
+): EditableDetailInfoItem[] {
+  switch (type) {
+    case 'activity':
+      const teamNum = basicDetail.teamNum ?? '';
+      const contributionRate = basicDetail.contributionRate ?? '';
+
+      return [
+        { type: 'period', label: '기간', value: periodLabel },
+        {
+          type: 'field',
+          label: '팀원 수',
+          value: teamNum,
+          displayValue: teamNum ? `${teamNum}명` : '',
+          name: 'teamNum',
+        },
+        {
+          type: 'field',
+          label: '내 역할',
+          value: basicDetail.role ?? '',
+          displayValue: basicDetail.role ?? '',
+          name: 'role',
+        },
+        {
+          type: 'field',
+          label: '기여도',
+          value: contributionRate,
+          displayValue: contributionRate ? `${contributionRate}%` : '',
+          name: 'contributionRate',
+        },
+      ];
+    case 'career':
+      return [
+        { type: 'period', label: '기간', value: periodLabel },
+        {
+          type: 'field',
+          label: '회사/기관/단체명',
+          value: basicDetail.company ?? '',
+          displayValue: basicDetail.company ?? '',
+          name: 'company',
+        },
+        {
+          type: 'field',
+          label: '고용 형태',
+          value: basicDetail.employmentStatus ?? '',
+          displayValue: basicDetail.employmentStatus ?? '',
+          name: 'employmentStatus',
+        },
+      ];
+    case 'education':
+      return [
+        { type: 'period', label: '기간', value: periodLabel },
+        {
+          type: 'field',
+          label: '기관명',
+          value: basicDetail.organizationName ?? '',
+          displayValue: basicDetail.organizationName ?? '',
+          name: 'organizationName',
+        },
+        {
+          type: 'field',
+          label: '수강명',
+          value: basicDetail.name ?? '',
+          displayValue: basicDetail.name ?? '',
+          name: 'name',
+        },
+      ];
+    case 'etc':
+      return [{ type: 'period', label: '기간', value: periodLabel }];
+  }
+}
+
+function InlineTextArea({
+  value,
+  ariaLabel,
+  className,
+  onChange,
+}: {
+  value: string;
+  ariaLabel: string;
+  className?: string;
+  onChange: (value: string) => void;
+}) {
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  React.useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+
+    if (!textarea) return;
+
+    textarea.style.height = '0px';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, [value]);
+
+  return (
+    <textarea
+      ref={textareaRef}
+      value={value}
+      aria-label={ariaLabel}
+      rows={1}
+      className={cn(
+        'block min-h-[1.48em] w-full min-w-0 resize-none overflow-hidden bg-transparent p-0 leading-[1.48] outline-none',
+        className,
+      )}
+      onChange={(event) => onChange(event.currentTarget.value)}
+    />
   );
 }
 

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -197,6 +197,8 @@ export function ExperienceDetailContent({
       setEditingTagGroup(null);
       setDatePickerOpen(false);
       setDatePickerTop(null);
+    } catch (error) {
+      window.alert(error instanceof Error ? error.message : '경험 수정 중 오류가 발생했습니다.');
     } finally {
       setIsSaving(false);
     }

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -79,7 +79,9 @@ export function ExperienceDetailContent({
   const previousExperienceIdRef = React.useRef(experience.id);
 
   React.useEffect(() => {
-    if (previousExperienceIdRef.current === experience.id) {
+    const isSameExperience = previousExperienceIdRef.current === experience.id;
+
+    if (isSameExperience && isEditing) {
       return;
     }
 
@@ -108,6 +110,7 @@ export function ExperienceDetailContent({
     experience.skillTags,
     experience.startDate,
     experience.title,
+    isEditing,
   ]);
 
   React.useEffect(() => {

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -469,7 +469,7 @@ function getDetailInfoItems(
   periodLabel: string,
 ): EditableDetailInfoItem[] {
   switch (type) {
-    case 'activity':
+    case 'activity': {
       const teamNum = basicDetail.teamNum ?? '';
       const contributionRate = basicDetail.contributionRate ?? '';
 
@@ -497,6 +497,7 @@ function getDetailInfoItems(
           name: 'contributionRate',
         },
       ];
+    }
     case 'career':
       return [
         { type: 'period', label: '기간', value: periodLabel },

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -9,6 +9,11 @@ import { CalendarIcon } from '@/components/common/icons/CalendarIcon';
 import { EditIcon } from '@/components/common/icons/EditIcon';
 import { Tag } from '@/components/common/Tag';
 import { DetailInput } from '@/components/common/DetailInput';
+import {
+  type SingleMonthCalendarDateRange,
+  SingleMonthRangeCalendar,
+} from '@/components/common/SingleMonthRangeCalendar';
+import { type CalendarDateRange, RangeCalendar } from '@/components/common/RangeCalendar';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/lib/utils';
@@ -29,7 +34,12 @@ export interface ExperienceDetailContentProps extends React.ComponentProps<'div'
   defaultEditing?: boolean;
   scrollable?: boolean;
   onEdit?: () => void;
-  onSave?: (experience: Pick<ExperienceItem, 'detail' | 'skillTags' | 'competencyTags'>) => void;
+  onSave?: (
+    experience: Pick<
+      ExperienceItem,
+      'detail' | 'skillTags' | 'competencyTags' | 'startDate' | 'endDate'
+    >,
+  ) => void;
 }
 
 export function ExperienceDetailContent({
@@ -45,10 +55,16 @@ export function ExperienceDetailContent({
   const category = getExperienceCategoryMeta(experience.type);
   const isPage = variant === 'page';
   const [detail, setDetail] = React.useState(experience.detail);
+  const [startDate, setStartDate] = React.useState(experience.startDate);
+  const [endDate, setEndDate] = React.useState(experience.endDate);
   const [skillTags, setSkillTags] = React.useState(experience.skillTags);
   const [competencyTags, setCompetencyTags] = React.useState(experience.competencyTags);
   const [isEditing, setIsEditing] = React.useState(defaultEditing);
   const [editingTagGroup, setEditingTagGroup] = React.useState<EditableTagGroupKey | null>(null);
+  const [datePickerOpen, setDatePickerOpen] = React.useState(false);
+  const [datePickerTop, setDatePickerTop] = React.useState<number | null>(null);
+  const datePickerRootRef = React.useRef<HTMLDivElement>(null);
+  const datePickerButtonRef = React.useRef<HTMLButtonElement>(null);
   const previousExperienceIdRef = React.useRef(experience.id);
 
   React.useEffect(() => {
@@ -58,17 +74,68 @@ export function ExperienceDetailContent({
 
     previousExperienceIdRef.current = experience.id;
     setDetail(experience.detail);
+    setStartDate(experience.startDate);
+    setEndDate(experience.endDate);
     setSkillTags(experience.skillTags);
     setCompetencyTags(experience.competencyTags);
     setIsEditing(defaultEditing);
     setEditingTagGroup(null);
+    setDatePickerOpen(false);
+    setDatePickerTop(null);
   }, [
     defaultEditing,
     experience.competencyTags,
     experience.detail,
+    experience.endDate,
     experience.id,
     experience.skillTags,
+    experience.startDate,
   ]);
+
+  React.useEffect(() => {
+    if (!datePickerOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const root = datePickerRootRef.current;
+
+      if (root && !root.contains(event.target as Node)) {
+        setDatePickerOpen(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown, true);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown, true);
+    };
+  }, [datePickerOpen]);
+
+  React.useEffect(() => {
+    if (!datePickerOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setDatePickerOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [datePickerOpen]);
+
+  const selectedDateRange = React.useMemo<
+    CalendarDateRange | SingleMonthCalendarDateRange | null
+  >(() => {
+    const parsedStartDate = parseDateValue(startDate);
+    const parsedEndDate = parseDateValue(endDate);
+
+    if (!parsedStartDate || !parsedEndDate) return null;
+
+    return { start: parsedStartDate, end: parsedEndDate };
+  }, [endDate, startDate]);
 
   const handleDetailChange =
     (key: keyof ExperienceItem['detail']): React.ChangeEventHandler<HTMLTextAreaElement> =>
@@ -88,12 +155,28 @@ export function ExperienceDetailContent({
   const handleSaveEdit = () => {
     onSave?.({
       detail,
+      startDate,
+      endDate,
       skillTags,
       competencyTags,
     });
     setIsEditing(false);
     setEditingTagGroup(null);
+    setDatePickerOpen(false);
+    setDatePickerTop(null);
   };
+
+  const toggleDatePicker = () => {
+    const buttonRect = datePickerButtonRef.current?.getBoundingClientRect();
+
+    if (buttonRect) {
+      setDatePickerTop(buttonRect.bottom + 8);
+    }
+
+    setDatePickerOpen((open) => !open);
+  };
+
+  const periodLabel = formatPeriod(startDate, endDate);
 
   return (
     <div
@@ -150,14 +233,64 @@ export function ExperienceDetailContent({
                 </dt>
                 <dd
                   className={cn(
-                    'flex items-center gap-1 text-secondary',
+                    'relative flex items-center gap-1 text-secondary',
                     isPage ? 'body-1-regular' : 'body-3-regular',
                   )}
                 >
-                  {isEditing && item.label === '기간' && (
-                    <CalendarIcon className="size-[21px] shrink-0 text-tertiary" />
-                  )}
-                  <span>{item.value}</span>
+                  {isEditing && item.label === '기간' ? (
+                    <div ref={datePickerRootRef} className="relative flex items-center gap-1">
+                      <button
+                        ref={datePickerButtonRef}
+                        type="button"
+                        aria-label="기간 선택"
+                        aria-expanded={datePickerOpen}
+                        className="flex size-[21px] shrink-0 items-center justify-center rounded-sm text-tertiary focus-visible:shadow-focus-ring focus-visible:outline-none"
+                        onClick={toggleDatePicker}
+                      >
+                        <CalendarIcon className="size-[21px]" />
+                      </button>
+                      {datePickerOpen && (
+                        <div
+                          role="dialog"
+                          aria-label="기간 선택"
+                          className={cn(
+                            'z-60',
+                            isPage
+                              ? 'absolute top-full left-0 mt-2'
+                              : 'fixed right-[max(1rem,calc((min(100vw,500px)-24rem)/2))]',
+                          )}
+                          style={isPage ? undefined : { top: datePickerTop ?? undefined }}
+                        >
+                          {isPage ? (
+                            <RangeCalendar
+                              value={selectedDateRange}
+                              defaultVisibleMonth={selectedDateRange?.start ?? new Date()}
+                              onChange={(nextRange) => {
+                                if (!nextRange) return;
+
+                                setStartDate(formatDateValue(nextRange.start));
+                                setEndDate(formatDateValue(nextRange.end));
+                                setDatePickerOpen(false);
+                              }}
+                            />
+                          ) : (
+                            <SingleMonthRangeCalendar
+                              value={selectedDateRange}
+                              defaultVisibleMonth={selectedDateRange?.start ?? new Date()}
+                              onChange={(nextRange) => {
+                                if (!nextRange) return;
+
+                                setStartDate(formatDateValue(nextRange.start));
+                                setEndDate(formatDateValue(nextRange.end));
+                                setDatePickerOpen(false);
+                              }}
+                            />
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  ) : null}
+                  <span>{item.label === '기간' ? periodLabel : item.value}</span>
                 </dd>
               </div>
             ))}
@@ -239,6 +372,35 @@ export function ExperienceDetailContent({
       </div>
     </div>
   );
+}
+
+function parseDateValue(value: string) {
+  if (!value) return null;
+
+  const date = new Date(`${value}T00:00:00`);
+
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatDateValue(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}
+
+function formatPeriod(startDate: string, endDate: string) {
+  const start = startDate.replaceAll('-', '.');
+  const end = endDate.replaceAll('-', '.');
+
+  if (!start || !end) return '';
+
+  if (startDate.slice(0, 4) === endDate.slice(0, 4)) {
+    return `${start}~${end.slice(5)}`;
+  }
+
+  return `${start}~${end}`;
 }
 
 interface EditableTagGroupProps {

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -225,7 +225,7 @@ export function ExperienceDetailContent({
             </span>
           </div>
 
-          <dl className={cn('flex flex-col gap-1.5', isPage ? 'pt-0' : 'pt-2.5')}>
+          <dl className="flex flex-col gap-1.5">
             {experience.detailInfo.map((item) => (
               <div key={item.label} className="flex items-center gap-4">
                 <dt className={cn('font-bold text-strong', isPage ? 'body-1-bold' : 'body-3-bold')}>

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -28,6 +28,17 @@ const detailFields = [
 
 type EditableTagGroupKey = 'skill' | 'competency';
 type BasicDetailKey = keyof ExperienceItem['basicDetail'];
+export type ExperienceDetailSaveValue = Pick<
+  ExperienceItem,
+  | 'title'
+  | 'description'
+  | 'basicDetail'
+  | 'detail'
+  | 'skillTags'
+  | 'competencyTags'
+  | 'startDate'
+  | 'endDate'
+>;
 
 export interface ExperienceDetailContentProps extends React.ComponentProps<'div'> {
   experience: ExperienceItem;
@@ -35,19 +46,7 @@ export interface ExperienceDetailContentProps extends React.ComponentProps<'div'
   defaultEditing?: boolean;
   scrollable?: boolean;
   onEdit?: () => void;
-  onSave?: (
-    experience: Pick<
-      ExperienceItem,
-      | 'title'
-      | 'description'
-      | 'basicDetail'
-      | 'detail'
-      | 'skillTags'
-      | 'competencyTags'
-      | 'startDate'
-      | 'endDate'
-    >,
-  ) => void;
+  onSave?: (experience: ExperienceDetailSaveValue) => Promise<void> | void;
 }
 
 export function ExperienceDetailContent({
@@ -71,6 +70,7 @@ export function ExperienceDetailContent({
   const [skillTags, setSkillTags] = React.useState(experience.skillTags);
   const [competencyTags, setCompetencyTags] = React.useState(experience.competencyTags);
   const [isEditing, setIsEditing] = React.useState(defaultEditing);
+  const [isSaving, setIsSaving] = React.useState(false);
   const [editingTagGroup, setEditingTagGroup] = React.useState<EditableTagGroupKey | null>(null);
   const [datePickerOpen, setDatePickerOpen] = React.useState(false);
   const [datePickerTop, setDatePickerTop] = React.useState<number | null>(null);
@@ -93,6 +93,7 @@ export function ExperienceDetailContent({
     setSkillTags(experience.skillTags);
     setCompetencyTags(experience.competencyTags);
     setIsEditing(defaultEditing);
+    setIsSaving(false);
     setEditingTagGroup(null);
     setDatePickerOpen(false);
     setDatePickerTop(null);
@@ -176,21 +177,26 @@ export function ExperienceDetailContent({
     setEditingTagGroup(null);
   };
 
-  const handleSaveEdit = () => {
-    onSave?.({
-      title,
-      description,
-      detail,
-      basicDetail,
-      startDate,
-      endDate,
-      skillTags,
-      competencyTags,
-    });
-    setIsEditing(false);
-    setEditingTagGroup(null);
-    setDatePickerOpen(false);
-    setDatePickerTop(null);
+  const handleSaveEdit = async () => {
+    try {
+      setIsSaving(true);
+      await onSave?.({
+        title,
+        description,
+        detail,
+        basicDetail,
+        startDate,
+        endDate,
+        skillTags,
+        competencyTags,
+      });
+      setIsEditing(false);
+      setEditingTagGroup(null);
+      setDatePickerOpen(false);
+      setDatePickerTop(null);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   const toggleDatePicker = () => {
@@ -245,8 +251,8 @@ export function ExperienceDetailContent({
           </div>
 
           {isEditing ? (
-            <Button type="button" onClick={handleSaveEdit}>
-              저장하기
+            <Button type="button" disabled={isSaving} onClick={handleSaveEdit}>
+              {isSaving ? '저장 중...' : '저장하기'}
             </Button>
           ) : (
             <Button type="button" variant="secondary" onClick={handleEditClick}>

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
 
 import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
 import { getExperienceCategoryMeta } from '@/app/(pages)/experience/_utils/ExperienceCategory';
+import { formatExperiencePeriod } from '@/app/(pages)/experience/_utils/formatExperiencePeriod';
 import { CalendarIcon } from '@/components/common/icons/CalendarIcon';
 import { EditIcon } from '@/components/common/icons/EditIcon';
 import { Tag } from '@/components/common/Tag';
@@ -214,7 +215,7 @@ export function ExperienceDetailContent({
     setDatePickerOpen((open) => !open);
   };
 
-  const periodLabel = formatPeriod(startDate, endDate);
+  const periodLabel = formatExperiencePeriod(startDate, endDate);
   const detailInfoItems = React.useMemo(
     () => getDetailInfoItems(experience.type, basicDetail, periodLabel),
     [basicDetail, experience.type, periodLabel],
@@ -588,19 +589,6 @@ function formatDateValue(date: Date) {
   const day = String(date.getDate()).padStart(2, '0');
 
   return `${year}-${month}-${day}`;
-}
-
-function formatPeriod(startDate: string, endDate: string) {
-  const start = startDate.replaceAll('-', '.');
-  const end = endDate.replaceAll('-', '.');
-
-  if (!start || !end) return '';
-
-  if (startDate.slice(0, 4) === endDate.slice(0, 4)) {
-    return `${start}~${end.slice(5)}`;
-  }
-
-  return `${start}~${end}`;
 }
 
 interface EditableTagGroupProps {

--- a/src/app/(pages)/experience/_components/ExperienceDetailPanel.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailPanel.tsx
@@ -17,7 +17,19 @@ export interface ExperienceDetailPanelProps extends Omit<
   open: boolean;
   onExpand?: () => void;
   onEdit?: () => void;
-  onSave?: (experience: Pick<ExperienceItem, 'detail' | 'skillTags' | 'competencyTags'>) => void;
+  onSave?: (
+    experience: Pick<
+      ExperienceItem,
+      | 'title'
+      | 'description'
+      | 'basicDetail'
+      | 'detail'
+      | 'skillTags'
+      | 'competencyTags'
+      | 'startDate'
+      | 'endDate'
+    >,
+  ) => void;
   detailError?: boolean;
   detailLoading?: boolean;
   onClose: () => void;

--- a/src/app/(pages)/experience/_components/ExperienceDetailPanel.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailPanel.tsx
@@ -2,7 +2,10 @@
 
 import * as React from 'react';
 
-import { ExperienceDetailContent } from '@/app/(pages)/experience/_components/ExperienceDetailContent';
+import {
+  ExperienceDetailContent,
+  type ExperienceDetailSaveValue,
+} from '@/app/(pages)/experience/_components/ExperienceDetailContent';
 import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
 import { EmptyState } from '@/components/common/EmptyState';
 import { ExpandIcon } from '@/components/common/icons/ExpandIcon';
@@ -17,19 +20,7 @@ export interface ExperienceDetailPanelProps extends Omit<
   open: boolean;
   onExpand?: () => void;
   onEdit?: () => void;
-  onSave?: (
-    experience: Pick<
-      ExperienceItem,
-      | 'title'
-      | 'description'
-      | 'basicDetail'
-      | 'detail'
-      | 'skillTags'
-      | 'competencyTags'
-      | 'startDate'
-      | 'endDate'
-    >,
-  ) => void;
+  onSave?: (experience: ExperienceDetailSaveValue) => Promise<void> | void;
   detailError?: boolean;
   detailLoading?: boolean;
   onClose: () => void;

--- a/src/app/(pages)/experience/_components/ExperiencePageContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperiencePageContent.tsx
@@ -11,14 +11,12 @@ export function ExperiencePageContent() {
   const [keyword, setKeyword] = React.useState('');
   const debouncedKeyword = useDebouncedValue(keyword.trim(), 500);
 
-  void debouncedKeyword;
-
   return (
     <div className="mx-16 flex min-h-[calc(100vh-32px)] flex-col">
       <div className="flex flex-1 flex-col gap-5">
         <ExperiencePageHeader keyword={keyword} onKeywordChange={setKeyword} />
         <Suspense>
-          <ExperienceBoard />
+          <ExperienceBoard keyword={debouncedKeyword || undefined} />
         </Suspense>
       </div>
     </div>

--- a/src/app/(pages)/experience/_components/ExperiencePageContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperiencePageContent.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { Suspense } from 'react';
+import * as React from 'react';
+
+import { ExperienceBoard } from '@/app/(pages)/experience/_components/ExperienceBoard';
+import { ExperiencePageHeader } from '@/app/(pages)/experience/_components/ExperiencePageHeader';
+import { useDebouncedValue } from '@/hooks/experience/useDebouncedValue';
+
+export function ExperiencePageContent() {
+  const [keyword, setKeyword] = React.useState('');
+  const debouncedKeyword = useDebouncedValue(keyword.trim(), 500);
+
+  void debouncedKeyword;
+
+  return (
+    <div className="mx-16 flex min-h-[calc(100vh-32px)] flex-col">
+      <div className="flex flex-1 flex-col gap-5">
+        <ExperiencePageHeader keyword={keyword} onKeywordChange={setKeyword} />
+        <Suspense>
+          <ExperienceBoard />
+        </Suspense>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(pages)/experience/_components/ExperiencePageHeader.tsx
+++ b/src/app/(pages)/experience/_components/ExperiencePageHeader.tsx
@@ -8,9 +8,17 @@ import { SearchBar } from '@/components/common/SearchBar';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
-export type ExperiencePageHeaderProps = React.ComponentProps<'header'>;
+export type ExperiencePageHeaderProps = React.ComponentProps<'header'> & {
+  keyword?: string;
+  onKeywordChange?: (keyword: string) => void;
+};
 
-export function ExperiencePageHeader({ className, ...props }: ExperiencePageHeaderProps) {
+export function ExperiencePageHeader({
+  keyword,
+  onKeywordChange,
+  className,
+  ...props
+}: ExperiencePageHeaderProps) {
   const router = useRouter();
 
   return (
@@ -23,8 +31,11 @@ export function ExperiencePageHeader({ className, ...props }: ExperiencePageHead
 
       <div className="flex w-full items-center justify-between">
         <SearchBar
+          value={keyword}
           className="w-full max-w-[551px]"
           placeholder="경험 제목, 기술 태그, 역량 태그를 검색해주세요"
+          onChange={(event) => onKeywordChange?.(event.currentTarget.value)}
+          onClear={() => onKeywordChange?.('')}
         />
         <Button onClick={() => router.push('/experience/add')} leftIcon={<PlusIcon />}>
           경험 추가

--- a/src/app/(pages)/experience/_components/SortableExperienceCard.tsx
+++ b/src/app/(pages)/experience/_components/SortableExperienceCard.tsx
@@ -9,6 +9,7 @@ export interface SortableExperienceCardProps {
   index: number;
   selected?: boolean;
   onClick?: (experience: ExperienceItem) => void;
+  onTitleSave?: (experience: ExperienceItem, nextTitle: string) => Promise<void> | void;
 }
 
 export function SortableExperienceCard({
@@ -16,6 +17,7 @@ export function SortableExperienceCard({
   index,
   selected = false,
   onClick,
+  onTitleSave,
 }: SortableExperienceCardProps) {
   const { ref, isDragSource, isDragging } = useSortable({
     id: experience.id,
@@ -37,6 +39,7 @@ export function SortableExperienceCard({
       disableActivationKeys
       className={cn('max-w-none', isDragSource && 'relative z-10 opacity-90')}
       onClick={() => onClick?.(experience)}
+      onTitleSave={(nextTitle) => onTitleSave?.(experience, nextTitle)}
     />
   );
 }

--- a/src/app/(pages)/experience/_components/SortableExperienceCard.tsx
+++ b/src/app/(pages)/experience/_components/SortableExperienceCard.tsx
@@ -9,6 +9,7 @@ export interface SortableExperienceCardProps {
   index: number;
   selected?: boolean;
   onClick?: (experience: ExperienceItem) => void;
+  onDelete?: (experience: ExperienceItem) => Promise<void> | void;
   onTitleSave?: (experience: ExperienceItem, nextTitle: string) => Promise<void> | void;
 }
 
@@ -17,6 +18,7 @@ export function SortableExperienceCard({
   index,
   selected = false,
   onClick,
+  onDelete,
   onTitleSave,
 }: SortableExperienceCardProps) {
   const { ref, isDragSource, isDragging } = useSortable({
@@ -39,6 +41,7 @@ export function SortableExperienceCard({
       disableActivationKeys
       className={cn('max-w-none', isDragSource && 'relative z-10 opacity-90')}
       onClick={() => onClick?.(experience)}
+      onDelete={() => onDelete?.(experience)}
       onTitleSave={(nextTitle) => onTitleSave?.(experience, nextTitle)}
     />
   );

--- a/src/app/(pages)/experience/_constants/experienceMockData.ts
+++ b/src/app/(pages)/experience/_constants/experienceMockData.ts
@@ -7,6 +7,7 @@ const defaultExperienceDetail = {
   description: '복잡한 비즈니스 로직을 DDD 패턴으로 설계하여 유지보수성 향상',
   startDate: '2026-04-01',
   endDate: '2026-04-28',
+  basicDetail: {},
   detail: {
     situation: '기존 서비스는 결제 도메인의 정책과 예외 처리가 여러 계층에 흩어져 있어 변경 영향 범위를 예측하기 어려웠습니다.',
     task: '결제 정책을 명확한 도메인 모델로 분리하고, 추후 기능 확장 시에도 유지보수하기 쉬운 구조를 설계해야 했습니다.',
@@ -14,7 +15,10 @@ const defaultExperienceDetail = {
     result: '결제 정책 변경 시 수정 지점이 줄어들었고, 주요 플로우에 대한 테스트 작성 범위도 명확해졌습니다.',
     taken: '복잡한 비즈니스 로직은 UI나 인프라보다 도메인 규칙을 먼저 정리해야 장기적인 변경 비용을 줄일 수 있다는 점을 배웠습니다.',
   },
-} satisfies Pick<ExperienceItem, 'description' | 'startDate' | 'endDate' | 'detail'>;
+} satisfies Pick<
+  ExperienceItem,
+  'description' | 'startDate' | 'endDate' | 'basicDetail' | 'detail'
+>;
 
 const detailInfoMap = {
   activity: [
@@ -53,6 +57,10 @@ export const experienceMockData: ExperienceItem[] = [
     title: '고가용성 결제 시스템 설계 및 운영',
     period: '2026.04.01~04.28',
     ...defaultExperienceDetail,
+    basicDetail: {
+      organizationName: '큐시즘대학교',
+      name: '데이터베이스시스템',
+    },
     detailInfo: detailInfoMap.education,
     skillTags: ['기술', '기술'],
     competencyTags: ['역량', '역량'],
@@ -63,6 +71,11 @@ export const experienceMockData: ExperienceItem[] = [
     title: '고가용성 결제 시스템 설계 및 운영',
     period: '2026.04.01~04.28',
     ...defaultExperienceDetail,
+    basicDetail: {
+      teamNum: '1',
+      role: '팀장',
+      contributionRate: '100',
+    },
     detailInfo: detailInfoMap.activity,
     skillTags: ['기술', '기술'],
     competencyTags: ['역량', '역량'],
@@ -73,6 +86,10 @@ export const experienceMockData: ExperienceItem[] = [
     title: '고가용성 결제 시스템 설계 및 운영',
     period: '2026.04.01~04.28',
     ...defaultExperienceDetail,
+    basicDetail: {
+      company: '리트머스',
+      employmentStatus: '인턴',
+    },
     detailInfo: detailInfoMap.career,
     skillTags: ['기술', '기술'],
     competencyTags: ['역량', '역량'],
@@ -93,6 +110,10 @@ export const experienceMockData: ExperienceItem[] = [
     title: '고가용성 결제 시스템 설계 및 운영',
     period: '2026.04.01~04.28',
     ...defaultExperienceDetail,
+    basicDetail: {
+      organizationName: '큐시즘대학교',
+      name: '데이터베이스시스템',
+    },
     detailInfo: detailInfoMap.education,
     skillTags: ['기술', '기술'],
     competencyTags: ['역량', '역량'],
@@ -103,6 +124,11 @@ export const experienceMockData: ExperienceItem[] = [
     title: '고가용성 결제 시스템 설계 및 운영',
     period: '2026.04.01~04.28',
     ...defaultExperienceDetail,
+    basicDetail: {
+      teamNum: '1',
+      role: '팀장',
+      contributionRate: '100',
+    },
     detailInfo: detailInfoMap.activity,
     skillTags: ['기술', '기술'],
     competencyTags: ['역량', '역량'],
@@ -113,6 +139,10 @@ export const experienceMockData: ExperienceItem[] = [
     title: '고가용성 결제 시스템 설계 및 운영',
     period: '2026.04.01~04.28',
     ...defaultExperienceDetail,
+    basicDetail: {
+      company: '리트머스',
+      employmentStatus: '인턴',
+    },
     detailInfo: detailInfoMap.career,
     skillTags: ['기술', '기술'],
     competencyTags: ['역량', '역량'],
@@ -133,6 +163,10 @@ export const experienceMockData: ExperienceItem[] = [
     title: '고가용성 결제 시스템 설계 및 운영',
     period: '2026.04.01~04.28',
     ...defaultExperienceDetail,
+    basicDetail: {
+      organizationName: '큐시즘대학교',
+      name: '데이터베이스시스템',
+    },
     detailInfo: detailInfoMap.education,
     skillTags: ['기술', '기술'],
     competencyTags: ['역량', '역량'],
@@ -143,6 +177,11 @@ export const experienceMockData: ExperienceItem[] = [
     title: '고가용성 결제 시스템 설계 및 운영',
     period: '2026.04.01~04.28',
     ...defaultExperienceDetail,
+    basicDetail: {
+      teamNum: '1',
+      role: '팀장',
+      contributionRate: '100',
+    },
     detailInfo: detailInfoMap.activity,
     skillTags: ['기술', '기술'],
     competencyTags: ['역량', '역량'],
@@ -153,6 +192,10 @@ export const experienceMockData: ExperienceItem[] = [
     title: '고가용성 결제 시스템 설계 및 운영',
     period: '2026.04.01~04.28',
     ...defaultExperienceDetail,
+    basicDetail: {
+      company: '리트머스',
+      employmentStatus: '인턴',
+    },
     detailInfo: detailInfoMap.career,
     skillTags: ['기술', '기술'],
     competencyTags: ['역량', '역량'],

--- a/src/app/(pages)/experience/_constants/experienceMockData.ts
+++ b/src/app/(pages)/experience/_constants/experienceMockData.ts
@@ -20,7 +20,8 @@ const detailInfoMap = {
   activity: [
     { label: '기간', value: '2026.04.01~04.28' },
     { label: '팀원 수', value: '1인' },
-    { label: '내 역할 및 기여도', value: '팀장, 100%' },
+    { label: '내 역할', value: '팀장' },
+    { label: '기여도', value: '100%' },
   ],
   career: [
     { label: '기간', value: '2026.04.01~04.28' },

--- a/src/app/(pages)/experience/_constants/experienceMockData.ts
+++ b/src/app/(pages)/experience/_constants/experienceMockData.ts
@@ -5,6 +5,8 @@ type ExperienceType = Exclude<ExperienceCategory, 'all'>;
 
 const defaultExperienceDetail = {
   description: '복잡한 비즈니스 로직을 DDD 패턴으로 설계하여 유지보수성 향상',
+  startDate: '2026-04-01',
+  endDate: '2026-04-28',
   detail: {
     situation: '기존 서비스는 결제 도메인의 정책과 예외 처리가 여러 계층에 흩어져 있어 변경 영향 범위를 예측하기 어려웠습니다.',
     task: '결제 정책을 명확한 도메인 모델로 분리하고, 추후 기능 확장 시에도 유지보수하기 쉬운 구조를 설계해야 했습니다.',
@@ -12,7 +14,7 @@ const defaultExperienceDetail = {
     result: '결제 정책 변경 시 수정 지점이 줄어들었고, 주요 플로우에 대한 테스트 작성 범위도 명확해졌습니다.',
     taken: '복잡한 비즈니스 로직은 UI나 인프라보다 도메인 규칙을 먼저 정리해야 장기적인 변경 비용을 줄일 수 있다는 점을 배웠습니다.',
   },
-} satisfies Pick<ExperienceItem, 'description' | 'detail'>;
+} satisfies Pick<ExperienceItem, 'description' | 'startDate' | 'endDate' | 'detail'>;
 
 const detailInfoMap = {
   activity: [

--- a/src/app/(pages)/experience/_utils/formatExperiencePeriod.ts
+++ b/src/app/(pages)/experience/_utils/formatExperiencePeriod.ts
@@ -1,0 +1,12 @@
+export function formatExperiencePeriod(startDate: string, endDate: string) {
+  const start = startDate.replaceAll('-', '.');
+  const end = endDate.replaceAll('-', '.');
+
+  if (!start || !end) return '';
+
+  if (startDate.slice(0, 4) === endDate.slice(0, 4)) {
+    return `${start}~${end.slice(5)}`;
+  }
+
+  return `${start}~${end}`;
+}

--- a/src/app/(pages)/experience/_utils/mapExperienceItemToUpdateRequest.ts
+++ b/src/app/(pages)/experience/_utils/mapExperienceItemToUpdateRequest.ts
@@ -66,11 +66,13 @@ function getTypeDetail(
 }
 
 function toNumber(value: string | undefined) {
-  if (value == null || value.trim() === '') {
+  const trimmedValue = value?.trim();
+
+  if (!trimmedValue) {
     return undefined;
   }
 
-  const numberValue = Number(value);
+  const numberValue = parseInt(trimmedValue, 10);
 
-  return Number.isFinite(numberValue) ? numberValue : undefined;
+  return Number.isInteger(numberValue) ? numberValue : undefined;
 }

--- a/src/app/(pages)/experience/_utils/mapExperienceItemToUpdateRequest.ts
+++ b/src/app/(pages)/experience/_utils/mapExperienceItemToUpdateRequest.ts
@@ -1,0 +1,76 @@
+import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+import type { ExperienceUpdateRequest } from '@/app/api/experience/types';
+
+export function mapExperienceItemToUpdateRequest(
+  experience: Pick<
+    ExperienceItem,
+    | 'type'
+    | 'title'
+    | 'description'
+    | 'basicDetail'
+    | 'detail'
+    | 'skillTags'
+    | 'competencyTags'
+    | 'startDate'
+    | 'endDate'
+  >,
+): ExperienceUpdateRequest {
+  return {
+    title: experience.title,
+    oneLineIntro: experience.description,
+    tags: [
+      ...experience.skillTags.map((tag) => ({ category: 'TECH' as const, field: tag })),
+      ...experience.competencyTags.map((tag) => ({
+        category: 'COMPETENCY' as const,
+        field: tag,
+      })),
+    ],
+    situation: experience.detail.situation,
+    task: experience.detail.task,
+    act: experience.detail.action,
+    result: experience.detail.result,
+    taken: experience.detail.taken,
+    detail: {
+      ...getTypeDetail(experience),
+      startDate: experience.startDate,
+      endDate: experience.endDate,
+    },
+  };
+}
+
+function getTypeDetail(
+  experience: Pick<ExperienceItem, 'type' | 'basicDetail'>,
+): Omit<ExperienceUpdateRequest['detail'], 'startDate' | 'endDate'> {
+  switch (experience.type) {
+    case 'activity':
+      return {
+        name: experience.basicDetail.name,
+        teamNum: toNumber(experience.basicDetail.teamNum),
+        role: experience.basicDetail.role,
+        contributionRate: toNumber(experience.basicDetail.contributionRate),
+      };
+    case 'career':
+      return {
+        name: experience.basicDetail.name,
+        company: experience.basicDetail.company,
+        employmentStatus: experience.basicDetail.employmentStatus,
+      };
+    case 'education':
+      return {
+        organizationName: experience.basicDetail.organizationName,
+        name: experience.basicDetail.name,
+      };
+    case 'etc':
+      return {};
+  }
+}
+
+function toNumber(value: string | undefined) {
+  if (value == null || value.trim() === '') {
+    return undefined;
+  }
+
+  const numberValue = Number(value);
+
+  return Number.isFinite(numberValue) ? numberValue : undefined;
+}

--- a/src/app/(pages)/experience/_utils/mapExperienceResponse.ts
+++ b/src/app/(pages)/experience/_utils/mapExperienceResponse.ts
@@ -27,12 +27,15 @@ const emptyDetail: ExperienceItem['detail'] = {
   taken: '',
 };
 
+const emptyBasicDetail: ExperienceItem['basicDetail'] = {};
+
 export function mapExperienceCardToItem(response: ExperienceCardResponse): ExperienceItem {
   const period = formatPeriod(response.startDate, response.endDate);
 
   return {
     ...mapCommonFields(response),
     detailInfo: [{ label: '기간', value: period }],
+    basicDetail: emptyBasicDetail,
     detail: emptyDetail,
   };
 }
@@ -49,6 +52,7 @@ export function mapExperienceDetailToItem(response: ExperienceDetailResponse): E
       tags: response.tags,
     }),
     detailInfo: getDetailInfo(response),
+    basicDetail: getBasicDetail(response),
     detail: {
       situation: response.situation,
       task: response.task,
@@ -57,6 +61,31 @@ export function mapExperienceDetailToItem(response: ExperienceDetailResponse): E
       taken: response.taken,
     },
   };
+}
+
+function getBasicDetail(response: ExperienceDetailResponse): ExperienceItem['basicDetail'] {
+  switch (response.type) {
+    case 'ACTIVITY':
+      return {
+        name: response.detail.name,
+        teamNum: String(response.detail.teamNum),
+        role: response.detail.role,
+        contributionRate: String(response.detail.contributionRate),
+      };
+    case 'CAREER':
+      return {
+        name: response.detail.name,
+        company: response.detail.company,
+        employmentStatus: response.detail.employmentStatus,
+      };
+    case 'EDUCATION':
+      return {
+        organizationName: response.detail.organizationName,
+        name: response.detail.name,
+      };
+    case 'ETC':
+      return {};
+  }
 }
 
 function mapCommonFields(response: CommonExperienceFields) {

--- a/src/app/(pages)/experience/_utils/mapExperienceResponse.ts
+++ b/src/app/(pages)/experience/_utils/mapExperienceResponse.ts
@@ -1,7 +1,7 @@
 import type {
   ExperienceCardResponse,
   ExperienceDetailResponse,
-  PieceType,
+  ExperiencePieceType,
   TagResponse,
 } from '@/app/api/experience/types';
 import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
@@ -12,7 +12,7 @@ type CommonExperienceFields = Pick<
   'experienceId' | 'type' | 'title' | 'oneLineIntro' | 'tags' | 'startDate' | 'endDate'
 >;
 
-const typeMap: Record<PieceType, UiExperienceType> = {
+const typeMap: Record<ExperiencePieceType, UiExperienceType> = {
   ACTIVITY: 'activity',
   CAREER: 'career',
   EDUCATION: 'education',

--- a/src/app/(pages)/experience/_utils/mapExperienceResponse.ts
+++ b/src/app/(pages)/experience/_utils/mapExperienceResponse.ts
@@ -65,6 +65,8 @@ function mapCommonFields(response: CommonExperienceFields) {
     type: typeMap[response.type],
     title: response.title,
     description: response.oneLineIntro,
+    startDate: response.startDate,
+    endDate: response.endDate,
     period: formatPeriod(response.startDate, response.endDate),
     skillTags: getTagsByCategory(response.tags, 'TECH'),
     competencyTags: getTagsByCategory(response.tags, 'COMPETENCY'),

--- a/src/app/(pages)/experience/_utils/mapExperienceResponse.ts
+++ b/src/app/(pages)/experience/_utils/mapExperienceResponse.ts
@@ -5,6 +5,7 @@ import type {
   TagResponse,
 } from '@/app/api/experience/types';
 import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+import { formatExperiencePeriod } from '@/app/(pages)/experience/_utils/formatExperiencePeriod';
 
 type UiExperienceType = ExperienceItem['type'];
 type CommonExperienceFields = Pick<
@@ -30,7 +31,7 @@ const emptyDetail: ExperienceItem['detail'] = {
 const emptyBasicDetail: ExperienceItem['basicDetail'] = {};
 
 export function mapExperienceCardToItem(response: ExperienceCardResponse): ExperienceItem {
-  const period = formatPeriod(response.startDate, response.endDate);
+  const period = formatExperiencePeriod(response.startDate, response.endDate);
 
   return {
     ...mapCommonFields(response),
@@ -96,14 +97,14 @@ function mapCommonFields(response: CommonExperienceFields) {
     description: response.oneLineIntro,
     startDate: response.startDate,
     endDate: response.endDate,
-    period: formatPeriod(response.startDate, response.endDate),
+    period: formatExperiencePeriod(response.startDate, response.endDate),
     skillTags: getTagsByCategory(response.tags, 'TECH'),
     competencyTags: getTagsByCategory(response.tags, 'COMPETENCY'),
   };
 }
 
 function getDetailInfo(response: ExperienceDetailResponse): ExperienceItem['detailInfo'] {
-  const period = formatPeriod(response.detail.startDate, response.detail.endDate);
+  const period = formatExperiencePeriod(response.detail.startDate, response.detail.endDate);
 
   switch (response.type) {
     case 'ACTIVITY':
@@ -132,19 +133,4 @@ function getDetailInfo(response: ExperienceDetailResponse): ExperienceItem['deta
 
 function getTagsByCategory(tags: TagResponse[], category: TagResponse['category']) {
   return tags.filter((tag) => tag.category === category).map((tag) => tag.field);
-}
-
-function formatPeriod(startDate: string, endDate: string) {
-  const start = formatDate(startDate);
-  const end = formatDate(endDate);
-
-  if (startDate.slice(0, 4) === endDate.slice(0, 4)) {
-    return `${start}~${end.slice(5)}`;
-  }
-
-  return `${start}~${end}`;
-}
-
-function formatDate(date: string) {
-  return date.replaceAll('-', '.');
 }

--- a/src/app/(pages)/experience/_utils/mapExperienceResponse.ts
+++ b/src/app/(pages)/experience/_utils/mapExperienceResponse.ts
@@ -81,10 +81,8 @@ function getDetailInfo(response: ExperienceDetailResponse): ExperienceItem['deta
       return [
         { label: '기간', value: period },
         { label: '팀원 수', value: `${response.detail.teamNum}명` },
-        {
-          label: '내 역할 및 기여도',
-          value: `${response.detail.role}, ${response.detail.contributionRate}%`,
-        },
+        { label: '내 역할', value: response.detail.role },
+        { label: '기여도', value: `${response.detail.contributionRate}%` },
       ];
     case 'CAREER':
       return [

--- a/src/app/(pages)/experience/page.tsx
+++ b/src/app/(pages)/experience/page.tsx
@@ -1,17 +1,5 @@
-import { Suspense } from 'react';
-
-import { ExperienceBoard } from '@/app/(pages)/experience/_components/ExperienceBoard';
-import { ExperiencePageHeader } from '@/app/(pages)/experience/_components/ExperiencePageHeader';
+import { ExperiencePageContent } from '@/app/(pages)/experience/_components/ExperiencePageContent';
 
 export default function ExperiencePage() {
-  return (
-    <div className="mx-16 flex min-h-[calc(100vh-32px)] flex-col">
-      <div className="flex flex-1 flex-col gap-5">
-        <ExperiencePageHeader />
-        <Suspense>
-          <ExperienceBoard />
-        </Suspense>
-      </div>
-    </div>
-  );
+  return <ExperiencePageContent />;
 }

--- a/src/app/api/experience/index.ts
+++ b/src/app/api/experience/index.ts
@@ -3,14 +3,14 @@ import { api } from '@/app/api/client';
 import type {
   ExperienceDetailResponse,
   ExperienceListResponse,
+  ExperiencePieceType,
   ExperienceOrderUpdateRequest,
   ExperienceTitleUpdateRequest,
   ExperienceUpdateRequest,
-  PieceType,
 } from './types';
 
 export type GetExperiencesParams = {
-  type?: PieceType;
+  type?: ExperiencePieceType;
   cursor?: number | null;
   size?: number;
 };

--- a/src/app/api/experience/index.ts
+++ b/src/app/api/experience/index.ts
@@ -1,6 +1,13 @@
 import { api } from '@/app/api/client';
 
-import type { ExperienceDetailResponse, ExperienceListResponse, PieceType } from './types';
+import type {
+  ExperienceDetailResponse,
+  ExperienceListResponse,
+  ExperienceOrderUpdateRequest,
+  ExperienceTitleUpdateRequest,
+  ExperienceUpdateRequest,
+  PieceType,
+} from './types';
 
 export type GetExperiencesParams = {
   type?: PieceType;
@@ -16,4 +23,23 @@ export function getExperiences(params?: GetExperiencesParams) {
 
 export function getExperienceDetail(experienceId: number) {
   return api.get<ExperienceDetailResponse>(`/api/v1/experiences/${experienceId}`);
+}
+
+export function updateExperience(experienceId: number, request: ExperienceUpdateRequest) {
+  return api.patch<null>(`/api/v1/experiences/${experienceId}`, request);
+}
+
+export function updateExperienceTitle(
+  experienceId: number,
+  request: ExperienceTitleUpdateRequest,
+) {
+  return api.patch<null>(`/api/v1/experiences/${experienceId}/title`, request);
+}
+
+export function deleteExperience(experienceId: number) {
+  return api.delete<null>(`/api/v1/experiences/${experienceId}`);
+}
+
+export function updateExperienceOrder(request: ExperienceOrderUpdateRequest) {
+  return api.patch<null>('/api/v1/experiences/order', request);
 }

--- a/src/app/api/experience/index.ts
+++ b/src/app/api/experience/index.ts
@@ -11,6 +11,7 @@ import type {
 
 export type GetExperiencesParams = {
   type?: ExperiencePieceType;
+  keyword?: string;
   cursor?: number | null;
   size?: number;
 };

--- a/src/app/api/experience/types.ts
+++ b/src/app/api/experience/types.ts
@@ -4,6 +4,11 @@ export type TagCategory = 'TECH' | 'COMPETENCY';
 
 type ISODateString = string;
 
+export interface TagRequest {
+  category: TagCategory;
+  field: string;
+}
+
 export interface TagResponse {
   category: TagCategory;
   field: string;
@@ -85,3 +90,36 @@ export type ExperienceDetailResponse =
       type: 'ETC';
       detail: EtcDetail;
     });
+
+export interface ExperienceUpdateDetailRequest {
+  name?: string;
+  teamNum?: number;
+  role?: string;
+  contributionRate?: number;
+  company?: string;
+  employmentStatus?: string;
+  organizationName?: string;
+  startDate: ISODateString;
+  endDate: ISODateString;
+}
+
+export interface ExperienceUpdateRequest {
+  title: string;
+  oneLineIntro: string;
+  tags: TagRequest[];
+  situation?: string;
+  task?: string;
+  act?: string;
+  result?: string;
+  taken?: string;
+  detail: ExperienceUpdateDetailRequest;
+}
+
+export interface ExperienceTitleUpdateRequest {
+  title: string;
+}
+
+export interface ExperienceOrderUpdateRequest {
+  type: PieceType;
+  experienceIds: number[];
+}

--- a/src/app/api/experience/types.ts
+++ b/src/app/api/experience/types.ts
@@ -1,4 +1,5 @@
-export type PieceType = 'ACTIVITY' | 'CAREER' | 'EDUCATION' | 'ETC';
+export type PieceType = 'ALL' | 'ACTIVITY' | 'CAREER' | 'EDUCATION' | 'ETC';
+export type ExperiencePieceType = Exclude<PieceType, 'ALL'>;
 
 export type TagCategory = 'TECH' | 'COMPETENCY';
 
@@ -17,7 +18,7 @@ export interface TagResponse {
 export interface ExperienceCardResponse {
   pieceId: number;
   experienceId: number;
-  type: PieceType;
+  type: ExperiencePieceType;
   title: string;
   oneLineIntro: string;
   startDate: ISODateString;

--- a/src/components/common/SingleMonthRangeCalendar.tsx
+++ b/src/components/common/SingleMonthRangeCalendar.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import * as React from 'react';
+
+import { ChevronLeftIcon } from '@/components/common/icons/ChevronLeftIcon';
+import { ChevronRightIcon } from '@/components/common/icons/ChevronRightIcon';
+import { MonthPanel } from '@/components/common/MonthPanel';
+import { cn } from '@/lib/utils';
+
+export type SingleMonthCalendarDateRange = { start: Date; end: Date };
+
+function startOfLocalDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+function dayTime(d: Date): number {
+  return startOfLocalDay(d).getTime();
+}
+
+function compareLocalDay(a: Date, b: Date): number {
+  return dayTime(a) - dayTime(b);
+}
+
+function addMonths(year: number, monthIndex: number, delta: number): { year: number; month: number } {
+  const d = new Date(year, monthIndex + delta, 1);
+  return { year: d.getFullYear(), month: d.getMonth() };
+}
+
+function formatMonthTitle(year: number, month: number): string {
+  return `${year}년 ${month + 1}월`;
+}
+
+export interface SingleMonthRangeCalendarProps
+  extends Omit<React.ComponentProps<'div'>, 'onChange' | 'defaultValue'> {
+  defaultVisibleMonth?: Date;
+  defaultRange?: SingleMonthCalendarDateRange | null;
+  value?: SingleMonthCalendarDateRange | null;
+  onChange?: (range: SingleMonthCalendarDateRange | null) => void;
+  minDate?: Date;
+  maxDate?: Date;
+}
+
+export function SingleMonthRangeCalendar({
+  className,
+  defaultVisibleMonth,
+  defaultRange = null,
+  value: valueProp,
+  onChange,
+  minDate,
+  maxDate,
+  ...props
+}: SingleMonthRangeCalendarProps) {
+  const initialAnchor = React.useMemo(() => {
+    const base = defaultVisibleMonth ?? new Date();
+    return { year: base.getFullYear(), month: base.getMonth() };
+  }, [defaultVisibleMonth]);
+
+  const [anchor, setAnchor] = React.useState(initialAnchor);
+  const isControlled = valueProp !== undefined;
+
+  const [draftStart, setDraftStart] = React.useState<Date | null>(() => {
+    if (valueProp) return startOfLocalDay(valueProp.start);
+    if (defaultRange) return startOfLocalDay(defaultRange.start);
+    return null;
+  });
+  const [draftEnd, setDraftEnd] = React.useState<Date | null>(() => {
+    if (valueProp) return startOfLocalDay(valueProp.end);
+    if (defaultRange) return startOfLocalDay(defaultRange.end);
+    return null;
+  });
+
+  const valueSyncKey =
+    valueProp == null ? 'empty' : `${dayTime(valueProp.start)}-${dayTime(valueProp.end)}`;
+  const prevCommittedKey = React.useRef<string | null>(null);
+
+  React.useEffect(() => {
+    if (!isControlled) return;
+    if (valueProp) {
+      setDraftStart(startOfLocalDay(valueProp.start));
+      setDraftEnd(startOfLocalDay(valueProp.end));
+      prevCommittedKey.current = valueSyncKey;
+      return;
+    }
+    if (prevCommittedKey.current != null && prevCommittedKey.current !== 'empty') {
+      setDraftStart(null);
+      setDraftEnd(null);
+    }
+    prevCommittedKey.current = 'empty';
+  }, [isControlled, valueSyncKey, valueProp]);
+
+  const bumpAnchor = (delta: number) => {
+    setAnchor((currentAnchor) => addMonths(currentAnchor.year, currentAnchor.month, delta));
+  };
+
+  const handleDayClick = (cell: Date) => {
+    const inMonth = cell.getMonth() === anchor.month && cell.getFullYear() === anchor.year;
+    if (!inMonth) return;
+
+    const t = dayTime(cell);
+    if (minDate && t < dayTime(minDate)) return;
+    if (maxDate && t > dayTime(maxDate)) return;
+
+    const day = startOfLocalDay(cell);
+
+    if (!draftStart || (draftStart && draftEnd)) {
+      setDraftStart(day);
+      setDraftEnd(null);
+      onChange?.(null);
+      return;
+    }
+
+    let start = draftStart;
+    let end = day;
+    if (compareLocalDay(end, start) < 0) [start, end] = [end, start];
+    setDraftStart(start);
+    setDraftEnd(end);
+    onChange?.({ start, end });
+  };
+
+  return (
+    <div
+      data-slot="single-month-range-calendar"
+      className={cn(
+        'inline-flex w-96 flex-col gap-2.5 rounded-2xl bg-background-w p-6 shadow-lg',
+        className,
+      )}
+      {...props}
+    >
+      <div className="flex w-full items-center">
+        <button
+          type="button"
+          aria-label="이전 달"
+          className="flex size-8 shrink-0 items-center justify-center rounded-sm text-gray-main outline-none hover:bg-gray-100 focus-visible:shadow-focus-ring"
+          onClick={() => bumpAnchor(-1)}
+        >
+          <ChevronLeftIcon className="size-6" />
+        </button>
+        <span className="flex-1 text-center text-base font-semibold leading-7 text-strong">
+          {formatMonthTitle(anchor.year, anchor.month)}
+        </span>
+        <button
+          type="button"
+          aria-label="다음 달"
+          className="flex size-8 shrink-0 items-center justify-center rounded-sm text-gray-main outline-none hover:bg-gray-100 focus-visible:shadow-focus-ring"
+          onClick={() => bumpAnchor(1)}
+        >
+          <ChevronRightIcon className="size-6" />
+        </button>
+      </div>
+      <div className="flex w-full justify-center">
+        <MonthPanel
+          year={anchor.year}
+          month={anchor.month}
+          selectionStart={draftStart}
+          selectionEnd={draftEnd}
+          onDayClick={handleDayClick}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/experience/useDebouncedValue.ts
+++ b/src/hooks/experience/useDebouncedValue.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import * as React from 'react';
+
+export function useDebouncedValue<T>(value: T, delay: number) {
+  const [debouncedValue, setDebouncedValue] = React.useState(value);
+
+  React.useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [delay, value]);
+
+  return debouncedValue;
+}

--- a/src/hooks/experience/useExperiences.ts
+++ b/src/hooks/experience/useExperiences.ts
@@ -1,12 +1,27 @@
 'use client';
 
-import { skipToken, useInfiniteQuery, useQuery } from '@tanstack/react-query';
+import {
+  skipToken,
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import {
+  deleteExperience,
   getExperienceDetail,
   getExperiences,
+  updateExperience,
+  updateExperienceOrder,
+  updateExperienceTitle,
   type GetExperiencesParams,
 } from '@/app/api/experience';
+import type {
+  ExperienceOrderUpdateRequest,
+  ExperienceTitleUpdateRequest,
+  ExperienceUpdateRequest,
+} from '@/app/api/experience/types';
 
 export const experienceQueryKeys = {
   all: ['experiences'] as const,
@@ -45,5 +60,64 @@ export function useExperienceDetail(experienceId: number | null | undefined) {
   return useQuery({
     queryKey: experienceQueryKeys.detail(experienceId),
     queryFn: experienceId != null ? () => getExperienceDetail(experienceId) : skipToken,
+  });
+}
+
+export function useUpdateExperience() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      experienceId,
+      request,
+    }: {
+      experienceId: number;
+      request: ExperienceUpdateRequest;
+    }) => updateExperience(experienceId, request),
+    onSuccess: (_, { experienceId }) => {
+      void queryClient.invalidateQueries({ queryKey: experienceQueryKeys.lists() });
+      void queryClient.invalidateQueries({ queryKey: experienceQueryKeys.detail(experienceId) });
+    },
+  });
+}
+
+export function useUpdateExperienceTitle() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      experienceId,
+      request,
+    }: {
+      experienceId: number;
+      request: ExperienceTitleUpdateRequest;
+    }) => updateExperienceTitle(experienceId, request),
+    onSuccess: (_, { experienceId }) => {
+      void queryClient.invalidateQueries({ queryKey: experienceQueryKeys.lists() });
+      void queryClient.invalidateQueries({ queryKey: experienceQueryKeys.detail(experienceId) });
+    },
+  });
+}
+
+export function useDeleteExperience() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteExperience,
+    onSuccess: (_, experienceId) => {
+      void queryClient.invalidateQueries({ queryKey: experienceQueryKeys.lists() });
+      void queryClient.invalidateQueries({ queryKey: experienceQueryKeys.detail(experienceId) });
+    },
+  });
+}
+
+export function useUpdateExperienceOrder() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: ExperienceOrderUpdateRequest) => updateExperienceOrder(request),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: experienceQueryKeys.lists() });
+    },
   });
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#38 

## 📝작업 내용

백엔드에서 추가 구현된 경험 관리 API를 연동했습니다.

- 경험 카드 제목 수정 API를 연동했습니다.
  - 카드 드롭다운의 `제목 수정하기` 클릭 시 카드 내에서 바로 제목을 수정할 수 있도록 처리했습니다.

- 상세 경험 수정 API를 연동했습니다.
  - 상세 패널에서 제목, 한 줄 소개, 기간, 기본 정보, 핵심 경험, 결과 정보를 인라인으로 수정할 수 있도록 했습니다

- 경험 삭제 API를 연동했습니다.
  - 카드 드롭다운에서 삭제 요청을 보낼 수 있도록 훅/API 레이어를 추가했습니다.
  - 삭제 모달 UI는 추후 작업 예정입니다.

- 경험 순서 변경 API를 연동했습니다.
  - 카드 드래그 앤 드롭 후 변경된 순서를 서버에 저장하도록 처리했습니다.
  - 순서 저장 실패 시 기존 순서로 복구되도록 처리했습니다.

- 경험 목록 검색 API를 연동했습니다.
  - 검색어를 목록 조회 API의 `keyword` 파라미터로 전달하도록 추가했습니다.
  - 검색 입력은 0.5초 디바운스를 적용해 불필요한 요청을 줄였습니다.
  - 검색어 변경 시 기존 선택된 상세 패널 상태를 초기화하도록 처리했습니다.

### 스크린샷 (선택)

https://github.com/user-attachments/assets/bd4fbc87-cc8e-45f0-ba10-8386fa8e2937

https://github.com/user-attachments/assets/2d3e6179-a3db-4d6b-a2df-0b5e0da28c88

https://github.com/user-attachments/assets/4cf88d13-a887-406a-a8cf-2c26c08eaaa6

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fully editable experience details (title, description, dates, skills, competencies, type-specific fields) with save from the detail panel
  * Keyword search with debounced input and URL sync
  * Inline edit of experience titles directly on cards
  * Delete experiences from the UI
  * Reorder experiences with optimistic updates and server sync
  * Single-month calendar date-range picker for setting duration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-KKIUM/KKIUM-FE/pull/45?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->