### PR TITLE
[Feat] 모바일 랜딩 카카오톡 공유 기능 구현

### DIFF
--- a/src/app/_components/MobileLandingResult.tsx
+++ b/src/app/_components/MobileLandingResult.tsx
@@ -3,6 +3,9 @@ import Image from 'next/image';
 import { NameCompatibilityAnimation } from '@/app/_components/NameCompatibilityAnimation';
 import { Button } from '@/components/ui/button';
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '');
+const KKIUM_DESCRIPTION = '당신의 경험이 제자리를 찾는 방식';
+
 interface MobileLandingResultProps {
   name: string;
   company: string;
@@ -10,6 +13,36 @@ interface MobileLandingResultProps {
 }
 
 export function MobileLandingResult({ name, company, score }: MobileLandingResultProps) {
+  const handleKakaoShare = () => {
+    const kakao = window.Kakao;
+
+    if (!kakao?.isInitialized() || !SITE_URL) {
+      return;
+    }
+
+    kakao.Share.sendDefault({
+      objectType: 'feed',
+      content: {
+        title: 'KKIUM',
+        description: KKIUM_DESCRIPTION,
+        imageUrl: `${SITE_URL}/opengraph-image.png`,
+        link: {
+          mobileWebUrl: SITE_URL,
+          webUrl: SITE_URL,
+        },
+      },
+      buttons: [
+        {
+          title: 'KKIUM 보러가기',
+          link: {
+            mobileWebUrl: SITE_URL,
+            webUrl: SITE_URL,
+          },
+        },
+      ],
+    });
+  };
+
   return (
     <section className="relative flex min-h-dvh w-full overflow-x-hidden overflow-y-auto bg-[linear-gradient(180deg,var(--color-mint-300)_0%,var(--color-mint-50)_100%)]">
       <div aria-hidden="true" className="absolute inset-0 overflow-hidden">
@@ -74,6 +107,8 @@ export function MobileLandingResult({ name, company, score }: MobileLandingResul
                 type="button"
                 variant="secondary"
                 className="h-[52px] w-full bg-[#FEE500] text-black/85 hover:bg-[#FEE500] hover:brightness-95"
+                disabled={!SITE_URL}
+                onClick={handleKakaoShare}
               >
                 <span className="inline-flex items-center gap-2">
                   <Image

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import { AppShell } from '@/components/common/AppShell';
 import { GoogleAnalytics } from '@/components/common/GoogleAnalytics';
+import { KakaoSdkScript } from '@/components/common/KakaoSdkScript';
 import { nanumSquare } from './fonts';
 import { Providers } from './providers';
 import './globals.css';
@@ -30,6 +31,7 @@ export default function RootLayout({
     <html lang="ko" className={`${nanumSquare.className} h-full antialiased`}>
       <body className="min-h-full">
         <GoogleAnalytics />
+        <KakaoSdkScript />
         <Providers>
           <AppShell>{children}</AppShell>
         </Providers>

--- a/src/components/common/KakaoSdkScript.tsx
+++ b/src/components/common/KakaoSdkScript.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import Script from 'next/script';
+
+const KAKAO_JAVASCRIPT_KEY = process.env.NEXT_PUBLIC_KAKAO_JAVASCRIPT_KEY?.trim();
+const KAKAO_SDK_URL = 'https://t1.kakaocdn.net/kakao_js_sdk/2.8.1/kakao.min.js';
+const KAKAO_SDK_INTEGRITY =
+  'sha384-OL+ylM/iuPLtW5U3XcvLSGhE8JzReKDank5InqlHGWPhb4140/yrBw0bg0y7+C9J';
+
+export function KakaoSdkScript() {
+  if (!KAKAO_JAVASCRIPT_KEY) {
+    return null;
+  }
+
+  return (
+    <Script
+      id="kakao-javascript-sdk"
+      src={KAKAO_SDK_URL}
+      strategy="afterInteractive"
+      integrity={KAKAO_SDK_INTEGRITY}
+      crossOrigin="anonymous"
+      onReady={() => {
+        const kakao = window.Kakao;
+
+        if (!kakao || kakao.isInitialized()) {
+          return;
+        }
+
+        kakao.init(KAKAO_JAVASCRIPT_KEY);
+      }}
+    />
+  );
+}

--- a/src/types/kakao.d.ts
+++ b/src/types/kakao.d.ts
@@ -1,0 +1,32 @@
+export {};
+
+type KakaoLink = {
+  mobileWebUrl?: string;
+  webUrl?: string;
+};
+
+type KakaoShareDefaultTemplate = {
+  objectType: 'feed';
+  content: {
+    title: string;
+    description?: string;
+    imageUrl?: string;
+    link: KakaoLink;
+  };
+  buttons?: Array<{
+    title: string;
+    link: KakaoLink;
+  }>;
+};
+
+declare global {
+  interface Window {
+    Kakao?: {
+      init: (javascriptKey: string) => void;
+      isInitialized: () => boolean;
+      Share: {
+        sendDefault: (template: KakaoShareDefaultTemplate) => void;
+      };
+    };
+  }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#120 

## 📝작업 내용

- 카카오 JavaScript SDK를 로드하고 초기화하는 `KakaoSdkScript` 컴포넌트를 추가했습니다.
- `window.Kakao` 타입 선언을 추가했습니다.
- 루트 레이아웃에 카카오 SDK 스크립트를 연결했습니다.
- 모바일 랜딩 결과 페이지의 `카카오톡으로 KKIUM 공유하기` 버튼에 카카오톡 공유 기능을 연결했습니다.
- 공유 메시지는 궁합 결과가 아닌 KKIUM 서비스 링크를 공유하도록 구성했습니다.
  - 제목: `KKIUM`
  - 설명: `당신의 경험이 제자리를 찾는 방식`
  - 이미지: `/opengraph-image.png`
  - 링크: `NEXT_PUBLIC_SITE_URL`

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Kakao messaging integration now available on mobile results pages. Users can share content directly through Kakao, including images, links, titles, and descriptions. The integration ensures seamless sharing within the Kakao platform while maintaining full content context for recipients.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-KKIUM/KKIUM-FE/pull/121?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->