### PR TITLE
[fix] 지원 관리 UI 수정 

### DIFF
--- a/src/app/(pages)/apply/_constants/applyMockData.ts
+++ b/src/app/(pages)/apply/_constants/applyMockData.ts
@@ -245,11 +245,12 @@ export const coverLetterWritingGuideMock = {
 
 // --- 지원 목록 ---
 
-export type ApplyListCoverLetter = {
-  motivation: string;
-  experience: string;
-  aspiration: string;
+export type ApplyListCoverLetterQuestion = {
+  label: string;
+  answer: string;
 };
+
+export type ApplyListCoverLetter = ApplyListCoverLetterQuestion[];
 
 export type ApplyListItem = {
   id: string;
@@ -260,14 +261,23 @@ export type ApplyListItem = {
   coverLetter: ApplyListCoverLetter;
 };
 
-const sampleListCoverLetter: ApplyListCoverLetter = {
-  motivation:
-    '대규모 서비스 운영 경험을 통해 안정성과 확장성의 중요성을 깊이 이해하게 되었습니다. 네이버의 기술적 도전과 글로벌 서비스 운영 노하우를 배우고 싶어 지원하게 되었습니다.',
-  experience:
-    '블랙프라이데이 기간 동안 동시 접속자 10만명을 안정적으로 처리하기 위해 Redis 캐싱 레이어를 구축하고 MySQL 쿼리를 최적화했습니다. 그 결과 TPS를 500에서 2000으로 4배 향상시켰고, 검색 응답 속도를 50% 개선했습니다.',
-  aspiration:
-    '네이버에 입사하게 된다면 글로벌 서비스의 대규모 트래픽 처리 경험을 쌓으며, 더 나은 사용자 경험을 제공하는 백엔드 시스템을 설계하고 싶습니다. 특히 AI 기술과 결합된 차세대 검색 엔진 개발에 기여하고 싶습니다.',
-};
+const sampleListCoverLetter: ApplyListCoverLetter = [
+  {
+    label: '지원동기',
+    answer:
+      '대규모 서비스 운영 경험을 통해 안정성과 확장성의 중요성을 깊이 이해하게 되었습니다. 네이버의 기술적 도전과 글로벌 서비스 운영 노하우를 배우고 싶어 지원하게 되었습니다.',
+  },
+  {
+    label: '핵심 경험',
+    answer:
+      '블랙프라이데이 기간 동안 동시 접속자 10만명을 안정적으로 처리하기 위해 Redis 캐싱 레이어를 구축하고 MySQL 쿼리를 최적화했습니다. 그 결과 TPS를 500에서 2000으로 4배 향상시켰고, 검색 응답 속도를 50% 개선했습니다.',
+  },
+  {
+    label: '입사 후 포부',
+    answer:
+      '네이버에 입사하게 된다면 글로벌 서비스의 대규모 트래픽 처리 경험을 쌓으며, 더 나은 사용자 경험을 제공하는 백엔드 시스템을 설계하고 싶습니다. 특히 AI 기술과 결합된 차세대 검색 엔진 개발에 기여하고 싶습니다.',
+  },
+];
 
 export const applyListMockData: ApplyListItem[] = [
   {

--- a/src/app/(pages)/apply/list/_components/ApplyAddJobPostingEditStep.tsx
+++ b/src/app/(pages)/apply/list/_components/ApplyAddJobPostingEditStep.tsx
@@ -190,7 +190,7 @@ export function ApplyAddJobPostingEditStep({
             onClick={onAddCoverQuestion}
           >
             <span className="flex size-8 shrink-0 items-center justify-center">
-              <PlusIcon className="size-6 text-tertiary" />
+              <PlusIcon className="size-5 text-tertiary" />
             </span>
             추가하기
           </button>
@@ -198,7 +198,7 @@ export function ApplyAddJobPostingEditStep({
       </div>
 
       <ModalClose asChild>
-        <Button type="button" variant="default" size="default" className="w-full text-xs font-bold leading-5">
+        <Button type="button" variant="default" size="default" className="w-full text-base font-bold leading-6">
           저장하기
         </Button>
       </ModalClose>

--- a/src/app/(pages)/apply/list/_components/ApplyAddJobPostingUrlStep.tsx
+++ b/src/app/(pages)/apply/list/_components/ApplyAddJobPostingUrlStep.tsx
@@ -1,5 +1,8 @@
 'use client';
 
+import Image from 'next/image';
+import * as React from 'react';
+
 import { ModalDescription, ModalTitle } from '@/components/common/Modal';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -31,6 +34,53 @@ export function ApplyAddJobPostingUrlStep({
   onAnalyze,
   canAnalyze,
 }: ApplyAddJobPostingUrlStepProps) {
+  const [isDragOver, setIsDragOver] = React.useState(false);
+  const [selectedImagePreviewUrl, setSelectedImagePreviewUrl] = React.useState<string | null>(null);
+  const [fileError, setFileError] = React.useState<string | null>(null);
+  const imageInputRef = React.useRef<HTMLInputElement>(null);
+  const hasSelectedImage = selectedImagePreviewUrl != null;
+  const shouldShowUrlError = showError && !validation.ok && !hasSelectedImage;
+  const canSubmitAnalyze = canAnalyze || hasSelectedImage;
+
+  React.useEffect(() => {
+    return () => {
+      if (selectedImagePreviewUrl) {
+        URL.revokeObjectURL(selectedImagePreviewUrl);
+      }
+    };
+  }, [selectedImagePreviewUrl]);
+
+  const isSupportedImageFile = React.useCallback((file: File) => {
+    const lowerName = file.name.toLowerCase();
+    const hasSupportedExtension =
+      lowerName.endsWith('.jpg') || lowerName.endsWith('.jpeg') || lowerName.endsWith('.png');
+    const hasSupportedMimeType = file.type === '' || file.type === 'image/jpeg' || file.type === 'image/png';
+
+    return hasSupportedExtension && hasSupportedMimeType;
+  }, []);
+
+  const handleImageFileSelect = React.useCallback(
+    (file: File | null) => {
+      if (!file) return;
+
+      if (!isSupportedImageFile(file)) {
+        setSelectedImagePreviewUrl((prev) => {
+          if (prev) URL.revokeObjectURL(prev);
+          return null;
+        });
+        setFileError('jpg, jpeg, png 형식만 업로드할 수 있어요.');
+        return;
+      }
+
+      setSelectedImagePreviewUrl((prev) => {
+        if (prev) URL.revokeObjectURL(prev);
+        return URL.createObjectURL(file);
+      });
+      setFileError(null);
+    },
+    [isSupportedImageFile],
+  );
+
   return (
     <>
       <div className="flex w-full min-w-0 items-start justify-between pr-10">
@@ -54,13 +104,13 @@ export function ApplyAddJobPostingUrlStep({
               autoComplete="url"
               value={url}
               maxLength={maxLength}
-              aria-invalid={showError}
-              aria-describedby={showError ? errorId : undefined}
+              aria-invalid={shouldShowUrlError}
+              aria-describedby={shouldShowUrlError ? errorId : undefined}
               onChange={(e) => setUrl(e.target.value)}
               onBlur={markTouched}
               placeholder="링크를 입력해주세요"
             />
-            {showError && !validation.ok ? (
+            {shouldShowUrlError ? (
               <p id={errorId} className="body-3-regular text-red-700" role="alert">
                 {validation.error}
               </p>
@@ -78,14 +128,102 @@ export function ApplyAddJobPostingUrlStep({
             공고 직접 등록하기
           </button>
         </div>
+
+        <div className="flex w-full flex-col items-start gap-4">
+          <h3 className="title-2-bold text-strong">공고 이미지 추가</h3>
+          <input
+            ref={imageInputRef}
+            type="file"
+            accept=".jpg,.jpeg,.png,image/jpeg,image/png"
+            className="hidden"
+            onChange={(event) => {
+              handleImageFileSelect(event.currentTarget.files?.[0] ?? null);
+              event.currentTarget.value = '';
+            }}
+          />
+          <div
+            className={`relative flex h-72 w-full flex-col items-center justify-start overflow-hidden rounded-lg border border-dashed ${
+              isDragOver ? 'border-gray-700 bg-gray-50' : 'border-gray-500 bg-gray-100'
+            }`}
+            onDragEnter={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              setIsDragOver(true);
+            }}
+            onDragOver={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              setIsDragOver(true);
+            }}
+            onDragLeave={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              setIsDragOver(false);
+            }}
+            onDrop={(event) => {
+              event.preventDefault();
+              event.stopPropagation();
+              setIsDragOver(false);
+              handleImageFileSelect(event.dataTransfer.files?.[0] ?? null);
+            }}
+          >
+            {selectedImagePreviewUrl ? (
+              <>
+                <Image
+                  src={selectedImagePreviewUrl}
+                  alt="업로드한 공고 이미지 미리보기"
+                  fill
+                  unoptimized
+                  className="object-cover"
+                />
+                <div className="absolute inset-x-0 bottom-0 flex items-center justify-end bg-black/45 px-4 py-3">
+                  <button
+                    type="button"
+                    className="inline-flex h-10 items-center justify-center overflow-hidden rounded-lg bg-background-w px-3 text-base font-bold leading-6 text-strong hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-background-w"
+                    onClick={() => imageInputRef.current?.click()}
+                  >
+                    이미지 변경
+                  </button>
+                </div>
+              </>
+            ) : (
+              <div className="flex w-full flex-col items-center justify-start gap-3 px-5 pt-0 text-center">
+                <Image
+                  src="/null.svg"
+                  alt=""
+                  width={132}
+                  height={100}
+                  className="h-24 w-32 object-contain"
+                />
+                <div className="flex flex-col items-center gap-1">
+                  <p className="body-1-bold text-strong">공고 이미지 파일 업로드</p>
+                  <p className="body-1-regular text-gray-700">
+                    파일을 선택하거나 드래그 앤 드롭으로 파일을 추가해주세요
+                  </p>
+                </div>
+                <button
+                  type="button"
+                  className="inline-flex h-9 items-center justify-center overflow-hidden rounded-lg bg-gray-main px-2.5 py-0.5 text-xs font-bold leading-5 text-white hover:bg-gray-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-default"
+                  onClick={() => imageInputRef.current?.click()}
+                >
+                  공고 이미지 업로드
+                </button>
+              </div>
+            )}
+            {!selectedImagePreviewUrl ? (
+              <p className="mt-2 body-1-regular text-gray-700">jpg, jpeg, png 형식만 지원해요</p>
+            ) : null}
+          </div>
+          {fileError ? <p className="body-2-regular text-red-700">{fileError}</p> : null}
+        </div>
       </div>
 
       <Button
         type="button"
         variant="default"
         size="default"
-        disabled={!canAnalyze}
-        className="w-full text-xs font-bold leading-5"
+        disabled={!canSubmitAnalyze}
+        className="w-full text-base font-bold leading-5"
         onClick={onAnalyze}
       >
         공고 분석하기

--- a/src/app/(pages)/apply/list/_components/ApplyCard.tsx
+++ b/src/app/(pages)/apply/list/_components/ApplyCard.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import * as React from 'react';
 
+import { ApplyCardMenuDropdown } from '@/app/(pages)/apply/list/_components/ApplyCardMenuDropdown';
 import { CalendarIcon } from '@/components/common/icons/CalendarIcon';
 import { MoreVerticalIcon } from '@/components/common/icons/MoreVerticalIcon';
 import { PencilIcon } from '@/components/common/icons/PencilIcon';
@@ -14,7 +15,6 @@ export interface ApplyCardProps extends React.ComponentProps<'article'> {
   companyName: string;
   jobField: string;
   period: string;
-  actionLabel?: string;
   selected?: boolean;
   onCardClick?: React.MouseEventHandler<HTMLElement>;
 }
@@ -24,7 +24,6 @@ export function ApplyCard({
   companyName,
   jobField,
   period,
-  actionLabel = '지원서 작성하기',
   selected = false,
   onCardClick,
   onClick,
@@ -33,6 +32,23 @@ export function ApplyCard({
   ...props
 }: ApplyCardProps) {
   const isInteractive = Boolean(onCardClick);
+  const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+  const menuContainerRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    if (!isMenuOpen) {
+      return;
+    }
+
+    const handleOutsideClick = (event: MouseEvent) => {
+      if (!menuContainerRef.current?.contains(event.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleOutsideClick);
+    return () => document.removeEventListener('mousedown', handleOutsideClick);
+  }, [isMenuOpen]);
 
   const handleClick: React.MouseEventHandler<HTMLElement> = (event) => {
     onClick?.(event);
@@ -65,7 +81,7 @@ export function ApplyCard({
       className={cn(
         'flex h-60 w-full max-w-[494px] flex-col justify-between gap-7 overflow-hidden rounded-xl border border-border-default bg-background-w px-5 py-7',
         selected &&
-          'shadow-[0px_0px_0px_3px_rgba(114,224,206,1.00)] outline-1 outline-offset-[-1px] outline-border-default',
+          'shadow-[0px_0px_0px_3px_rgba(114,224,206,1.00)] outline-1 -outline-offset-1 outline-border-default',
         isInteractive &&
           'cursor-pointer hover:shadow-md focus-visible:shadow-focus-ring focus-visible:outline-none',
         className,
@@ -109,23 +125,32 @@ export function ApplyCard({
             </div>
           </div>
 
-          <button
-            type="button"
-            aria-label="카드 메뉴"
-            className="flex size-8 shrink-0 items-center justify-center rounded bg-background-w text-gray-main"
-          >
-            <MoreVerticalIcon className="size-6" />
-          </button>
+          <div ref={menuContainerRef} className="relative shrink-0">
+            <button
+              type="button"
+              aria-label="카드 메뉴"
+              aria-expanded={isMenuOpen}
+              className="flex size-8 cursor-pointer items-center justify-center rounded bg-background-w text-gray-main hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-default"
+              onClick={(event) => {
+                event.stopPropagation();
+                setIsMenuOpen((prev) => !prev);
+              }}
+            >
+              <MoreVerticalIcon className="size-6" />
+            </button>
+
+            {isMenuOpen && <ApplyCardMenuDropdown />}
+          </div>
         </div>
       </div>
 
       <Link
         href="/apply"
-        className="inline-flex h-10 w-full items-center justify-center gap-1 rounded-lg bg-mint-50 px-3 py-1 text-mint-600"
+        className="inline-flex h-10 w-full items-center justify-center gap-1 overflow-hidden rounded-lg bg-background-w px-3 py-1 text-gray-600 outline -outline-offset-1 outline-border-default"
         onClick={(event) => event.stopPropagation()}
       >
-        <PencilIcon className="size-6" />
-        <span className="body-1-bold">{actionLabel}</span>
+        <PencilIcon className="size-6 text-gray-600" />
+        <span className="body-1-bold text-gray-600">자기소개서 작성하기</span>
       </Link>
     </article>
   );

--- a/src/app/(pages)/apply/list/_components/ApplyCardMenuDropdown.tsx
+++ b/src/app/(pages)/apply/list/_components/ApplyCardMenuDropdown.tsx
@@ -1,0 +1,36 @@
+import { NomalStarIcon } from '@/components/common/icons/NomalStarIcon';
+import { PencilIcon } from '@/components/common/icons/PencilIcon';
+import { TrashIcon } from '@/components/common/icons/TrashIcon';
+
+export function ApplyCardMenuDropdown() {
+  return (
+    <div
+      className="absolute right-0 top-9 z-20 inline-flex w-48 flex-col overflow-hidden rounded-lg border border-border-default bg-background-w shadow-lg"
+      onClick={(event) => event.stopPropagation()}
+    >
+      <button
+        type="button"
+        className="inline-flex h-10 w-full cursor-pointer items-center justify-between border-b border-gray-300 px-3 py-1 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-border-default"
+      >
+        <span className="body-1-bold text-gray-600">제목 수정하기</span>
+        <PencilIcon className="size-6 text-gray-600" />
+      </button>
+
+      <button
+        type="button"
+        className="inline-flex h-10 w-full cursor-pointer items-center justify-between border-b border-gray-300 px-3 py-1 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-border-default"
+      >
+        <span className="body-1-bold text-gray-600">목표 공고 등록하기</span>
+        <NomalStarIcon className="size-6 text-gray-600" />
+      </button>
+
+      <button
+        type="button"
+        className="inline-flex h-10 w-full cursor-pointer items-center justify-between px-3 py-1 hover:bg-gray-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-border-default"
+      >
+        <span className="body-1-bold text-red-300">삭제</span>
+        <TrashIcon className="size-6 text-red-300" />
+      </button>
+    </div>
+  );
+}

--- a/src/app/(pages)/apply/list/_components/ApplyDetailSidebar.tsx
+++ b/src/app/(pages)/apply/list/_components/ApplyDetailSidebar.tsx
@@ -4,7 +4,10 @@ import Image from 'next/image';
 import * as React from 'react';
 
 import { CalendarIcon } from '@/components/common/icons/CalendarIcon';
+import { CopyIcon } from '@/components/common/icons/CopyIcon';
+import { ExpandIcon } from '@/components/common/icons/ExpandIcon';
 import { XIcon } from '@/components/common/icons/XIcon';
+import { ToastMessage } from '@/components/ui/ToastMessage';
 import { cn } from '@/lib/utils';
 
 import type { ApplyListItem } from '@/app/(pages)/apply/_constants/applyMockData';
@@ -16,24 +19,29 @@ export interface ApplyDetailSidebarProps {
 }
 
 export function ApplyDetailSidebar({ open, item, onClose }: ApplyDetailSidebarProps) {
-  const [entered, setEntered] = React.useState(false);
+  const [panelVisible, setPanelVisible] = React.useState(false);
+  const [expanded, setExpanded] = React.useState(false);
+  const [isEditing, setIsEditing] = React.useState(false);
+  const [toastOpen, setToastOpen] = React.useState(false);
+  const toastTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [editableQuestions, setEditableQuestions] = React.useState(item?.coverLetter ?? []);
 
   React.useEffect(() => {
-    if (!item) {
-      setEntered(false);
-      return;
-    }
-
     if (open) {
-      setEntered(false);
-      const id = requestAnimationFrame(() => {
-        requestAnimationFrame(() => setEntered(true));
+      setPanelVisible(false);
+      let secondFrame = 0;
+      const firstFrame = window.requestAnimationFrame(() => {
+        secondFrame = window.requestAnimationFrame(() => setPanelVisible(true));
       });
-      return () => cancelAnimationFrame(id);
+
+      return () => {
+        window.cancelAnimationFrame(firstFrame);
+        window.cancelAnimationFrame(secondFrame);
+      };
     }
 
-    setEntered(false);
-  }, [open, item]);
+    setPanelVisible(false);
+  }, [open]);
 
   React.useEffect(() => {
     if (!open) {
@@ -50,11 +58,55 @@ export function ApplyDetailSidebar({ open, item, onClose }: ApplyDetailSidebarPr
     return () => document.removeEventListener('keydown', onKeyDown);
   }, [open, onClose]);
 
+  React.useEffect(() => {
+    if (!item) {
+      setExpanded(false);
+      setIsEditing(false);
+    }
+  }, [item]);
+
+  React.useEffect(() => {
+    setEditableQuestions(item?.coverLetter ?? []);
+  }, [item]);
+
+  React.useEffect(() => {
+    return () => {
+      if (toastTimerRef.current) {
+        clearTimeout(toastTimerRef.current);
+      }
+    };
+  }, []);
+
   if (!item) {
     return null;
   }
 
-  const panelOpen = open && entered;
+  const coverLetterQuestions = editableQuestions.map((question, index) => ({
+    index: index + 1,
+    label: question.label,
+    answer: question.answer,
+  }));
+
+  const handleCopy = async (answer: string) => {
+    if (!answer) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(answer);
+      setToastOpen(true);
+
+      if (toastTimerRef.current) {
+        clearTimeout(toastTimerRef.current);
+      }
+
+      toastTimerRef.current = setTimeout(() => {
+        setToastOpen(false);
+        toastTimerRef.current = null;
+      }, 1600);
+    } catch {
+    }
+  };
 
   return (
     <>
@@ -71,21 +123,52 @@ export function ApplyDetailSidebar({ open, item, onClose }: ApplyDetailSidebarPr
       <aside
         role="dialog"
         aria-modal="true"
-        aria-labelledby="apply-detail-title"
+        aria-labelledby="apply-detail-heading"
         className={cn(
-          'fixed top-0 right-0 z-50 flex h-screen w-[500px] flex-col overflow-hidden bg-background-w shadow-xl',
+          'fixed z-50 flex flex-col overflow-hidden shadow-xl transform-gpu',
+          expanded
+            ? 'top-0 right-0 h-screen w-[calc(100vw-var(--app-sidebar-width))] rounded-none bg-[#FAFAFA]'
+            : 'top-0 right-0 h-screen w-[500px] bg-background-w',
           'shadow-[0px_25px_50px_-12px_rgba(0,0,0,0.10)]',
-          'transition-transform duration-300 ease-out will-change-transform',
-          panelOpen ? 'translate-x-0' : 'translate-x-full',
+          'will-change-transform',
         )}
+        style={{
+          transform: panelVisible ? 'translate3d(0, 0, 0)' : 'translate3d(100%, 0, 0)',
+          transition:
+            'transform 520ms cubic-bezier(0.22, 1, 0.36, 1), width 520ms cubic-bezier(0.22, 1, 0.36, 1), border-radius 520ms cubic-bezier(0.22, 1, 0.36, 1), background-color 520ms cubic-bezier(0.22, 1, 0.36, 1)',
+        }}
       >
-        <div className="flex min-h-0 flex-1 flex-col gap-6 px-6 pt-8">
+        <div className={cn('flex min-h-0 flex-1 flex-col gap-6 px-6 pt-8', expanded && 'px-8 pt-6')}>
           <div className="flex shrink-0 flex-col gap-4">
+            <div className="flex items-center justify-between pb-2">
+              <button
+                type="button"
+                aria-label="확장"
+                aria-pressed={expanded}
+                className="flex size-8 cursor-pointer items-center justify-center rounded-full text-gray-main hover:bg-gray-100"
+                onClick={() => setExpanded((prev) => !prev)}
+              >
+                <ExpandIcon className="size-6" />
+              </button>
+
+              <h2 id="apply-detail-heading" className="text-xl font-extrabold leading-8 text-strong">
+                지원 상세
+              </h2>
+
+              <button
+                type="button"
+                aria-label="닫기"
+                className="flex size-8 cursor-pointer shrink-0 items-center justify-center rounded-full text-gray-main hover:bg-gray-100"
+                onClick={onClose}
+              >
+                <XIcon className="size-6" />
+              </button>
+            </div>
             <div className="flex items-start justify-between gap-4">
-              <div className="flex min-w-0 flex-col gap-5">
+              <div className="flex min-w-0 flex-1 flex-col gap-5">
                 <h2
                   id="apply-detail-title"
-                  className="text-2xl leading-9 font-bold text-strong"
+                  className="min-w-0 flex-1 text-2xl leading-9 font-bold text-strong"
                 >
                   {item.title}
                 </h2>
@@ -120,40 +203,56 @@ export function ApplyDetailSidebar({ open, item, onClose }: ApplyDetailSidebarPr
                   </div>
                 </div>
               </div>
+              {expanded ? (
+                <button
+                  type="button"
+                  className={cn(
+                    'inline-flex h-9 shrink-0 items-center justify-start gap-1 overflow-hidden rounded-lg px-2 py-0.5',
+                    isEditing ? 'bg-gray-main' : 'bg-gray-200',
+                  )}
+                  onClick={() => setIsEditing((prev) => !prev)}
+                >
+                  <span
+                    className={cn(
+                      'text-base leading-6 font-bold',
+                      isEditing ? 'text-white' : 'text-tertiary',
+                    )}
+                  >
+                    {isEditing ? '저장하기' : '수정하기'}
+                  </span>
+                </button>
+              ) : null}
 
-              <button
-                type="button"
-                aria-label="닫기"
-                className="flex size-8 shrink-0 items-center justify-center rounded bg-background-w text-gray-main"
-                onClick={onClose}
-              >
-                <XIcon className="size-6" />
-              </button>
             </div>
 
-            <div className="h-px w-full max-w-[452px] bg-gray-300" />
+            <div className={cn('h-px w-full bg-gray-300', !expanded && 'max-w-[452px]')} />
           </div>
 
           <div className="min-h-0 flex-1 overflow-y-auto pb-6">
-            <div className="flex max-w-[452px] flex-col gap-3">
-              <QuestionBlock
-                index={1}
-                label="지원동기"
-                answer={item.coverLetter.motivation}
-              />
-              <QuestionBlock
-                index={2}
-                label="핵심 경험"
-                answer={item.coverLetter.experience}
-              />
-              <QuestionBlock
-                index={3}
-                label="입사 후 포부"
-                answer={item.coverLetter.aspiration}
-              />
+            <div className={cn('flex flex-col gap-3', !expanded && 'max-w-[452px]')}>
+              {coverLetterQuestions.map((question) => (
+                <QuestionBlock
+                  key={`${question.label}-${question.index}`}
+                  index={question.index}
+                  label={question.label}
+                  answer={question.answer}
+                  expanded={expanded}
+                  editable={isEditing}
+                  inputBackgroundClassName={isEditing ? 'bg-[#F5F5F5]' : 'bg-[#FFFFFF]'}
+                  onAnswerChange={(nextAnswer) =>
+                    setEditableQuestions((prev) =>
+                      prev.map((entry, entryIndex) =>
+                        entryIndex === question.index - 1 ? { ...entry, answer: nextAnswer } : entry,
+                      ),
+                    )
+                  }
+                  onCopy={() => void handleCopy(question.answer)}
+                />
+              ))}
             </div>
           </div>
         </div>
+        <ToastMessage open={toastOpen} message="복사되었습니다" />
       </aside>
     </>
   );
@@ -163,19 +262,52 @@ function QuestionBlock({
   index,
   label,
   answer,
+  expanded = false,
+  editable = false,
+  inputBackgroundClassName,
+  onAnswerChange,
+  onCopy,
 }: {
   index: number;
   label: string;
   answer: string;
+  expanded?: boolean;
+  editable?: boolean;
+  inputBackgroundClassName?: string;
+  onAnswerChange?: (value: string) => void;
+  onCopy?: () => void;
 }) {
   return (
-    <div className="flex w-full max-w-[452px] flex-col gap-1.5">
+    <div className={cn('flex w-full flex-col gap-1.5', !expanded && 'max-w-[452px]')}>
       <div className="flex items-center gap-1 px-2">
-        <span className="body-1-bold text-mint-300">Q{index}.</span>
-        <span className="body-1-bold text-gray-800">{label}</span>
+        <div className="flex min-w-0 flex-1 items-center gap-1">
+          <span className="body-1-bold text-mint-300">Q{index}.</span>
+          <span className="body-1-bold text-gray-800">{label}</span>
+        </div>
+        <button
+          type="button"
+          aria-label={`${label} 복사`}
+          className="flex size-7 shrink-0 cursor-pointer items-center justify-center rounded text-gray-main outline-none transition-colors hover:bg-gray-100 focus-visible:shadow-focus-ring"
+          onClick={onCopy}
+        >
+          <CopyIcon className="size-4" />
+        </button>
       </div>
-      <div className="flex min-h-36 flex-col gap-2 rounded-2xl bg-background-default px-3 py-4">
-        <p className="body-3-bold text-gray-700">{answer}</p>
+      <div
+        className={cn(
+          'flex min-h-36 flex-col gap-2 rounded-2xl px-3 py-4',
+          inputBackgroundClassName ?? 'bg-[#FFFFFF]',
+        )}
+      >
+        {editable ? (
+          <textarea
+            value={answer}
+            className="h-full min-h-28 w-full resize-none bg-transparent body-3-bold text-gray-700 outline-none"
+            onChange={(event) => onAnswerChange?.(event.currentTarget.value)}
+          />
+        ) : (
+          <p className="body-3-bold text-gray-700">{answer}</p>
+        )}
       </div>
     </div>
   );

--- a/src/app/(pages)/apply/list/_components/ApplyListSection.tsx
+++ b/src/app/(pages)/apply/list/_components/ApplyListSection.tsx
@@ -1,6 +1,9 @@
 'use client';
 
 import * as React from 'react';
+import { arrayMove } from '@dnd-kit/helpers';
+import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react';
+import { isSortable, useSortable } from '@dnd-kit/react/sortable';
 
 import type { ApplyListItem } from '@/app/(pages)/apply/_constants/applyMockData';
 import { ApplyCard } from './ApplyCard';
@@ -11,9 +14,14 @@ export interface ApplyListSectionProps {
 }
 
 export function ApplyListSection({ cards }: ApplyListSectionProps) {
+  const [orderedCards, setOrderedCards] = React.useState(cards);
   const [sidebarOpen, setSidebarOpen] = React.useState(false);
   const [activeId, setActiveId] = React.useState<string | null>(null);
   const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    setOrderedCards(cards);
+  }, [cards]);
 
   React.useEffect(() => {
     return () => {
@@ -24,8 +32,8 @@ export function ApplyListSection({ cards }: ApplyListSectionProps) {
   }, []);
 
   const activeItem = React.useMemo(
-    () => cards.find((card) => card.id === activeId) ?? null,
-    [cards, activeId],
+    () => orderedCards.find((card) => card.id === activeId) ?? null,
+    [orderedCards, activeId],
   );
 
   function handleClose() {
@@ -48,24 +56,73 @@ export function ApplyListSection({ cards }: ApplyListSectionProps) {
     setSidebarOpen(true);
   }
 
+  const handleDragEnd = React.useCallback((event: DragEndEvent) => {
+    if (event.canceled) {
+      return;
+    }
+
+    const { source } = event.operation;
+
+    if (!isSortable(source)) {
+      return;
+    }
+
+    const { initialIndex, index } = source;
+
+    if (initialIndex === index) {
+      return;
+    }
+
+    setOrderedCards((prev) => arrayMove(prev, initialIndex, index));
+  }, []);
+
   return (
     <>
-      <div className="grid grid-cols-2 gap-5 [@media(min-width:1855px)]:grid-cols-3">
-        {cards.map((card) => (
-          <ApplyCard
-            key={card.id}
-            applyTitle={card.title}
-            companyName={card.companyName}
-            jobField={card.jobField}
-            period={card.period}
-            selected={sidebarOpen && activeId === card.id}
-            onCardClick={() => handleCardOpen(card.id)}
-            className="max-w-none"
-          />
-        ))}
-      </div>
+      <DragDropProvider onDragEnd={handleDragEnd}>
+        <div className="grid grid-cols-2 gap-5 [@media(min-width:1855px)]:grid-cols-3">
+          {orderedCards.map((card, index) => (
+            <SortableApplyCard
+              key={card.id}
+              card={card}
+              index={index}
+              selected={sidebarOpen && activeId === card.id}
+              onCardClick={handleCardOpen}
+            />
+          ))}
+        </div>
+      </DragDropProvider>
 
       <ApplyDetailSidebar open={sidebarOpen} item={activeItem} onClose={handleClose} />
     </>
+  );
+}
+
+interface SortableApplyCardProps {
+  card: ApplyListItem;
+  index: number;
+  selected: boolean;
+  onCardClick: (cardId: string) => void;
+}
+
+function SortableApplyCard({ card, index, selected, onCardClick }: SortableApplyCardProps) {
+  const { ref, isDragSource } = useSortable({
+    id: card.id,
+    index,
+    type: 'apply-card',
+    accept: 'apply-card',
+  });
+
+  return (
+    <div ref={ref} className={isDragSource ? 'relative z-10 opacity-90' : undefined}>
+      <ApplyCard
+        applyTitle={card.title}
+        companyName={card.companyName}
+        jobField={card.jobField}
+        period={card.period}
+        selected={selected}
+        onCardClick={() => onCardClick(card.id)}
+        className="max-w-none"
+      />
+    </div>
   );
 }

--- a/src/app/(pages)/apply/list/_components/ApplyListSection.tsx
+++ b/src/app/(pages)/apply/list/_components/ApplyListSection.tsx
@@ -44,7 +44,7 @@ export function ApplyListSection({ cards }: ApplyListSectionProps) {
     closeTimerRef.current = setTimeout(() => {
       setActiveId(null);
       closeTimerRef.current = null;
-    }, 300);
+    }, 560);
   }
 
   function handleCardOpen(cardId: string) {

--- a/src/app/(pages)/apply/list/_components/ApplyListSection.tsx
+++ b/src/app/(pages)/apply/list/_components/ApplyListSection.tsx
@@ -50,7 +50,7 @@ export function ApplyListSection({ cards }: ApplyListSectionProps) {
 
   return (
     <>
-      <div className="grid grid-cols-2 gap-5">
+      <div className="grid grid-cols-2 gap-5 [@media(min-width:1855px)]:grid-cols-3">
         {cards.map((card) => (
           <ApplyCard
             key={card.id}

--- a/src/components/common/icons/NomalStarIcon.tsx
+++ b/src/components/common/icons/NomalStarIcon.tsx
@@ -1,0 +1,12 @@
+import type { SVGProps } from 'react';
+
+export function NomalStarIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true" {...props}>
+      <path
+        d="M14.9893 7.88672L21.5508 8.41211L21.8359 9.29102L16.8359 13.5732L18.3643 19.9756L17.6172 20.5176L12 17.0869L6.38281 20.5176L5.63574 19.9756L7.16309 13.5732L2.16406 9.29102L2.44922 8.41211L9.00977 7.88672L11.5381 1.80859L12.4619 1.80859L14.9893 7.88672Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호
resolve #52 

## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- 지원관리 리스트 모달 
<img width="264" height="236" alt="스크린샷 2026-05-27 오전 6 47 16" src="https://github.com/user-attachments/assets/5cfbd99a-dbae-4552-b8d5-6cba5213b9aa" />

- 공고 이미지 업로드 컴포넌트 
<img width="827" height="662" alt="스크린샷 2026-05-27 오전 6 47 56" src="https://github.com/user-attachments/assets/6a8b8ae8-2e1c-4ede-a6e2-59e48828c484" />

- 확장 사이드바 
<img width="1504" height="743" alt="스크린샷 2026-05-27 오전 6 48 38" src="https://github.com/user-attachments/assets/b163114a-ca5a-4df1-85d5-410c1d3ad3d5" />

- 지원관리 리스트 순서 변경  로직 
- 버튼 크기 조정

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
