### PR TITLE
[Feat] QA 반영

### DIFF
--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -6,6 +6,11 @@ import * as React from 'react';
 import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
 import { EditableTagGroup } from '@/app/(pages)/experience/_components/EditableTagGroup';
 import { getExperienceCategoryMeta } from '@/app/(pages)/experience/_utils/ExperienceCategory';
+import {
+  EXPERIENCE_FIELD_MAX_LENGTHS,
+  getExperienceFieldMaxLength,
+  limitExperienceFieldText,
+} from '@/app/(pages)/experience/_utils/experienceFieldLimits';
 import { formatExperiencePeriod } from '@/app/(pages)/experience/_utils/formatExperiencePeriod';
 import { sanitizeNumberText } from '@/app/(pages)/experience/_utils/sanitizeNumberText';
 import { DetailInput } from '@/components/common/DetailInput';
@@ -237,8 +242,9 @@ export function ExperienceDetailContent({
               <InlineTextArea
                 value={title}
                 ariaLabel="제목"
+                maxLength={EXPERIENCE_FIELD_MAX_LENGTHS.title}
                 className={cn('text-strong', isPage ? 'heading-2-bold' : 'title-1-bold')}
-                onChange={setTitle}
+                onChange={(value) => setTitle(limitExperienceFieldText('title', value))}
               />
             ) : (
               <h3 className={cn('text-strong', isPage ? 'heading-2-bold' : 'title-1-bold')}>
@@ -249,8 +255,11 @@ export function ExperienceDetailContent({
               <InlineTextArea
                 value={description}
                 ariaLabel="한 줄 설명"
+                maxLength={EXPERIENCE_FIELD_MAX_LENGTHS.description}
                 className={cn('text-quaternary', isPage ? 'body-1-bold' : 'body-3-regular')}
-                onChange={setDescription}
+                onChange={(value) =>
+                  setDescription(limitExperienceFieldText('description', value))
+                }
               />
             ) : (
               <p className={cn('text-quaternary', isPage ? 'body-1-bold' : 'body-3-regular')}>
@@ -364,6 +373,7 @@ export function ExperienceDetailContent({
                     <InlineTextArea
                       value={item.value}
                       ariaLabel={item.label}
+                      maxLength={getExperienceFieldMaxLength(item.name)}
                       className="text-secondary"
                       onChange={(value) => updateBasicDetail(item.name, value)}
                     />
@@ -473,7 +483,7 @@ function getSanitizedBasicDetailValue(key: BasicDetailKey, value: string) {
     return sanitizeNumberText(value, 100);
   }
 
-  return value;
+  return limitExperienceFieldText(key, value);
 }
 
 type EditableDetailInfoItem =
@@ -569,11 +579,13 @@ function getDetailInfoItems(
 function InlineTextArea({
   value,
   ariaLabel,
+  maxLength,
   className,
   onChange,
 }: {
   value: string;
   ariaLabel: string;
+  maxLength?: number;
   className?: string;
   onChange: (value: string) => void;
 }) {
@@ -593,12 +605,13 @@ function InlineTextArea({
       ref={textareaRef}
       value={value}
       aria-label={ariaLabel}
+      maxLength={maxLength}
       rows={1}
       className={cn(
         'block min-h-[1.48em] w-full min-w-0 resize-none overflow-hidden bg-transparent p-0 leading-[1.48] outline-none',
         className,
       )}
-      onChange={(event) => onChange(event.currentTarget.value)}
+      onChange={(event) => onChange(event.currentTarget.value.slice(0, maxLength))}
     />
   );
 }

--- a/src/app/(pages)/experience/_components/TagSet.tsx
+++ b/src/app/(pages)/experience/_components/TagSet.tsx
@@ -7,6 +7,7 @@ import { Tag } from '@/components/common/Tag';
 import { cn } from '@/lib/utils';
 
 const DEFAULT_MAX_TAG_COUNT = 4;
+const DEFAULT_MAX_TAG_LENGTH = 15;
 
 interface TagSetProps {
   label: string;
@@ -15,6 +16,7 @@ interface TagSetProps {
   className?: string;
   placeholder?: string;
   maxTagCount?: number;
+  maxTagLength?: number;
   onChange?: (tags: string[]) => void;
   onRequestClose?: () => void;
 }
@@ -26,6 +28,7 @@ export function TagSet({
   className,
   placeholder = `적용하고 싶은 ${label}을 작성해주세요`,
   maxTagCount = DEFAULT_MAX_TAG_COUNT,
+  maxTagLength = DEFAULT_MAX_TAG_LENGTH,
   onChange,
   onRequestClose,
 }: TagSetProps) {
@@ -118,10 +121,11 @@ export function TagSet({
           value={inputValue}
           aria-label={`${label} 태그 입력`}
           placeholder={placeholder}
+          maxLength={maxTagLength}
           className="h-full min-w-0 flex-1 bg-transparent px-5 py-4 body-2-bold text-strong outline-none placeholder:text-quaternary"
           onBlur={addTag}
           onChange={(event) => {
-            setInputValue(event.target.value);
+            setInputValue(event.target.value.slice(0, maxTagLength));
             setErrorMessage('');
           }}
           onKeyDown={handleInputKeyDown}

--- a/src/app/(pages)/experience/_utils/experienceFieldLimits.ts
+++ b/src/app/(pages)/experience/_utils/experienceFieldLimits.ts
@@ -11,7 +11,7 @@ export const EXPERIENCE_FIELD_MAX_LENGTHS = {
 
 type ExperienceFieldLimitKey = keyof typeof EXPERIENCE_FIELD_MAX_LENGTHS;
 
-export function getExperienceFieldMaxLength(fieldName: string) {
+export function getExperienceFieldMaxLength(fieldName: string): number | undefined {
   return EXPERIENCE_FIELD_MAX_LENGTHS[fieldName as ExperienceFieldLimitKey];
 }
 

--- a/src/app/(pages)/experience/_utils/experienceFieldLimits.ts
+++ b/src/app/(pages)/experience/_utils/experienceFieldLimits.ts
@@ -1,7 +1,7 @@
 export const EXPERIENCE_FIELD_MAX_LENGTHS = {
   title: 80,
   description: 100,
-  oneLineIntro: 200,
+  oneLineIntro: 100,
   company: 50,
   employmentStatus: 50,
   organizationName: 50,

--- a/src/app/(pages)/experience/_utils/experienceFieldLimits.ts
+++ b/src/app/(pages)/experience/_utils/experienceFieldLimits.ts
@@ -1,0 +1,26 @@
+export const EXPERIENCE_FIELD_MAX_LENGTHS = {
+  title: 80,
+  description: 100,
+  oneLineIntro: 200,
+  company: 50,
+  employmentStatus: 50,
+  organizationName: 50,
+  role: 50,
+  name: 80,
+} as const;
+
+type ExperienceFieldLimitKey = keyof typeof EXPERIENCE_FIELD_MAX_LENGTHS;
+
+export function getExperienceFieldMaxLength(fieldName: string) {
+  return EXPERIENCE_FIELD_MAX_LENGTHS[fieldName as ExperienceFieldLimitKey];
+}
+
+export function limitExperienceFieldText(fieldName: string, value: string) {
+  const maxLength = getExperienceFieldMaxLength(fieldName);
+
+  if (!maxLength) {
+    return value;
+  }
+
+  return value.slice(0, maxLength);
+}

--- a/src/app/(pages)/experience/add/_components/ExperienceAddBasicInfoStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddBasicInfoStep.tsx
@@ -16,6 +16,10 @@ import {
   EXPERIENCE_TYPE_OPTIONS,
 } from '@/app/(pages)/experience/add/_constants/experienceTypeOptions';
 import type { ExperienceAddBasicInfoForm } from '@/app/(pages)/experience/add/_types/experienceAddForm';
+import {
+  getExperienceFieldMaxLength,
+  limitExperienceFieldText,
+} from '@/app/(pages)/experience/_utils/experienceFieldLimits';
 import { sanitizeNumberText } from '@/app/(pages)/experience/_utils/sanitizeNumberText';
 import { type CalendarDateRange, RangeCalendar } from '@/components/common/RangeCalendar';
 import { TextField } from '@/components/common/TextField';
@@ -119,6 +123,7 @@ export function ExperienceAddBasicInfoStep({ value, onChange }: ExperienceAddBas
                           variant="input"
                           placeholder={field.placeholder}
                           value={value[field.name]}
+                          maxLength={getExperienceFieldMaxLength(field.name)}
                           description={false}
                           onChange={handleInputChange(field.name)}
                         />
@@ -131,6 +136,7 @@ export function ExperienceAddBasicInfoStep({ value, onChange }: ExperienceAddBas
                       variant="input"
                       placeholder={fieldGroup.fields[0].placeholder}
                       value={value[fieldGroup.fields[0].name]}
+                      maxLength={getExperienceFieldMaxLength(fieldGroup.fields[0].name)}
                       description={false}
                       onChange={handleInputChange(fieldGroup.fields[0].name)}
                     />
@@ -153,7 +159,7 @@ function getSanitizedBasicInfoValue(
     return sanitizeNumberText(value, 100);
   }
 
-  return value;
+  return limitExperienceFieldText(fieldName, value);
 }
 
 const DATE_RANGE_PLACEHOLDER = '0000년 00월 00일 ~ 0000년 00월 00일';

--- a/src/app/(pages)/experience/add/_components/ExperienceAddResultStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddResultStep.tsx
@@ -9,6 +9,10 @@ import type {
   ExperienceAddResultInfoForm,
 } from '@/app/(pages)/experience/add/_types/experienceAddForm';
 import { EditableTagGroup } from '@/app/(pages)/experience/_components/EditableTagGroup';
+import {
+  getExperienceFieldMaxLength,
+  limitExperienceFieldText,
+} from '@/app/(pages)/experience/_utils/experienceFieldLimits';
 import { TextField } from '@/components/common/TextField';
 import { cn } from '@/lib/utils';
 
@@ -69,12 +73,13 @@ export function ExperienceAddResultStep({
         {BASIC_RESULT_FIELDS.map((field) => (
           <ResultField
             key={field.name}
+            fieldName={field.name}
             label={field.label}
             value={basicInfo[field.name]}
             onChange={(fieldValue) =>
               onBasicInfoChange({
                 ...basicInfo,
-                [field.name]: fieldValue,
+                [field.name]: limitExperienceFieldText(field.name, fieldValue),
               })
             }
           />
@@ -159,10 +164,12 @@ function ResultSection({
 }
 
 function ResultField({
+  fieldName,
   label,
   value,
   onChange,
 }: {
+  fieldName: (typeof BASIC_RESULT_FIELDS)[number]['name'];
   label: string;
   value: string;
   onChange: (value: string) => void;
@@ -172,6 +179,7 @@ function ResultField({
       <span className="body-2-regular text-strong">{label}</span>
       <TextField
         value={value}
+        maxLength={getExperienceFieldMaxLength(fieldName)}
         description={false}
         onChange={(event) => onChange(event.currentTarget.value)}
       />

--- a/src/app/(pages)/experience/add/_components/ExperienceAddResultStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddResultStep.tsx
@@ -29,7 +29,7 @@ interface ExperienceAddResultStepProps {
 
 const BASIC_RESULT_FIELDS = [
   { name: 'title', label: '제목' },
-  { name: 'oneLineIntro', label: '한 줄 소개' },
+  { name: 'oneLineIntro', label: '한 줄 설명' },
 ] as const;
 
 const CORE_RESULT_FIELDS = [

--- a/src/app/(pages)/experience/add/_constants/experienceResultData.ts
+++ b/src/app/(pages)/experience/add/_constants/experienceResultData.ts
@@ -4,7 +4,7 @@ export const RESULT_BASIC_FIELDS = [
     value: '브랜드 마케팅 전략을 수립하고 실행하여 전환율 20% 향상을 달성한 프로젝트',
   },
   {
-    label: '한 줄 소개',
+    label: '한 줄 설명',
     value: '브랜드 마케팅 전략을 수립하고 실행하여 전환율 20% 향상을 달성한 프로젝트',
   },
 ] as const;

--- a/src/components/common/SearchBar.tsx
+++ b/src/components/common/SearchBar.tsx
@@ -70,7 +70,7 @@ export function SearchBar({
         className,
       )}
     >
-      {showSearchIcon && <SearchIcon className="size-8 shrink-0 p-1 text-tertiary" />}
+      {showSearchIcon && <SearchIcon className="size-8 shrink-0 p-1 text-quaternary" />}
       <input
         ref={inputRef}
         type="text"
@@ -81,7 +81,7 @@ export function SearchBar({
         placeholder={placeholder}
         disabled={disabled}
         readOnly={readOnly}
-        className="h-8 min-w-0 flex-1 bg-transparent body-1-bold text-tertiary outline-none placeholder:text-tertiary"
+        className="h-8 min-w-0 flex-1 bg-transparent body-1-bold text-tertiary outline-none placeholder:text-quaternary"
         {...props}
       />
       {canClear && (

--- a/src/stories/SearchBar.stories.tsx
+++ b/src/stories/SearchBar.stories.tsx
@@ -25,15 +25,8 @@ export const StateMatrix: Story = {
   render: () => (
     <div className="flex w-fit flex-col gap-7 bg-background-default p-6">
       <SearchBar placeholder="경험을 검색해주세요" />
-      <SearchBar
-        placeholder="검색"
-        className="shadow-[0_0_0_3px_var(--color-mint-main)]"
-      />
-      <SearchBar
-        value="타이핑중"
-        onChange={() => {}}
-        className="shadow-[0_0_0_3px_var(--color-mint-main)]"
-      />
+      <SearchBar placeholder="검색" />
+      <SearchBar value="타이핑중" onChange={() => {}} />
     </div>
   ),
 };


### PR DESCRIPTION
## #️⃣연관된 이슈

#104 

## 📝작업 내용

- 태그 입력 길이를 최대 15자로 제한했습니다.
  - 입력/붙여넣기 모두 15자까지만 반영되도록 처리했습니다.
- 경험 기본정보 필드별 입력 길이 제한을 추가했습니다.
  - 제목: 80자
  - 한 줄 설명: 100자
  - 회사/기관/단체명: 50자
  - 고용 형태: 50자
  - 교육기관명: 50자
  - 수강명: 80자
  - 내 역할: 50자
- 입력 길이 제한값을 `experienceFieldLimits` 유틸로 분리해 Step 2, Step 4, 경험 수정 화면에서 공통으로 사용하도록 정리했습니다.
- SearchBar 컴포넌트를 Figma 변경사항에 맞게 수정했습니다.
- SearchBar Storybook 예시도 변경된 디자인 기준으로 정리했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added character length limits to text input fields throughout experience entry forms, including title, description, company, role, employment status, and organization name.
  * Introduced maximum tag length constraint for tag input fields.

* **Style**
  * Updated SearchBar component icon and placeholder text color styling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-KKIUM/KKIUM-FE/pull/106?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->