### PR TITLE
[Fix] OG 이미지 URL 수정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,7 @@ import { nanumSquare } from './fonts';
 import { Providers } from './providers';
 import './globals.css';
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ?? 'https://www.kkium.com';
+const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.kkium.com').replace(/\/$/, '');
 
 export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,7 +6,10 @@ import { nanumSquare } from './fonts';
 import { Providers } from './providers';
 import './globals.css';
 
+const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL?.replace(/\/$/, '') ?? 'https://www.kkium.com';
+
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: {
     default: 'KKIUM',
     template: '%s | KKIUM',


### PR DESCRIPTION
## #️⃣연관된 이슈

#123 

## 📝작업 내용

- Next.js root metadata에 `metadataBase`를 추가했습니다.
- `NEXT_PUBLIC_SITE_URL`을 기준으로 OG/Twitter 이미지 URL이 배포 도메인 기준으로 생성되도록 수정했습니다.
- 환경변수가 없는 경우에도 `https://www.kkium.com`을 fallback으로 사용하도록 처리했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)