### PR TITLE
[Feat] 프로필 API 연동

### DIFF
--- a/src/app/api/user/index.ts
+++ b/src/app/api/user/index.ts
@@ -1,0 +1,23 @@
+import { api } from '@/app/api/client';
+
+import {
+  updateProfileColorRequestSchema,
+  userProfileResponseSchema,
+  type UpdateProfileColorRequest,
+} from './types';
+
+export async function getUserProfile() {
+  const response = await api.get<unknown>('/api/v1/users/me/profile');
+
+  return userProfileResponseSchema.parse(response);
+}
+
+export async function updateUserProfileColor(request: UpdateProfileColorRequest) {
+  const parsedRequest = updateProfileColorRequestSchema.parse(request);
+
+  await api.patch<unknown>('/api/v1/users/me/profile-color', parsedRequest);
+}
+
+export async function deleteUserAccount() {
+  await api.delete<unknown>('/api/v1/users/me/delete');
+}

--- a/src/app/api/user/types.ts
+++ b/src/app/api/user/types.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const userProfileResponseSchema = z.object({
   name: z.string(),
   email: z.string(),
-  illustrateId: z.number().int().min(0).max(4),
+  illustrateId: z.number().int().min(0).max(4).nullable(),
 });
 
 export const updateProfileColorRequestSchema = z.object({

--- a/src/app/api/user/types.ts
+++ b/src/app/api/user/types.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const userProfileResponseSchema = z.object({
+  name: z.string(),
+  email: z.string(),
+  illustrateId: z.number().int().min(0).max(4),
+});
+
+export const updateProfileColorRequestSchema = z.object({
+  illustrateId: z.number().int().min(0).max(4),
+});
+
+export type UserProfileResponse = z.infer<typeof userProfileResponseSchema>;
+export type UpdateProfileColorRequest = z.infer<typeof updateProfileColorRequestSchema>;

--- a/src/app/api/user/types.ts
+++ b/src/app/api/user/types.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 
 export const userProfileResponseSchema = z.object({
   name: z.string(),
-  email: z.string(),
+  email: z.email().nullable(),
   illustrateId: z.number().int().min(0).max(4).nullable(),
 });
 

--- a/src/components/common/AccountDialog.tsx
+++ b/src/components/common/AccountDialog.tsx
@@ -15,6 +15,10 @@ interface AccountDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   name?: string;
+  illustrateId?: number | null;
+  isProfileUpdating?: boolean;
+  isAccountDeleting?: boolean;
+  onProfileColorChange?: (illustrateId: number) => Promise<void> | void;
   onDelete?: () => Promise<void> | void;
 }
 
@@ -39,19 +43,31 @@ export function AccountDialog({
   open,
   onOpenChange,
   name = 'KKIUM',
+  illustrateId,
+  isProfileUpdating = false,
+  isAccountDeleting = false,
+  onProfileColorChange,
   onDelete,
 }: AccountDialogProps) {
   const [view, setView] = React.useState<'account' | 'profile' | 'delete'>('account');
-  const [profileSrc, setProfileSrc] = React.useState<string>(defaultProfileOptions[0].src);
-  const [selectedProfileSrc, setSelectedProfileSrc] = React.useState<string>(profileSrc);
+  const currentProfileOption = getProfileOptionByIllustrateId(illustrateId);
+  const [selectedIllustrateId, setSelectedIllustrateId] = React.useState(
+    currentProfileOption.illustrateId,
+  );
   const [deleteConfirmText, setDeleteConfirmText] = React.useState('');
-  const hasProfileChange = selectedProfileSrc !== profileSrc;
-  const canDeleteAccount = deleteConfirmText === DELETE_CONFIRM_TEXT;
+  const hasProfileChange = selectedIllustrateId !== currentProfileOption.illustrateId;
+  const canDeleteAccount = deleteConfirmText === DELETE_CONFIRM_TEXT && !isAccountDeleting;
+
+  React.useEffect(() => {
+    if (!open) return;
+
+    setSelectedIllustrateId(currentProfileOption.illustrateId);
+  }, [currentProfileOption.illustrateId, open]);
 
   const handleOpenChange = (nextOpen: boolean) => {
     if (!nextOpen) {
       setView('account');
-      setSelectedProfileSrc(profileSrc);
+      setSelectedIllustrateId(currentProfileOption.illustrateId);
       setDeleteConfirmText('');
     }
 
@@ -59,17 +75,19 @@ export function AccountDialog({
   };
 
   const openProfileView = () => {
-    setSelectedProfileSrc(profileSrc);
+    setSelectedIllustrateId(currentProfileOption.illustrateId);
     setView('profile');
   };
 
   const closeProfileView = () => {
-    setSelectedProfileSrc(profileSrc);
+    setSelectedIllustrateId(currentProfileOption.illustrateId);
     setView('account');
   };
 
-  const saveProfile = () => {
-    setProfileSrc(selectedProfileSrc);
+  const saveProfile = async () => {
+    if (!hasProfileChange || isProfileUpdating) return;
+
+    await onProfileColorChange?.(selectedIllustrateId);
     setView('account');
   };
 
@@ -103,7 +121,7 @@ export function AccountDialog({
         <>
           <AccountSummary
             name={name}
-            profileSrc={profileSrc}
+            profileSrc={currentProfileOption.src}
             onProfileChangeClick={openProfileView}
           />
 
@@ -122,6 +140,7 @@ export function AccountDialog({
             <DeleteAccountPanel
               value={deleteConfirmText}
               canDelete={canDeleteAccount}
+              isDeleting={isAccountDeleting}
               onChange={setDeleteConfirmText}
               onCancel={closeDeleteView}
               onDelete={handleDeleteAccount}
@@ -148,7 +167,7 @@ export function AccountDialog({
               </header>
 
               <div className="flex h-[116px] items-center gap-6">
-                <ProfileImage src={profileSrc} size={114} priority />
+                <ProfileImage src={currentProfileOption.src} size={114} priority />
                 <p className="text-[22px] leading-[1.48] font-extrabold text-primary">{name}</p>
               </div>
             </div>
@@ -161,11 +180,11 @@ export function AccountDialog({
               </h2>
               <div className="flex gap-8">
                 {defaultProfileOptions.map((option) => {
-                  const selected = selectedProfileSrc === option.src;
+                  const selected = selectedIllustrateId === option.illustrateId;
 
                   return (
                     <button
-                      key={option.src}
+                      key={option.illustrateId}
                       type="button"
                       aria-label={option.label}
                       aria-pressed={selected}
@@ -173,7 +192,7 @@ export function AccountDialog({
                         'size-[88px] cursor-pointer overflow-hidden rounded-full transition-opacity focus-visible:shadow-focus-ring focus-visible:outline-none',
                         hasProfileChange && !selected && 'opacity-40',
                       )}
-                      onClick={() => setSelectedProfileSrc(option.src)}
+                      onClick={() => setSelectedIllustrateId(option.illustrateId)}
                     >
                       <Image
                         src={option.src}
@@ -189,7 +208,12 @@ export function AccountDialog({
             </section>
           </div>
 
-          <Button type="button" className="w-full" disabled={!hasProfileChange} onClick={saveProfile}>
+          <Button
+            type="button"
+            className="w-full"
+            disabled={!hasProfileChange || isProfileUpdating}
+            onClick={() => void saveProfile()}
+          >
             프로필 변경하기
           </Button>
         </>
@@ -244,12 +268,14 @@ function AccountSummary({
 function DeleteAccountPanel({
   value,
   canDelete,
+  isDeleting,
   onChange,
   onCancel,
   onDelete,
 }: {
   value: string;
   canDelete: boolean;
+  isDeleting: boolean;
   onChange: (value: string) => void;
   onCancel: () => void;
   onDelete: () => Promise<void> | void;
@@ -273,7 +299,7 @@ function DeleteAccountPanel({
           <Button
             type="button"
             variant="danger"
-            disabled={!canDelete}
+            disabled={!canDelete || isDeleting}
             className="w-[87px]"
             onClick={() => void onDelete()}
           >

--- a/src/components/common/AccountDialog.tsx
+++ b/src/components/common/AccountDialog.tsx
@@ -20,13 +20,20 @@ interface AccountDialogProps {
 
 const DELETE_CONFIRM_TEXT = '계정을 삭제합니다';
 
-const defaultProfileOptions = [
-  { src: '/profile-default-1.svg', label: '기본 프로필 이미지 1' },
-  { src: '/profile-default-2.svg', label: '기본 프로필 이미지 2' },
-  { src: '/profile-default-3.svg', label: '기본 프로필 이미지 3' },
-  { src: '/profile-default-4.svg', label: '기본 프로필 이미지 4' },
-  { src: '/profile-default-5.svg', label: '기본 프로필 이미지 5' },
+export const defaultProfileOptions = [
+  { illustrateId: 0, src: '/profile-default-1.svg', label: '기본 프로필 이미지 1' },
+  { illustrateId: 1, src: '/profile-default-2.svg', label: '기본 프로필 이미지 2' },
+  { illustrateId: 2, src: '/profile-default-3.svg', label: '기본 프로필 이미지 3' },
+  { illustrateId: 3, src: '/profile-default-4.svg', label: '기본 프로필 이미지 4' },
+  { illustrateId: 4, src: '/profile-default-5.svg', label: '기본 프로필 이미지 5' },
 ] as const;
+
+export function getProfileOptionByIllustrateId(illustrateId: number | null | undefined) {
+  return (
+    defaultProfileOptions.find((option) => option.illustrateId === illustrateId) ??
+    defaultProfileOptions[0]
+  );
+}
 
 export function AccountDialog({
   open,

--- a/src/components/common/AccountDialog.tsx
+++ b/src/components/common/AccountDialog.tsx
@@ -54,6 +54,7 @@ export function AccountDialog({
   const [selectedIllustrateId, setSelectedIllustrateId] = React.useState(
     currentProfileOption.illustrateId,
   );
+  const previewProfileOption = getProfileOptionByIllustrateId(selectedIllustrateId);
   const [deleteConfirmText, setDeleteConfirmText] = React.useState('');
   const hasProfileChange = selectedIllustrateId !== currentProfileOption.illustrateId;
   const canDeleteAccount = deleteConfirmText === DELETE_CONFIRM_TEXT && !isAccountDeleting;
@@ -171,7 +172,7 @@ export function AccountDialog({
               </header>
 
               <div className="flex h-[116px] items-center gap-6">
-                <ProfileImage src={currentProfileOption.src} size={114} priority />
+                <ProfileImage src={previewProfileOption.src} size={114} priority />
                 <p className="text-[22px] leading-[1.48] font-extrabold text-primary">{name}</p>
               </div>
             </div>

--- a/src/components/common/AccountDialog.tsx
+++ b/src/components/common/AccountDialog.tsx
@@ -87,8 +87,12 @@ export function AccountDialog({
   const saveProfile = async () => {
     if (!hasProfileChange || isProfileUpdating) return;
 
-    await onProfileColorChange?.(selectedIllustrateId);
-    setView('account');
+    try {
+      await onProfileColorChange?.(selectedIllustrateId);
+      setView('account');
+    } catch (error) {
+      console.error('Failed to update profile color:', error);
+    }
   };
 
   const openDeleteView = () => {

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -6,7 +6,10 @@ import * as React from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 
 import { clearAccessTokenFromSession } from '@/app/_utils/authFetch';
-import { AccountDialog } from '@/components/common/AccountDialog';
+import {
+  AccountDialog,
+  getProfileOptionByIllustrateId,
+} from '@/components/common/AccountDialog';
 import { ApplicationIcon } from '@/components/common/icons/ApplicationIcon';
 import { ExperienceIcon } from '@/components/common/icons/ExperienceIcon';
 import { HomeIcon } from '@/components/common/icons/HomeIcon';
@@ -14,6 +17,11 @@ import { LogoutIcon } from '@/components/common/icons/LogoutIcon';
 import { SettingsIcon } from '@/components/common/icons/SettingsIcon';
 import { SidebarMenuItem, type SidebarMenuItemIcon } from '@/components/common/SidebarMenuItem';
 import { SidebarProfile } from '@/components/common/SidebarProfile';
+import {
+  useDeleteUserAccount,
+  useUpdateUserProfileColor,
+  useUserProfile,
+} from '@/hooks/user/useUserProfile';
 import { cn } from '@/lib/utils';
 
 export type SidebarItem = {
@@ -51,6 +59,11 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
   const profileMenuRef = React.useRef<HTMLDivElement>(null);
   const [isProfileMenuOpen, setIsProfileMenuOpen] = React.useState(false);
   const [isAccountDialogOpen, setIsAccountDialogOpen] = React.useState(false);
+  const userProfileQuery = useUserProfile();
+  const updateProfileColorMutation = useUpdateUserProfileColor();
+  const deleteUserAccountMutation = useDeleteUserAccount();
+  const profileOption = getProfileOptionByIllustrateId(userProfileQuery.data?.illustrateId);
+  const profileName = userProfileQuery.data?.name ?? 'KKIUM';
   const logoSrc = collapsed ? '/logo-light-mark.svg' : '/logo-light.svg';
   const logoSize = collapsed ? { width: 49, height: 49 } : { width: 136, height: 49 };
 
@@ -90,6 +103,18 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
   const handleLogoutClick = () => {
     clearAccessTokenFromSession();
     setIsProfileMenuOpen(false);
+    router.replace('/login');
+  };
+
+  const handleProfileColorChange = async (illustrateId: number) => {
+    await updateProfileColorMutation.mutateAsync({ illustrateId });
+  };
+
+  const handleDeleteAccount = async () => {
+    await deleteUserAccountMutation.mutateAsync();
+    clearAccessTokenFromSession();
+    setIsProfileMenuOpen(false);
+    setIsAccountDialogOpen(false);
     router.replace('/login');
   };
 
@@ -145,11 +170,22 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
         <SidebarProfile
           collapsed={collapsed}
           active={isProfileMenuOpen}
+          name={profileName}
+          profileSrc={profileOption.src}
           ariaControls={profileMenuId}
           ariaExpanded={isProfileMenuOpen}
           onClick={handleProfileClick}
         />
-        <AccountDialog open={isAccountDialogOpen} onOpenChange={setIsAccountDialogOpen} />
+        <AccountDialog
+          open={isAccountDialogOpen}
+          onOpenChange={setIsAccountDialogOpen}
+          name={profileName}
+          illustrateId={userProfileQuery.data?.illustrateId}
+          isProfileUpdating={updateProfileColorMutation.isPending}
+          isAccountDeleting={deleteUserAccountMutation.isPending}
+          onProfileColorChange={handleProfileColorChange}
+          onDelete={handleDeleteAccount}
+        />
       </div>
     </aside>
   );

--- a/src/components/common/SidebarProfile.tsx
+++ b/src/components/common/SidebarProfile.tsx
@@ -7,6 +7,7 @@ interface SidebarProfileProps {
   collapsed?: boolean;
   active?: boolean;
   name?: string;
+  profileSrc?: string;
   ariaControls?: string;
   ariaExpanded?: boolean;
   onClick?: MouseEventHandler<HTMLButtonElement>;
@@ -16,6 +17,7 @@ export function SidebarProfile({
   collapsed = false,
   active = false,
   name = 'KKIUM',
+  profileSrc = '/profile.svg',
   ariaControls,
   ariaExpanded,
   onClick,
@@ -34,7 +36,7 @@ export function SidebarProfile({
       )}
       onClick={onClick}
     >
-      <Image src="/profile.svg" alt="" width={32} height={32} className="size-8 shrink-0" />
+      <Image src={profileSrc} alt="" width={32} height={32} className="size-8 shrink-0" />
       <span className={cn('min-w-0 flex-1 truncate body-3-bold text-primary', collapsed && 'sr-only')}>
         {name}
       </span>

--- a/src/hooks/user/useUserProfile.ts
+++ b/src/hooks/user/useUserProfile.ts
@@ -49,7 +49,7 @@ export function useDeleteUserAccount() {
   return useMutation({
     mutationFn: deleteUserAccount,
     onSuccess: () => {
-      queryClient.removeQueries({ queryKey: userProfileQueryKeys.all });
+      queryClient.clear();
     },
   });
 }

--- a/src/hooks/user/useUserProfile.ts
+++ b/src/hooks/user/useUserProfile.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import {
+  deleteUserAccount,
+  getUserProfile,
+  updateUserProfileColor,
+} from '@/app/api/user';
+import type {
+  UpdateProfileColorRequest,
+  UserProfileResponse,
+} from '@/app/api/user/types';
+
+export const userProfileQueryKeys = {
+  all: ['user-profile'] as const,
+  me: () => [...userProfileQueryKeys.all, 'me'] as const,
+};
+
+export function useUserProfile(enabled = true) {
+  return useQuery({
+    queryKey: userProfileQueryKeys.me(),
+    queryFn: getUserProfile,
+    enabled,
+  });
+}
+
+export function useUpdateUserProfileColor() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (request: UpdateProfileColorRequest) => updateUserProfileColor(request),
+    onSuccess: (_, request) => {
+      queryClient.setQueryData<UserProfileResponse>(
+        userProfileQueryKeys.me(),
+        (profile) => (profile ? { ...profile, illustrateId: request.illustrateId } : profile),
+      );
+      void queryClient.invalidateQueries({
+        queryKey: userProfileQueryKeys.me(),
+        refetchType: 'active',
+      });
+    },
+  });
+}
+
+export function useDeleteUserAccount() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteUserAccount,
+    onSuccess: () => {
+      queryClient.removeQueries({ queryKey: userProfileQueryKeys.all });
+    },
+  });
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#126 

## 📝작업 내용

- 사용자 프로필 조회/수정/삭제 API 클라이언트 추가
- 사용자 프로필 React Query 훅 추가
- 사이드바 프로필 이름과 이미지를 API 데이터 기반으로 표시
- 계정 모달의 프로필 이미지 선택 상태를 `illustrateId` 기반으로 변경
- 프로필 이미지 변경 시 API 호출 및 캐시 갱신 처리
- 계정 삭제 성공 시 세션 토큰 제거 후 로그인 페이지로 이동 처리

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added ability to update and customize your profile illustration from account settings.
  * Added account deletion functionality accessible from the account settings dialog.
  * Profile illustrations now display properly with multiple customizable options.
  * User profile data is now properly fetched and managed throughout the app.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/team-KKIUM/KKIUM-FE/pull/130?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->