### PR TITLE
[Feat] QA 반영

### DIFF
--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -93,6 +93,8 @@ export function ExperienceBoard({
     () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
     [data],
   );
+  const keywordKey = keyword ?? '';
+  const [emptyAllKeywordKey, setEmptyAllKeywordKey] = React.useState<string | null>(null);
   const [experienceOrderMap, setExperienceOrderMap] = React.useState(() =>
     createExperienceOrderMap(experiences),
   );
@@ -134,6 +136,23 @@ export function ExperienceBoard({
       return nextOrderMap;
     });
   }, [experiences, selectedCategory]);
+
+  React.useEffect(() => {
+    if (selectedCategory !== 'all' || !data || isError || isPending) {
+      return;
+    }
+
+    const isAllExperienceEmpty =
+      !hasNextPage && data.pages.every((page) => page.experiences.length === 0);
+
+    setEmptyAllKeywordKey((currentKeywordKey) => {
+      if (isAllExperienceEmpty) {
+        return keywordKey;
+      }
+
+      return currentKeywordKey === keywordKey ? null : currentKeywordKey;
+    });
+  }, [data, hasNextPage, isError, isPending, keywordKey, selectedCategory]);
 
   React.useEffect(() => {
     if (previousKeywordRef.current === keyword) {
@@ -241,8 +260,13 @@ export function ExperienceBoard({
     panelOpen &&
     Boolean(selectedExperienceId) &&
     (isDetailPending || (isDetailFetching && !selectedExperienceDetailMatches));
+  const showKnownAllEmpty =
+    selectedCategory !== 'all' &&
+    emptyAllKeywordKey === keywordKey &&
+    filteredExperiences.length === 0;
   const showListLoading =
-    isPending || (isFetching && !isFetchingNextPage && filteredExperiences.length === 0);
+    !showKnownAllEmpty &&
+    (isPending || (isFetching && !isFetchingNextPage && filteredExperiences.length === 0));
 
   const handleCategoryChange = (category: ExperienceCategory) => {
     if (closeTimerRef.current) {

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -431,7 +431,8 @@ export function ExperienceDetailContent({
 
       <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-x-hidden py-6">
         {detailFields.map(([label, key]) => {
-          const characterCount = detail[key].length;
+          const fieldValue = detail[key] ?? '';
+          const characterCount = fieldValue.length;
           const isMaxLength = characterCount >= DETAIL_FIELD_MAX_LENGTH;
 
           return (
@@ -445,7 +446,7 @@ export function ExperienceDetailContent({
                 </p>
               </div>
               <DetailInput
-                value={detail[key]}
+                value={fieldValue}
                 maxLength={DETAIL_FIELD_MAX_LENGTH}
                 readOnly={!isEditing}
                 onChange={handleDetailChange(key)}

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -312,10 +312,11 @@ export function ExperienceDetailContent({
                         type="button"
                         aria-label="기간 선택"
                         aria-expanded={datePickerOpen}
-                        className="flex size-[21px] shrink-0 cursor-pointer items-center justify-center rounded-sm text-tertiary focus-visible:shadow-focus-ring focus-visible:outline-none"
+                        className="flex min-w-0 cursor-pointer items-center gap-1 rounded-sm text-secondary focus-visible:shadow-focus-ring focus-visible:outline-none"
                         onClick={toggleDatePicker}
                       >
-                        <CalendarIcon className="size-[21px]" />
+                        <CalendarIcon className="size-[21px] shrink-0 text-tertiary" />
+                        <span>{item.value}</span>
                       </button>
                       {datePickerOpen && (
                         <div
@@ -366,7 +367,7 @@ export function ExperienceDetailContent({
                       onChange={(value) => updateBasicDetail(item.name, value)}
                     />
                   ) : (
-                    <span>{item.type === 'field' ? item.displayValue : item.value}</span>
+                    !isEditing && <span>{item.type === 'field' ? item.displayValue : item.value}</span>
                   )}
                 </dd>
               </div>

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -169,9 +169,11 @@ export function ExperienceDetailContent({
     };
 
   const updateBasicDetail = (key: BasicDetailKey, value: string) => {
+    const nextValue = getSanitizedBasicDetailValue(key, value);
+
     setBasicDetail((currentBasicDetail) => ({
       ...currentBasicDetail,
-      [key]: value,
+      [key]: nextValue,
     }));
   };
 
@@ -461,6 +463,24 @@ export function ExperienceDetailContent({
       />
     </div>
   );
+}
+
+function getSanitizedBasicDetailValue(key: BasicDetailKey, value: string) {
+  if (key === 'teamNum' || key === 'contributionRate') {
+    return sanitizeNumberText(value, 100);
+  }
+
+  return value;
+}
+
+function sanitizeNumberText(value: string, maxValue: number) {
+  const numberText = value.replace(/\D/g, '');
+
+  if (!numberText) {
+    return '';
+  }
+
+  return String(Math.min(Number(numberText), maxValue));
 }
 
 type EditableDetailInfoItem =

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -46,7 +46,6 @@ export interface ExperienceDetailContentProps extends React.ComponentProps<'div'
   experience: ExperienceItem;
   variant?: 'panel' | 'page';
   defaultEditing?: boolean;
-  scrollable?: boolean;
   onEdit?: () => void;
   onSave?: (experience: ExperienceDetailSaveValue) => Promise<void> | void;
 }
@@ -55,7 +54,6 @@ export function ExperienceDetailContent({
   experience,
   variant = 'panel',
   defaultEditing = false,
-  scrollable = true,
   onEdit,
   onSave,
   className,
@@ -427,12 +425,7 @@ export function ExperienceDetailContent({
 
       {!isEditing ? <div className="mt-4 h-px w-full shrink-0 bg-gray-300" /> : null}
 
-      <div
-        className={cn(
-          'flex min-h-0 flex-1 flex-col gap-3 overflow-x-hidden py-6',
-          scrollable && 'overflow-y-auto',
-        )}
-      >
+      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-x-hidden py-6">
         {detailFields.map(([label, key]) => {
           const characterCount = detail[key].length;
           const isMaxLength = characterCount >= DETAIL_FIELD_MAX_LENGTH;

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -26,6 +26,7 @@ const detailFields = [
   ['Result', 'result'],
   ['Taken', 'taken'],
 ] as const;
+const DETAIL_FIELD_MAX_LENGTH = 1000;
 
 type EditableTagGroupKey = 'skill' | 'competency';
 type BasicDetailKey = keyof ExperienceItem['basicDetail'];
@@ -432,21 +433,29 @@ export function ExperienceDetailContent({
           scrollable && 'overflow-y-auto',
         )}
       >
-        {detailFields.map(([label, key]) => (
-          <div key={key} className="flex w-full flex-col gap-1.5">
-            <div className="flex items-center justify-between px-2">
-              <h3 className={cn('font-bold text-primary', isPage ? 'title-2-bold' : 'body-2-bold')}>
-                {label}
-              </h3>
+        {detailFields.map(([label, key]) => {
+          const characterCount = detail[key].length;
+          const isMaxLength = characterCount >= DETAIL_FIELD_MAX_LENGTH;
+
+          return (
+            <div key={key} className="flex w-full flex-col gap-1.5">
+              <div className="flex items-end gap-3 px-2">
+                <h3 className={cn('font-bold text-primary', isPage ? 'title-2-bold' : 'body-2-bold')}>
+                  {label}
+                </h3>
+                <p className={cn('caption-bold', isMaxLength ? 'text-danger' : 'text-quaternary')}>
+                  {characterCount}자 / {DETAIL_FIELD_MAX_LENGTH}자
+                </p>
+              </div>
+              <DetailInput
+                value={detail[key]}
+                maxLength={DETAIL_FIELD_MAX_LENGTH}
+                readOnly={!isEditing}
+                onChange={handleDetailChange(key)}
+              />
             </div>
-            <DetailInput
-              value={detail[key]}
-              maxLength={1000}
-              readOnly={!isEditing}
-              onChange={handleDetailChange(key)}
-            />
-          </div>
-        ))}
+          );
+        })}
       </div>
       <ErrorDialog
         open={errorMessage.length > 0}

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -7,10 +7,11 @@ import type { ExperienceItem } from '@/app/(pages)/experience/_components/Experi
 import { EditableTagGroup } from '@/app/(pages)/experience/_components/EditableTagGroup';
 import { getExperienceCategoryMeta } from '@/app/(pages)/experience/_utils/ExperienceCategory';
 import { formatExperiencePeriod } from '@/app/(pages)/experience/_utils/formatExperiencePeriod';
+import { sanitizeNumberText } from '@/app/(pages)/experience/_utils/sanitizeNumberText';
+import { DetailInput } from '@/components/common/DetailInput';
 import { ErrorDialog } from '@/components/common/ErrorDialog';
 import { CalendarIcon } from '@/components/common/icons/CalendarIcon';
 import { Tag } from '@/components/common/Tag';
-import { DetailInput } from '@/components/common/DetailInput';
 import {
   type SingleMonthCalendarDateRange,
   SingleMonthRangeCalendar,
@@ -472,16 +473,6 @@ function getSanitizedBasicDetailValue(key: BasicDetailKey, value: string) {
   }
 
   return value;
-}
-
-function sanitizeNumberText(value: string, maxValue: number) {
-  const numberText = value.replace(/\D/g, '');
-
-  if (!numberText) {
-    return '';
-  }
-
-  return String(Math.min(Number(numberText), maxValue));
 }
 
 type EditableDetailInfoItem =

--- a/src/app/(pages)/experience/_components/ExperienceDetailPageContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailPageContent.tsx
@@ -55,7 +55,7 @@ export function ExperienceDetailPageContent({ experienceId }: ExperienceDetailPa
   };
 
   return (
-    <div className="mx-16 flex min-h-[calc(100vh-32px)] flex-col bg-background-default">
+    <div className="flex min-h-[calc(100vh-32px)] flex-col">
       <div className="flex w-full flex-1 flex-col gap-[22px]">
         <header className="grid h-8 grid-cols-[32px_1fr_32px] items-center">
           <button

--- a/src/app/(pages)/experience/_components/ExperienceDetailPageContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailPageContent.tsx
@@ -96,7 +96,6 @@ export function ExperienceDetailPageContent({ experienceId }: ExperienceDetailPa
           <ExperienceDetailContent
             experience={experience}
             variant="page"
-            scrollable={false}
             onSave={handleExperienceSave}
           />
         )}

--- a/src/app/(pages)/experience/_components/ExperienceDetailPanel.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailPanel.tsx
@@ -141,7 +141,7 @@ export function ExperienceDetailPanel({
       aria-labelledby={titleId}
       tabIndex={-1}
       className={cn(
-        'fixed top-0 right-0 z-40 flex h-dvh w-full max-w-[500px] flex-col bg-background-default px-6 pt-8 shadow-2xl',
+        'fixed top-0 right-0 z-40 flex h-dvh w-full max-w-[500px] flex-col overflow-x-hidden overflow-y-auto overscroll-contain bg-background-default px-6 pt-8 pb-8 shadow-2xl',
         'transition-transform duration-300 ease-out will-change-transform',
         open && entered ? 'translate-x-0' : 'translate-x-full',
         className,
@@ -191,6 +191,7 @@ export function ExperienceDetailPanel({
         <ExperienceDetailContent
           experience={experience}
           variant="panel"
+          className="flex-none"
           onEdit={onEdit}
           onSave={onSave}
         />

--- a/src/app/(pages)/experience/_components/ExperiencePageContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperiencePageContent.tsx
@@ -54,7 +54,7 @@ function ExperiencePageRouteContent({
   }
 
   return (
-    <div className="mx-16 flex min-h-[calc(100vh-32px)] flex-col">
+    <div className="flex min-h-[calc(100vh-32px)] flex-col">
       <div className="flex flex-1 flex-col gap-5">
         <ExperiencePageHeader keyword={keyword} onKeywordChange={onKeywordChange} />
         <ExperienceBoard keyword={debouncedKeyword || undefined} />

--- a/src/app/(pages)/experience/_utils/sanitizeNumberText.ts
+++ b/src/app/(pages)/experience/_utils/sanitizeNumberText.ts
@@ -1,0 +1,9 @@
+export function sanitizeNumberText(value: string, maxValue: number) {
+  const numberText = value.replace(/\D/g, '');
+
+  if (!numberText) {
+    return '';
+  }
+
+  return String(Math.min(Number(numberText), maxValue));
+}

--- a/src/app/(pages)/experience/add/_components/ExperienceAddBasicInfoStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddBasicInfoStep.tsx
@@ -33,9 +33,11 @@ export function ExperienceAddBasicInfoStep({ value, onChange }: ExperienceAddBas
     fieldName: keyof Omit<ExperienceAddBasicInfoForm, 'type'>,
     fieldValue: string,
   ) => {
+    const nextValue = getSanitizedBasicInfoValue(fieldName, fieldValue);
+
     onChange({
       ...value,
-      [fieldName]: fieldValue,
+      [fieldName]: nextValue,
     });
   };
   const handleInputChange =
@@ -140,6 +142,27 @@ export function ExperienceAddBasicInfoStep({ value, onChange }: ExperienceAddBas
       )}
     </section>
   );
+}
+
+function getSanitizedBasicInfoValue(
+  fieldName: keyof Omit<ExperienceAddBasicInfoForm, 'type'>,
+  value: string,
+) {
+  if (fieldName === 'teamNum' || fieldName === 'contributionRate') {
+    return sanitizeNumberText(value, 100);
+  }
+
+  return value;
+}
+
+function sanitizeNumberText(value: string, maxValue: number) {
+  const numberText = value.replace(/\D/g, '');
+
+  if (!numberText) {
+    return '';
+  }
+
+  return String(Math.min(Number(numberText), maxValue));
 }
 
 const DATE_RANGE_PLACEHOLDER = '0000년 00월 00일 ~ 0000년 00월 00일';

--- a/src/app/(pages)/experience/add/_components/ExperienceAddBasicInfoStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddBasicInfoStep.tsx
@@ -16,6 +16,7 @@ import {
   EXPERIENCE_TYPE_OPTIONS,
 } from '@/app/(pages)/experience/add/_constants/experienceTypeOptions';
 import type { ExperienceAddBasicInfoForm } from '@/app/(pages)/experience/add/_types/experienceAddForm';
+import { sanitizeNumberText } from '@/app/(pages)/experience/_utils/sanitizeNumberText';
 import { type CalendarDateRange, RangeCalendar } from '@/components/common/RangeCalendar';
 import { TextField } from '@/components/common/TextField';
 import { cn } from '@/lib/utils';
@@ -153,16 +154,6 @@ function getSanitizedBasicInfoValue(
   }
 
   return value;
-}
-
-function sanitizeNumberText(value: string, maxValue: number) {
-  const numberText = value.replace(/\D/g, '');
-
-  if (!numberText) {
-    return '';
-  }
-
-  return String(Math.min(Number(numberText), maxValue));
 }
 
 const DATE_RANGE_PLACEHOLDER = '0000년 00월 00일 ~ 0000년 00월 00일';

--- a/src/app/(pages)/experience/add/_components/ExperienceAddCoreStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddCoreStep.tsx
@@ -5,6 +5,9 @@ import {
 import type { ExperienceAddCoreInfoForm } from '@/app/(pages)/experience/add/_types/experienceAddForm';
 import { TextField } from '@/components/common/TextField';
 import { CoreTipIcon } from '@/components/common/icons/CoreTipIcon';
+import { cn } from '@/lib/utils';
+
+const CORE_FIELD_MAX_LENGTH = 1000;
 
 interface ExperienceAddCoreStepProps {
   value: ExperienceAddCoreInfoForm;
@@ -80,16 +83,25 @@ function CoreQuestionField({
   value: string;
   onChange: (value: string) => void;
 }) {
+  const characterCount = value.length;
+  const isMaxLength = characterCount >= CORE_FIELD_MAX_LENGTH;
+
   return (
     <div className="flex w-full flex-col gap-4">
-      <div className="flex items-start gap-0.5 title-2-bold">
-        <span className="text-mint-300">{number}</span>
-        <span className="text-strong">{label}</span>
+      <div className="flex items-end gap-3">
+        <div className="flex items-start gap-0.5 title-2-bold">
+          <span className="text-mint-300">{number}</span>
+          <span className="text-strong">{label}</span>
+        </div>
+        <p className={cn('caption-bold', isMaxLength ? 'text-danger' : 'text-quaternary')}>
+          {characterCount}자 / {CORE_FIELD_MAX_LENGTH}자
+        </p>
       </div>
       <TextField
         variant="textarea"
         placeholder={placeholder}
         value={value}
+        maxLength={CORE_FIELD_MAX_LENGTH}
         description={false}
         onChange={(event) => onChange(event.currentTarget.value)}
       />

--- a/src/app/(pages)/experience/add/_components/ExperienceAddCoreStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddCoreStep.tsx
@@ -80,10 +80,11 @@ function CoreQuestionField({
   number: string;
   label: string;
   placeholder: string;
-  value: string;
+  value?: string | null;
   onChange: (value: string) => void;
 }) {
-  const characterCount = value.length;
+  const fieldValue = value ?? '';
+  const characterCount = fieldValue.length;
   const isMaxLength = characterCount >= CORE_FIELD_MAX_LENGTH;
 
   return (
@@ -100,7 +101,7 @@ function CoreQuestionField({
       <TextField
         variant="textarea"
         placeholder={placeholder}
-        value={value}
+        value={fieldValue}
         maxLength={CORE_FIELD_MAX_LENGTH}
         description={false}
         onChange={(event) => onChange(event.currentTarget.value)}

--- a/src/app/(pages)/experience/add/_components/ExperienceAddMaterialSelectView.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddMaterialSelectView.tsx
@@ -39,8 +39,11 @@ export function ExperienceAddMaterialSelectView({
     setIsPdfDragging(false);
   };
 
-  const isFileDragEvent = (event: React.DragEvent<HTMLDivElement>) =>
-    Array.from(event.dataTransfer.types).includes('Files');
+  const isFileDragEvent = (event: React.DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer) return false;
+
+    return Array.from(event.dataTransfer.types).includes('Files');
+  };
 
   const addPdfFiles = (fileList: FileList | null) => {
     if (!fileList) return;

--- a/src/app/(pages)/experience/add/_components/ExperienceAddMaterialSelectView.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddMaterialSelectView.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 
 import type { ExperienceMaterial } from '@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal';
 import { LogoIcon } from '@/components/common/icons/LogoIcon';
@@ -29,8 +29,18 @@ export function ExperienceAddMaterialSelectView({
   onSave,
 }: ExperienceAddMaterialSelectViewProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const pdfDragDepthRef = useRef(0);
+  const [isPdfDragging, setIsPdfDragging] = useState(false);
   const pdfMaterials = materials.filter((material) => material.type === 'pdf');
   const canSave = materials.length > 0;
+
+  const resetPdfDragState = () => {
+    pdfDragDepthRef.current = 0;
+    setIsPdfDragging(false);
+  };
+
+  const isFileDragEvent = (event: React.DragEvent<HTMLDivElement>) =>
+    Array.from(event.dataTransfer.types).includes('Files');
 
   const addPdfFiles = (fileList: FileList | null) => {
     if (!fileList) return;
@@ -56,10 +66,40 @@ export function ExperienceAddMaterialSelectView({
           </h3>
 
           <div
-            className="flex h-[274px] w-full flex-col items-center justify-between rounded-lg border border-dashed border-gray-500 bg-gray-100 py-5"
-            onDragOver={(event) => event.preventDefault()}
+            className={cn(
+              'flex h-[274px] w-full flex-col items-center justify-between rounded-lg border border-dashed py-5 transition-colors',
+              isPdfDragging ? 'border-brand bg-mint-50' : 'border-gray-500 bg-gray-100',
+            )}
+            onDragEnter={(event) => {
+              event.preventDefault();
+
+              if (!isFileDragEvent(event)) return;
+
+              pdfDragDepthRef.current += 1;
+              setIsPdfDragging(true);
+            }}
+            onDragOver={(event) => {
+              event.preventDefault();
+
+              if (isFileDragEvent(event)) {
+                event.dataTransfer.dropEffect = 'copy';
+                setIsPdfDragging(true);
+              }
+            }}
+            onDragLeave={(event) => {
+              event.preventDefault();
+
+              if (!isFileDragEvent(event)) return;
+
+              pdfDragDepthRef.current = Math.max(0, pdfDragDepthRef.current - 1);
+
+              if (pdfDragDepthRef.current === 0) {
+                setIsPdfDragging(false);
+              }
+            }}
             onDrop={(event) => {
               event.preventDefault();
+              resetPdfDragState();
               addPdfFiles(event.dataTransfer.files);
             }}
           >

--- a/src/app/(pages)/experience/add/_components/ExperienceAddNotionPageSelectView.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddNotionPageSelectView.tsx
@@ -7,6 +7,7 @@ import {
   getNotionTypeLabel,
   NotionPageIcon,
 } from '@/app/(pages)/experience/add/_utils/notionPageDisplay';
+import { LoadingState } from '@/components/common/LoadingState';
 import { ModalClose, ModalDescription, ModalTitle } from '@/components/common/Modal';
 import { Tag } from '@/components/common/Tag';
 import { Button } from '@/components/ui/button';
@@ -77,9 +78,12 @@ export function ExperienceAddNotionPageSelectView({
 
       <div className="flex max-h-[calc(100dvh-260px)] min-h-[360px] w-full flex-col gap-2 overflow-y-auto">
         {isLoading && (
-          <div className="flex min-h-[360px] w-full items-center justify-center rounded-lg bg-gray-50">
-            <p className="body-2-regular text-gray-700">노션 페이지를 불러오는 중이에요</p>
-          </div>
+          <LoadingState
+            message="노션 페이지를 불러오는 중이에요"
+            ariaLabel="노션 페이지를 불러오는 중"
+            className="h-auto min-h-[360px] rounded-lg border-0 bg-gray-50"
+            lottieClassName="size-20"
+          />
         )}
 
         {!isLoading && errorMessage && (

--- a/src/app/(pages)/experience/add/_components/ExperienceAddNotionPageSelectView.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddNotionPageSelectView.tsx
@@ -109,29 +109,31 @@ export function ExperienceAddNotionPageSelectView({
                 type="button"
                 aria-pressed={isSelected}
                 className={cn(
-                  'flex w-full cursor-pointer items-center gap-3 rounded-lg px-2.5 py-2 text-left',
+                  'flex w-full cursor-pointer items-center rounded-lg px-2.5 py-2 text-left',
                   'focus-visible:shadow-focus-ring focus-visible:outline-none',
                   isSelected ? 'bg-[#eefffd]' : 'bg-gray-50 hover:bg-gray-100',
                 )}
                 onClick={() => onPageToggle(page.pageId)}
               >
-                <span
-                  aria-hidden="true"
-                  className={cn(
-                    'flex size-10 shrink-0 items-center justify-center text-tertiary',
-                    isSelected && 'text-mint-500',
-                  )}
-                >
-                  {isSelected ? (
-                    <CheckedBoxIcon className="size-6" />
-                  ) : (
-                    <EmptyBoxIcon className="size-6" />
-                  )}
+                <span className="flex shrink-0 items-center">
+                  <span
+                    aria-hidden="true"
+                    className={cn(
+                      'flex size-10 shrink-0 items-center justify-center text-tertiary',
+                      isSelected && 'text-mint-500',
+                    )}
+                  >
+                    {isSelected ? (
+                      <CheckedBoxIcon className="size-6" />
+                    ) : (
+                      <EmptyBoxIcon className="size-6" />
+                    )}
+                  </span>
+                  <span className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-background-w">
+                    <NotionPageIcon icon={page.icon} />
+                  </span>
                 </span>
-                <span className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-sm bg-background-w">
-                  <NotionPageIcon icon={page.icon} />
-                </span>
-                <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+                <span className="ml-3 flex min-w-0 flex-1 flex-col gap-0.5">
                   <span className="truncate body-1-bold text-strong">{page.title}</span>
                   <span className="flex items-center gap-2.5">
                     <Tag tone={getNotionTagTone(page.type)}>{getNotionTypeLabel(page.type)}</Tag>

--- a/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
@@ -186,7 +186,7 @@ export function ExperienceAddPageContent() {
   };
 
   return (
-    <div className="mx-20 flex min-h-dvh flex-col py-5">
+    <div className="flex min-h-dvh flex-col py-5">
       <header className="flex items-center gap-2">
         <button
           type="button"

--- a/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
@@ -11,12 +11,15 @@ import type {
 import { ExperienceAddProgress } from '@/app/(pages)/experience/add/_components/ExperienceAddProgress';
 import { ExperienceAddStepContent } from '@/app/(pages)/experience/add/_components/ExperienceAddStepContent';
 import { EXPERIENCE_ADD_STEPS } from '@/app/(pages)/experience/add/_constants/experienceAddSteps';
+import { CORE_EXPERIENCE_FIELDS } from '@/app/(pages)/experience/add/_constants/experienceCoreQuestions';
 import { EXPERIENCE_TYPE_FIELD_GROUPS } from '@/app/(pages)/experience/add/_constants/experienceTypeOptions';
 import {
   createEmptyBasicInfoForm,
   createEmptyCoreInfoForm,
   createEmptyResultInfoForm,
   type ExperienceAddBasicInfoForm,
+  type ExperienceAddCoreInfoForm,
+  type ExperienceAddResultInfoForm,
 } from '@/app/(pages)/experience/add/_types/experienceAddForm';
 import {
   mapAnalyzeResponseToBasicInfoForm,
@@ -65,8 +68,14 @@ export function ExperienceAddPageContent() {
   const isFirstStep = currentStepIndex === 0;
   const isCompleteStep = currentStepIndex === EXPERIENCE_ADD_STEPS.length;
   const isBasicInfoStep = currentStepIndex === 1;
+  const isCoreInfoStep = currentStepIndex === 2;
+  const isResultStep = currentStepIndex === EXPERIENCE_ADD_STEPS.length - 1;
   const isNextStepDisabled =
-    isAnalyzing || isSaving || (isBasicInfoStep && !isBasicInfoComplete(basicInfo));
+    isAnalyzing ||
+    isSaving ||
+    (isBasicInfoStep && !isBasicInfoComplete(basicInfo)) ||
+    (isCoreInfoStep && !isCoreInfoComplete(coreInfo)) ||
+    (isResultStep && !isResultStepComplete({ basicInfo, coreInfo, resultInfo }));
 
   useEffect(() => {
     if (!isNotionConnected) return;
@@ -246,6 +255,35 @@ function isBasicInfoComplete(basicInfo: ExperienceAddBasicInfoForm) {
   if (!basicInfo.type) return false;
 
   return EXPERIENCE_TYPE_FIELD_GROUPS[basicInfo.type].every((fieldGroup) =>
-    fieldGroup.fields.every((field) => (basicInfo[field.name] ?? '').trim().length > 0),
+    fieldGroup.fields.every((field) => hasText(basicInfo[field.name])),
   );
+}
+
+function isCoreInfoComplete(coreInfo: ExperienceAddCoreInfoForm) {
+  return CORE_EXPERIENCE_FIELDS.every((field) => hasText(coreInfo[field.name]));
+}
+
+function isResultStepComplete({
+  basicInfo,
+  coreInfo,
+  resultInfo,
+}: {
+  basicInfo: ExperienceAddBasicInfoForm;
+  coreInfo: ExperienceAddCoreInfoForm;
+  resultInfo: ExperienceAddResultInfoForm;
+}) {
+  return (
+    isBasicInfoComplete(basicInfo) &&
+    isCoreInfoComplete(coreInfo) &&
+    hasTag(resultInfo.skillTags) &&
+    hasTag(resultInfo.competencyTags)
+  );
+}
+
+function hasText(value: string | null | undefined) {
+  return (value ?? '').trim().length > 0;
+}
+
+function hasTag(tags: string[]) {
+  return tags.some(hasText);
 }

--- a/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
@@ -84,6 +84,10 @@ export function ExperienceAddPageContent() {
   }, [isNotionConnected, router]);
 
   useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }, [currentStepIndex]);
+
+  useEffect(() => {
     const restorePdfDraft = async () => {
       try {
         const pdfMaterial = await getExperienceAddPdfDraft();

--- a/src/app/(pages)/experience/add/_components/ExperienceAddResultStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddResultStep.tsx
@@ -185,10 +185,11 @@ function ResultTextareaField({
   onChange,
 }: {
   label: string;
-  value: string;
+  value?: string | null;
   onChange: (value: string) => void;
 }) {
-  const characterCount = value.length;
+  const fieldValue = value ?? '';
+  const characterCount = fieldValue.length;
   const isMaxLength = characterCount >= CORE_RESULT_FIELD_MAX_LENGTH;
 
   return (
@@ -201,7 +202,7 @@ function ResultTextareaField({
       </span>
       <TextField
         variant="textarea"
-        value={value}
+        value={fieldValue}
         maxLength={CORE_RESULT_FIELD_MAX_LENGTH}
         description={false}
         onChange={(event) => onChange(event.currentTarget.value)}

--- a/src/app/(pages)/experience/add/_components/ExperienceAddResultStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddResultStep.tsx
@@ -10,6 +10,7 @@ import type {
 } from '@/app/(pages)/experience/add/_types/experienceAddForm';
 import { EditableTagGroup } from '@/app/(pages)/experience/_components/EditableTagGroup';
 import { TextField } from '@/components/common/TextField';
+import { cn } from '@/lib/utils';
 
 type EditableTagGroupKey = 'skill' | 'competency';
 
@@ -34,6 +35,7 @@ const CORE_RESULT_FIELDS = [
   { name: 'result', label: 'Result (결과 및 성과)' },
   { name: 'taken', label: 'Taken (배운 점)' },
 ] as const;
+const CORE_RESULT_FIELD_MAX_LENGTH = 1000;
 
 export function ExperienceAddResultStep({
   basicInfo,
@@ -186,12 +188,21 @@ function ResultTextareaField({
   value: string;
   onChange: (value: string) => void;
 }) {
+  const characterCount = value.length;
+  const isMaxLength = characterCount >= CORE_RESULT_FIELD_MAX_LENGTH;
+
   return (
     <label className="flex w-full flex-col gap-4">
-      <span className="title-2-bold text-strong">{label}</span>
+      <span className="flex items-end gap-3">
+        <span className="title-2-bold text-strong">{label}</span>
+        <span className={cn('caption-bold', isMaxLength ? 'text-danger' : 'text-quaternary')}>
+          {characterCount}자 / {CORE_RESULT_FIELD_MAX_LENGTH}자
+        </span>
+      </span>
       <TextField
         variant="textarea"
         value={value}
+        maxLength={CORE_RESULT_FIELD_MAX_LENGTH}
         description={false}
         onChange={(event) => onChange(event.currentTarget.value)}
       />

--- a/src/components/common/AppShell.tsx
+++ b/src/components/common/AppShell.tsx
@@ -66,7 +66,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     >
       {!hideSidebar && <Sidebar collapsed={collapsed} />}
       <main className={`ml-(--app-sidebar-width) min-h-dvh min-w-0 ${hideSidebar ? 'pt-0' : 'pt-[30px]'}`}>
-        {children}
+        <div className={hideSidebar ? undefined : 'mx-20'}>{children}</div>
       </main>
     </div>
   );

--- a/src/components/common/LoadingState.tsx
+++ b/src/components/common/LoadingState.tsx
@@ -24,8 +24,8 @@ export function LoadingState({
       )}
       {...props}
     >
-      <div className="flex w-[211px] flex-col items-center gap-3">
-        <div className="flex h-[155px] w-[199px] items-center justify-center">
+      <div className="flex w-full flex-col items-center gap-3">
+        <div className="flex h-[155px] w-[211px] items-center justify-center">
           <LoadingLottie className={lottieClassName} />
         </div>
         <p className="body-1-bold text-strong">{message}</p>

--- a/src/components/common/MonthPanel.tsx
+++ b/src/components/common/MonthPanel.tsx
@@ -48,7 +48,15 @@ function buildMonthWeeks(year: number, month: number): Date[][] {
   return weeks;
 }
 
-type DayVariant = 'default' | 'disabled' | 'range-start' | 'range-mid' | 'range-end' | 'range-single';
+type DayVariant =
+  | 'default'
+  | 'disabled'
+  | 'selected-single'
+  | 'selected-start'
+  | 'selected-end'
+  | 'range-mid'
+  | 'preview-start'
+  | 'preview-end';
 
 function getDayVariant(
   cell: Date,
@@ -56,6 +64,7 @@ function getDayVariant(
   viewMonth: number,
   rangeStart: Date | null,
   rangeEnd: Date | null,
+  previewEnd: Date | null,
 ): DayVariant {
   const inMonth = cell.getMonth() === viewMonth && cell.getFullYear() === viewYear;
   if (!inMonth) return 'disabled';
@@ -63,7 +72,25 @@ function getDayVariant(
   if (!rangeStart) return 'default';
 
   if (!rangeEnd) {
-    return sameLocalDay(cell, rangeStart) ? 'range-single' : 'default';
+    if (!previewEnd) {
+      return sameLocalDay(cell, rangeStart) ? 'selected-single' : 'default';
+    }
+
+    const s = startOfLocalDay(rangeStart);
+    const e = startOfLocalDay(previewEnd);
+    const lo = compareLocalDay(s, e) <= 0 ? s : e;
+    const hi = compareLocalDay(s, e) <= 0 ? e : s;
+
+    const c = startOfLocalDay(cell);
+    if (compareLocalDay(c, lo) < 0 || compareLocalDay(c, hi) > 0) return 'default';
+    if (sameLocalDay(c, s) && sameLocalDay(c, e)) return 'selected-single';
+    if (sameLocalDay(c, s)) {
+      return compareLocalDay(s, e) <= 0 ? 'selected-start' : 'selected-end';
+    }
+    if (sameLocalDay(c, e)) {
+      return compareLocalDay(s, e) <= 0 ? 'preview-end' : 'preview-start';
+    }
+    return 'range-mid';
   }
 
   const s = startOfLocalDay(rangeStart);
@@ -73,9 +100,9 @@ function getDayVariant(
 
   const c = startOfLocalDay(cell);
   if (compareLocalDay(c, lo) < 0 || compareLocalDay(c, hi) > 0) return 'default';
-  if (sameLocalDay(c, lo) && sameLocalDay(c, hi)) return 'range-single';
-  if (sameLocalDay(c, lo)) return 'range-start';
-  if (sameLocalDay(c, hi)) return 'range-end';
+  if (sameLocalDay(c, lo) && sameLocalDay(c, hi)) return 'selected-single';
+  if (sameLocalDay(c, lo)) return 'selected-start';
+  if (sameLocalDay(c, hi)) return 'selected-end';
   return 'range-mid';
 }
 
@@ -83,12 +110,16 @@ function dayCellClass(variant: DayVariant): string {
   switch (variant) {
     case 'disabled':
       return 'text-quaternary';
-    case 'range-single':
-      return 'bg-mint-500 text-on-fill rounded-xl';
-    case 'range-start':
-      return 'bg-mint-500 text-on-fill rounded-tl-xl rounded-bl-xl';
-    case 'range-end':
-      return 'bg-mint-500 text-on-fill rounded-tr-xl rounded-br-xl';
+    case 'selected-single':
+      return 'rounded-md bg-mint-500 text-on-fill';
+    case 'selected-start':
+      return 'rounded-tl-md rounded-bl-md bg-mint-500 text-on-fill';
+    case 'selected-end':
+      return 'rounded-tr-md rounded-br-md bg-mint-500 text-on-fill';
+    case 'preview-start':
+      return 'rounded-tl-md rounded-bl-md bg-mint-100 text-success';
+    case 'preview-end':
+      return 'rounded-tr-md rounded-br-md bg-mint-100 text-success';
     case 'range-mid':
       return 'bg-mint-50 text-success';
     default:
@@ -101,14 +132,24 @@ export type MonthPanelProps = {
   month: number;
   selectionStart: Date | null;
   selectionEnd: Date | null;
+  previewEnd?: Date | null;
   onDayClick: (d: Date) => void;
+  onDayHover?: (d: Date | null) => void;
 };
 
-export function MonthPanel({ year, month, selectionStart, selectionEnd, onDayClick }: MonthPanelProps) {
+export function MonthPanel({
+  year,
+  month,
+  selectionStart,
+  selectionEnd,
+  previewEnd = null,
+  onDayClick,
+  onDayHover,
+}: MonthPanelProps) {
   const weeks = React.useMemo(() => buildMonthWeeks(year, month), [year, month]);
 
   return (
-    <div className="flex flex-col gap-px">
+    <div className="flex flex-col" onPointerLeave={() => onDayHover?.(null)}>
       <div className="flex h-10 w-[336px] items-center">
         {WEEK_LABELS.map((label) => (
           <div
@@ -123,29 +164,44 @@ export function MonthPanel({ year, month, selectionStart, selectionEnd, onDayCli
       {weeks.map((row, ri) => (
         <div key={ri} className="flex w-[336px] items-center">
           {row.map((cell, ci) => {
-            const variant = getDayVariant(cell, year, month, selectionStart, selectionEnd);
+            const variant = getDayVariant(cell, year, month, selectionStart, selectionEnd, previewEnd);
+            const isDisabled = variant === 'disabled';
             return (
               <button
                 key={`${ri}-${ci}-${cell.getTime()}`}
                 type="button"
-                disabled={variant === 'disabled'}
+                disabled={isDisabled}
                 data-statement={
-                  variant === 'disabled'
+                  isDisabled
                     ? 'Disable'
-                    : variant.startsWith('range')
-                      ? variant.replace('range-', '')
-                      : 'Default'
+                    : variant === 'selected-single'
+                      ? 'Selected'
+                      : variant === 'selected-start'
+                        ? 'start'
+                        : variant === 'selected-end'
+                          ? 'end'
+                          : variant === 'range-mid'
+                            ? 'range'
+                            : variant === 'preview-start' || variant === 'preview-end'
+                              ? 'hover2'
+                              : 'Default'
                 }
                 className={cn(
                   'flex size-12 shrink-0 flex-col items-center justify-center overflow-hidden p-2.5 text-base font-bold leading-6 outline-none',
-                  variant === 'default' && 'rounded-full hover:bg-gray-100 focus-visible:shadow-focus-ring',
-                  variant === 'disabled' && 'cursor-default rounded-full',
-                  variant !== 'disabled' &&
+                  variant === 'default' &&
+                    'rounded-full hover:rounded-md hover:bg-gray-300 focus-visible:shadow-focus-ring',
+                  isDisabled && 'cursor-default rounded-full',
+                  !isDisabled &&
                     variant !== 'default' &&
                     'cursor-pointer focus-visible:shadow-focus-ring',
                   dayCellClass(variant),
                 )}
                 onClick={() => onDayClick(cell)}
+                onPointerEnter={() => {
+                  if (!isDisabled) {
+                    onDayHover?.(cell);
+                  }
+                }}
               >
                 {cell.getDate()}
               </button>

--- a/src/components/common/RangeCalendar.tsx
+++ b/src/components/common/RangeCalendar.tsx
@@ -67,6 +67,7 @@ export function RangeCalendar({
     if (defaultRange) return startOfLocalDay(defaultRange.end);
     return null;
   });
+  const [previewEnd, setPreviewEnd] = React.useState<Date | null>(null);
 
   const valueSyncKey =
     valueProp == null
@@ -92,6 +93,7 @@ export function RangeCalendar({
 
   const selectionStart = draftStart;
   const selectionEnd = draftEnd;
+  const rangePreviewEnd = selectionStart && !selectionEnd ? previewEnd : null;
 
   const commitRange = (next: CalendarDateRange | null) => {
     onChange?.(next);
@@ -114,6 +116,7 @@ export function RangeCalendar({
     if (!selectionStart || (selectionStart && selectionEnd)) {
       setDraftStart(day);
       setDraftEnd(null);
+      setPreviewEnd(null);
       commitRange(null);
       return;
     }
@@ -123,6 +126,7 @@ export function RangeCalendar({
     if (compareLocalDay(e, s) < 0) [s, e] = [e, s];
     setDraftStart(s);
     setDraftEnd(e);
+    setPreviewEnd(null);
     commitRange({ start: s, end: e });
   };
 
@@ -169,14 +173,18 @@ export function RangeCalendar({
           month={anchor.month}
           selectionStart={selectionStart}
           selectionEnd={selectionEnd}
+          previewEnd={rangePreviewEnd}
           onDayClick={(d) => handleDayClick(d, anchor.year, anchor.month)}
+          onDayHover={setPreviewEnd}
         />
         <MonthPanel
           year={second.year}
           month={second.month}
           selectionStart={selectionStart}
           selectionEnd={selectionEnd}
+          previewEnd={rangePreviewEnd}
           onDayClick={(d) => handleDayClick(d, second.year, second.month)}
+          onDayHover={setPreviewEnd}
         />
       </div>
     </div>

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 
 import { ApplicationIcon } from '@/components/common/icons/ApplicationIcon';
@@ -51,14 +52,20 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
       )}
     >
       <div className="flex flex-col gap-5">
-        <Image
-          src={logoSrc}
-          alt="KKIUM"
-          width={logoSize.width}
-          height={logoSize.height}
-          priority
-          className={cn(collapsed ? 'size-[49px]' : 'h-[49px] w-[136px]')}
-        />
+        <Link
+          href="/"
+          aria-label="홈으로 이동"
+          className="w-fit rounded-sm focus-visible:shadow-focus-ring focus-visible:outline-none"
+        >
+          <Image
+            src={logoSrc}
+            alt="KKIUM"
+            width={logoSize.width}
+            height={logoSize.height}
+            priority
+            className={cn(collapsed ? 'size-[49px]' : 'h-[49px] w-[136px]')}
+          />
+        </Link>
 
         <nav aria-label="주요 메뉴" className="flex flex-col gap-2.5">
           {sidebarItems.map((item) => (

--- a/src/components/common/SingleMonthRangeCalendar.tsx
+++ b/src/components/common/SingleMonthRangeCalendar.tsx
@@ -68,6 +68,7 @@ export function SingleMonthRangeCalendar({
     if (defaultRange) return startOfLocalDay(defaultRange.end);
     return null;
   });
+  const [previewEnd, setPreviewEnd] = React.useState<Date | null>(null);
 
   const valueSyncKey =
     valueProp == null ? 'empty' : `${dayTime(valueProp.start)}-${dayTime(valueProp.end)}`;
@@ -105,6 +106,7 @@ export function SingleMonthRangeCalendar({
     if (!draftStart || (draftStart && draftEnd)) {
       setDraftStart(day);
       setDraftEnd(null);
+      setPreviewEnd(null);
       onChange?.(null);
       return;
     }
@@ -114,6 +116,7 @@ export function SingleMonthRangeCalendar({
     if (compareLocalDay(end, start) < 0) [start, end] = [end, start];
     setDraftStart(start);
     setDraftEnd(end);
+    setPreviewEnd(null);
     onChange?.({ start, end });
   };
 
@@ -153,7 +156,9 @@ export function SingleMonthRangeCalendar({
           month={anchor.month}
           selectionStart={draftStart}
           selectionEnd={draftEnd}
+          previewEnd={draftStart && !draftEnd ? previewEnd : null}
           onDayClick={handleDayClick}
+          onDayHover={setPreviewEnd}
         />
       </div>
     </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

#81 

## 📝작업 내용

- 경험 목록에서 전체 탭이 비어있는 경우, 다른 탭으로 이동해도 불필요한 로딩 대신 빈 상태가 유지되도록 개선했습니다.
- 데이트피커 날짜 선택 상태를 Figma 기준으로 개선했습니다.
  - hover 상태
  - 시작/종료일 선택 상태
  - range 영역 스타일
- PDF 자료 추가 드롭존에 파일이 올라왔을 때 배경색이 변경되도록 반영했습니다.
- 노션 페이지를 불러오는 중인 화면에 공통 `LoadingState`를 적용했습니다.
- 경험 추가 Step 2, 3, 4에서 필수 입력값이 모두 채워지지 않으면 다음 버튼이 비활성화되도록 수정했습니다.
- 경험 추가 단계 이동 시 스크롤이 상단으로 초기화되도록 처리했습니다.
- 핵심 경험 입력 영역에 `0자 / 1000자` 글자 수 표시를 추가하고, 1000자 도달 시 danger 상태가 보이도록 반영했습니다.
- 경험 상세 패널의 스크롤 구조를 정리해 패널 전체가 자연스럽게 스크롤되도록 개선했습니다.
- 경험 수정에서 날짜 표시 영역까지 클릭해 데이트피커를 열 수 있도록 클릭 영역을 확대했습니다.
- 경험 수정/추가 입력에서 팀원 수와 기여도 값을 숫자만 입력 가능하게 하고, 최대 100으로 제한했습니다.
- 노션 페이지 선택 항목에서 체크박스와 이미지 사이 간격을 Figma에 맞게 조정했습니다.
- 전체 앱 레이아웃에 공통 좌우 여백을 적용했습니다.
- 사이드바 로고 클릭 시 홈으로 이동하도록 연결했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
