### PR TITLE
[Refactor] 경험 도메인 컴포넌트 및 로직 구조 개선

### DIFF
--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -2,27 +2,20 @@
 
 import * as React from 'react';
 
-import {
-  ExperienceCardGrid,
-  type ExperienceItem,
-} from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+import { ExperienceCardGrid } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
 import type { ExperienceCategory } from '@/app/(pages)/experience/_components/ExperienceCategoryTab';
 import { ExperienceCategoryTabs } from '@/app/(pages)/experience/_components/ExperienceCategoryTabs';
 import { ExperienceDetailPanel } from '@/app/(pages)/experience/_components/ExperienceDetailPanel';
 import { useExperienceBoardActions } from '@/app/(pages)/experience/_hooks/useExperienceBoardActions';
 import { useExperienceBoardInfiniteScroll } from '@/app/(pages)/experience/_hooks/useExperienceBoardInfiniteScroll';
 import { useExperienceBoardListState } from '@/app/(pages)/experience/_hooks/useExperienceBoardListState';
+import { useExperienceBoardOrder } from '@/app/(pages)/experience/_hooks/useExperienceBoardOrder';
 import { useExperienceBoardReorder } from '@/app/(pages)/experience/_hooks/useExperienceBoardReorder';
 import { useExperienceBoardSelection } from '@/app/(pages)/experience/_hooks/useExperienceBoardSelection';
 import {
   mapExperienceCardToItem,
   mapExperienceDetailToItem,
 } from '@/app/(pages)/experience/_utils/mapExperienceResponse';
-import {
-  areExperienceOrderMapsEqual,
-  createExperienceOrderMap,
-  syncExperienceOrderMap,
-} from '@/app/(pages)/experience/_utils/experienceOrder';
 import type { PieceType } from '@/app/api/experience/types';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { EmptyState } from '@/components/common/EmptyState';
@@ -80,9 +73,11 @@ export function ExperienceBoard({
     () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
     [data],
   );
-  const [experienceOrderMap, setExperienceOrderMap] = React.useState(() =>
-    createExperienceOrderMap(experiences),
-  );
+  const { experienceOrderMap, setExperienceOrderMap, filteredExperiences } =
+    useExperienceBoardOrder({
+      experiences,
+      selectedCategory,
+    });
   const selectedExperienceNumericId = selectedExperienceId ? Number(selectedExperienceId) : null;
   const {
     data: selectedExperienceDetail,
@@ -106,30 +101,6 @@ export function ExperienceBoard({
     applyInitialSelectedExperience(experiences);
   }, [applyInitialSelectedExperience, experiences]);
 
-  React.useEffect(() => {
-    setExperienceOrderMap((currentOrderMap) => {
-      const nextOrderMap = syncExperienceOrderMap(currentOrderMap, experiences, selectedCategory);
-
-      if (areExperienceOrderMapsEqual(currentOrderMap, nextOrderMap)) {
-        return currentOrderMap;
-      }
-
-      return nextOrderMap;
-    });
-  }, [experiences, selectedCategory]);
-
-  const experienceMap = React.useMemo(
-    () => new Map(experiences.map((experience) => [experience.id, experience])),
-    [experiences],
-  );
-
-  const filteredExperiences = React.useMemo(
-    () =>
-      experienceOrderMap[selectedCategory]
-        .map((id) => experienceMap.get(id))
-        .filter((experience): experience is ExperienceItem => Boolean(experience)),
-    [experienceMap, experienceOrderMap, selectedCategory],
-  );
   const { loadMoreRef } = useExperienceBoardInfiniteScroll({
     fetchNextPage,
     hasNextPage,

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -12,6 +12,7 @@ import { ExperienceDetailPanel } from '@/app/(pages)/experience/_components/Expe
 import { useExperienceBoardActions } from '@/app/(pages)/experience/_hooks/useExperienceBoardActions';
 import { useExperienceBoardInfiniteScroll } from '@/app/(pages)/experience/_hooks/useExperienceBoardInfiniteScroll';
 import { useExperienceBoardListState } from '@/app/(pages)/experience/_hooks/useExperienceBoardListState';
+import { useExperienceBoardReorder } from '@/app/(pages)/experience/_hooks/useExperienceBoardReorder';
 import { useExperienceBoardSelection } from '@/app/(pages)/experience/_hooks/useExperienceBoardSelection';
 import {
   mapExperienceCardToItem,
@@ -20,18 +21,13 @@ import {
 import {
   areExperienceOrderMapsEqual,
   createExperienceOrderMap,
-  parseOrderedExperienceIds,
   syncExperienceOrderMap,
 } from '@/app/(pages)/experience/_utils/experienceOrder';
 import type { PieceType } from '@/app/api/experience/types';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { EmptyState } from '@/components/common/EmptyState';
 import { ErrorDialog } from '@/components/common/ErrorDialog';
-import {
-  useExperienceDetail,
-  useInfiniteExperiences,
-  useUpdateExperienceOrder,
-} from '@/hooks/experience/useExperiences';
+import { useExperienceDetail, useInfiniteExperiences } from '@/hooks/experience/useExperiences';
 import { cn } from '@/lib/utils';
 
 export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
@@ -39,13 +35,6 @@ export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
   keyword?: string;
 }
 
-const orderPieceTypeByCategory: Record<ExperienceCategory, PieceType> = {
-  all: 'ALL',
-  activity: 'ACTIVITY',
-  career: 'CAREER',
-  education: 'EDUCATION',
-  etc: 'ETC',
-};
 const filterPieceTypeByCategory: Record<
   Exclude<ExperienceCategory, 'all'>,
   Exclude<PieceType, 'ALL'>
@@ -87,7 +76,6 @@ export function ExperienceBoard({
   );
   const { data, fetchNextPage, hasNextPage, isError, isFetching, isFetchingNextPage, isPending } =
     useInfiniteExperiences(experienceParams);
-  const updateExperienceOrderMutation = useUpdateExperienceOrder();
   const experiences = React.useMemo(
     () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
     [data],
@@ -184,38 +172,11 @@ export function ExperienceBoard({
     closeSelectedExperience,
     setExperienceOrderMap,
   });
-
-  const handleExperienceReorder = React.useCallback(
-    (orderedExperienceIds: string[]) => {
-      const previousOrderIds = experienceOrderMap[selectedCategory];
-      const parsedExperienceIds = parseOrderedExperienceIds(orderedExperienceIds);
-
-      if (!parsedExperienceIds) {
-        return;
-      }
-
-      setExperienceOrderMap((currentOrderMap) => ({
-        ...currentOrderMap,
-        [selectedCategory]: orderedExperienceIds,
-      }));
-
-      updateExperienceOrderMutation.mutate(
-        {
-          type: orderPieceTypeByCategory[selectedCategory],
-          experienceIds: parsedExperienceIds,
-        },
-        {
-          onError: () => {
-            setExperienceOrderMap((currentOrderMap) => ({
-              ...currentOrderMap,
-              [selectedCategory]: previousOrderIds,
-            }));
-          },
-        },
-      );
-    },
-    [experienceOrderMap, selectedCategory, updateExperienceOrderMutation],
-  );
+  const { handleExperienceReorder } = useExperienceBoardReorder({
+    selectedCategory,
+    experienceOrderMap,
+    setExperienceOrderMap,
+  });
 
   return (
     <section

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
 import * as React from 'react';
 
 import {
@@ -11,6 +10,7 @@ import type { ExperienceCategory } from '@/app/(pages)/experience/_components/Ex
 import { ExperienceCategoryTabs } from '@/app/(pages)/experience/_components/ExperienceCategoryTabs';
 import type { ExperienceDetailSaveValue } from '@/app/(pages)/experience/_components/ExperienceDetailContent';
 import { ExperienceDetailPanel } from '@/app/(pages)/experience/_components/ExperienceDetailPanel';
+import { useExperienceBoardSelection } from '@/app/(pages)/experience/_hooks/useExperienceBoardSelection';
 import {
   mapExperienceCardToItem,
   mapExperienceDetailToItem,
@@ -18,7 +18,6 @@ import {
 import {
   areExperienceOrderMapsEqual,
   createExperienceOrderMap,
-  EXPERIENCE_ORDER_CATEGORIES,
   parseOrderedExperienceIds,
   removeExperienceFromOrderMap,
   syncExperienceOrderMap,
@@ -60,28 +59,26 @@ const filterPieceTypeByCategory: Record<
   etc: 'ETC',
 };
 
-function isExperienceCategory(category: string | null): category is ExperienceCategory {
-  return EXPERIENCE_ORDER_CATEGORIES.includes(category as ExperienceCategory);
-}
-
 export function ExperienceBoard({
   initialSelectedExperienceId,
   keyword,
   className,
   ...props
 }: ExperienceBoardProps) {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const selectedExperienceIdFromQuery = searchParams.get('selected') ?? initialSelectedExperienceId;
-  const selectedCategoryFromQuery = searchParams.get('category');
-  const initialSelectedCategory = isExperienceCategory(selectedCategoryFromQuery)
-    ? selectedCategoryFromQuery
-    : 'all';
-  const [selectedCategory, setSelectedCategory] =
-    React.useState<ExperienceCategory>(initialSelectedCategory);
-  const [selectedExperienceId, setSelectedExperienceId] = React.useState<string | undefined>(
-    selectedExperienceIdFromQuery,
-  );
+  const {
+    selectedCategory,
+    selectedExperienceId,
+    panelOpen,
+    applyInitialSelectedExperience,
+    handleCategoryChange,
+    handleExperienceSelect,
+    closeSelectedExperience,
+    handlePanelClose,
+    handlePanelExpand,
+  } = useExperienceBoardSelection({
+    initialSelectedExperienceId,
+    keyword,
+  });
   const selectedPieceType =
     selectedCategory === 'all' ? undefined : filterPieceTypeByCategory[selectedCategory];
   const experienceParams = React.useMemo(
@@ -106,15 +103,11 @@ export function ExperienceBoard({
   const [experienceOrderMap, setExperienceOrderMap] = React.useState(() =>
     createExperienceOrderMap(experiences),
   );
-  const [panelOpen, setPanelOpen] = React.useState(Boolean(selectedExperienceIdFromQuery));
   const [deleteTargetExperience, setDeleteTargetExperience] = React.useState<ExperienceItem | null>(
     null,
   );
   const [errorMessage, setErrorMessage] = React.useState('');
-  const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadMoreRef = React.useRef<HTMLDivElement>(null);
-  const hasAppliedInitialSelectionRef = React.useRef(false);
-  const previousKeywordRef = React.useRef(keyword);
   const selectedExperienceNumericId = selectedExperienceId ? Number(selectedExperienceId) : null;
   const {
     data: selectedExperienceDetail,
@@ -133,6 +126,10 @@ export function ExperienceBoard({
         : null,
     [selectedExperienceDetail, selectedExperienceDetailMatches],
   );
+
+  React.useEffect(() => {
+    applyInitialSelectedExperience(experiences);
+  }, [applyInitialSelectedExperience, experiences]);
 
   React.useEffect(() => {
     setExperienceOrderMap((currentOrderMap) => {
@@ -162,68 +159,6 @@ export function ExperienceBoard({
       return currentKeywordKey === keywordKey ? null : currentKeywordKey;
     });
   }, [data, hasNextPage, isError, isPending, keywordKey, selectedCategory]);
-
-  React.useEffect(() => {
-    if (previousKeywordRef.current === keyword) {
-      return;
-    }
-
-    previousKeywordRef.current = keyword;
-
-    if (closeTimerRef.current) {
-      clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = null;
-    }
-
-    setSelectedExperienceId(undefined);
-    setPanelOpen(false);
-
-    const params = new URLSearchParams(searchParams.toString());
-
-    params.delete('selected');
-
-    if (selectedCategory !== 'all') {
-      params.set('category', selectedCategory);
-    } else {
-      params.delete('category');
-    }
-
-    router.replace(params.size > 0 ? `/experience?${params.toString()}` : '/experience', {
-      scroll: false,
-    });
-  }, [keyword, router, searchParams, selectedCategory]);
-
-  React.useEffect(() => {
-    if (hasAppliedInitialSelectionRef.current || !selectedExperienceIdFromQuery) {
-      return;
-    }
-
-    const initialSelectedExperience = experiences.find(
-      (experience) => experience.id === selectedExperienceIdFromQuery,
-    );
-
-    if (!initialSelectedExperience) {
-      return;
-    }
-
-    if (closeTimerRef.current) {
-      clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = null;
-    }
-
-    setSelectedCategory(initialSelectedCategory);
-    setSelectedExperienceId(initialSelectedExperience.id);
-    setPanelOpen(true);
-    hasAppliedInitialSelectionRef.current = true;
-  }, [experiences, initialSelectedCategory, selectedExperienceIdFromQuery]);
-
-  React.useEffect(() => {
-    return () => {
-      if (closeTimerRef.current) {
-        clearTimeout(closeTimerRef.current);
-      }
-    };
-  }, []);
 
   const experienceMap = React.useMemo(
     () => new Map(experiences.map((experience) => [experience.id, experience])),
@@ -276,31 +211,6 @@ export function ExperienceBoard({
   const showListLoading =
     !showKnownAllEmpty &&
     (isPending || (isFetching && !isFetchingNextPage && filteredExperiences.length === 0));
-
-  const handleCategoryChange = (category: ExperienceCategory) => {
-    if (closeTimerRef.current) {
-      clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = null;
-    }
-
-    router.replace('/experience', { scroll: false });
-    setSelectedCategory(category);
-    setSelectedExperienceId(undefined);
-    setPanelOpen(false);
-  };
-
-  const handleExperienceSelect = (experience: ExperienceItem) => {
-    if (closeTimerRef.current) {
-      clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = null;
-    }
-
-    setSelectedExperienceId(experience.id);
-    setPanelOpen(true);
-    router.replace(`/experience?selected=${experience.id}&category=${selectedCategory}`, {
-      scroll: false,
-    });
-  };
 
   const handleExperienceReorder = React.useCallback(
     (orderedExperienceIds: string[]) => {
@@ -381,14 +291,7 @@ export function ExperienceBoard({
         );
 
         if (selectedExperienceId === experience.id) {
-          if (closeTimerRef.current) {
-            clearTimeout(closeTimerRef.current);
-            closeTimerRef.current = null;
-          }
-
-          setPanelOpen(false);
-          setSelectedExperienceId(undefined);
-          router.replace('/experience', { scroll: false });
+          closeSelectedExperience();
         }
       } catch (error) {
         setErrorMessage(
@@ -398,7 +301,7 @@ export function ExperienceBoard({
         setDeleteTargetExperience(null);
       }
     },
-    [deleteExperienceMutation, router, selectedExperienceId],
+    [closeSelectedExperience, deleteExperienceMutation, selectedExperienceId],
   );
 
   const handleExperienceDetailSave = React.useCallback(
@@ -425,33 +328,6 @@ export function ExperienceBoard({
     },
     [panelExperience, updateExperienceMutation],
   );
-
-  const handlePanelClose = () => {
-    if (closeTimerRef.current) {
-      clearTimeout(closeTimerRef.current);
-    }
-
-    setPanelOpen(false);
-    closeTimerRef.current = setTimeout(() => {
-      setSelectedExperienceId(undefined);
-      closeTimerRef.current = null;
-    }, 300);
-    router.replace('/experience', { scroll: false });
-  };
-
-  const handlePanelExpand = () => {
-    if (!panelExperience) {
-      return;
-    }
-
-    const params = new URLSearchParams(searchParams.toString());
-
-    params.set('selected', panelExperience.id);
-    params.set('category', selectedCategory);
-    params.set('view', 'detail');
-
-    router.push(`/experience?${params.toString()}`);
-  };
 
   return (
     <section
@@ -508,7 +384,7 @@ export function ExperienceBoard({
           open={panelOpen}
           detailError={isDetailError}
           detailLoading={showDetailLoading}
-          onExpand={handlePanelExpand}
+          onExpand={() => handlePanelExpand(panelExperience.id)}
           onSave={handleExperienceDetailSave}
           onClose={handlePanelClose}
         />

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -7,20 +7,18 @@ import type { ExperienceCategory } from '@/app/(pages)/experience/_components/Ex
 import { ExperienceCategoryTabs } from '@/app/(pages)/experience/_components/ExperienceCategoryTabs';
 import { ExperienceDetailPanel } from '@/app/(pages)/experience/_components/ExperienceDetailPanel';
 import { useExperienceBoardActions } from '@/app/(pages)/experience/_hooks/useExperienceBoardActions';
+import { useExperienceBoardDetail } from '@/app/(pages)/experience/_hooks/useExperienceBoardDetail';
 import { useExperienceBoardInfiniteScroll } from '@/app/(pages)/experience/_hooks/useExperienceBoardInfiniteScroll';
 import { useExperienceBoardListState } from '@/app/(pages)/experience/_hooks/useExperienceBoardListState';
 import { useExperienceBoardOrder } from '@/app/(pages)/experience/_hooks/useExperienceBoardOrder';
 import { useExperienceBoardReorder } from '@/app/(pages)/experience/_hooks/useExperienceBoardReorder';
 import { useExperienceBoardSelection } from '@/app/(pages)/experience/_hooks/useExperienceBoardSelection';
-import {
-  mapExperienceCardToItem,
-  mapExperienceDetailToItem,
-} from '@/app/(pages)/experience/_utils/mapExperienceResponse';
+import { mapExperienceCardToItem } from '@/app/(pages)/experience/_utils/mapExperienceResponse';
 import type { PieceType } from '@/app/api/experience/types';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { EmptyState } from '@/components/common/EmptyState';
 import { ErrorDialog } from '@/components/common/ErrorDialog';
-import { useExperienceDetail, useInfiniteExperiences } from '@/hooks/experience/useExperiences';
+import { useInfiniteExperiences } from '@/hooks/experience/useExperiences';
 import { cn } from '@/lib/utils';
 
 export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
@@ -78,24 +76,6 @@ export function ExperienceBoard({
       experiences,
       selectedCategory,
     });
-  const selectedExperienceNumericId = selectedExperienceId ? Number(selectedExperienceId) : null;
-  const {
-    data: selectedExperienceDetail,
-    isError: isDetailError,
-    isFetching: isDetailFetching,
-    isPending: isDetailPending,
-  } = useExperienceDetail(
-    Number.isFinite(selectedExperienceNumericId) ? selectedExperienceNumericId : null,
-  );
-  const selectedExperienceDetailMatches =
-    selectedExperienceDetail?.experienceId === selectedExperienceNumericId;
-  const selectedExperienceDetailItem = React.useMemo(
-    () =>
-      selectedExperienceDetail && selectedExperienceDetailMatches
-        ? mapExperienceDetailToItem(selectedExperienceDetail)
-        : null,
-    [selectedExperienceDetail, selectedExperienceDetailMatches],
-  );
 
   React.useEffect(() => {
     applyInitialSelectedExperience(experiences);
@@ -122,11 +102,11 @@ export function ExperienceBoard({
   const selectedExperience = filteredExperiences.find(
     (experience) => experience.id === selectedExperienceId,
   );
-  const panelExperience = selectedExperienceDetailItem ?? selectedExperience;
-  const showDetailLoading =
-    panelOpen &&
-    Boolean(selectedExperienceId) &&
-    (isDetailPending || (isDetailFetching && !selectedExperienceDetailMatches));
+  const { panelExperience, isDetailError, showDetailLoading } = useExperienceBoardDetail({
+    selectedExperienceId,
+    selectedExperience,
+    panelOpen,
+  });
   const {
     deleteTargetExperience,
     errorMessage,

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -8,8 +8,8 @@ import {
 } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
 import type { ExperienceCategory } from '@/app/(pages)/experience/_components/ExperienceCategoryTab';
 import { ExperienceCategoryTabs } from '@/app/(pages)/experience/_components/ExperienceCategoryTabs';
-import type { ExperienceDetailSaveValue } from '@/app/(pages)/experience/_components/ExperienceDetailContent';
 import { ExperienceDetailPanel } from '@/app/(pages)/experience/_components/ExperienceDetailPanel';
+import { useExperienceBoardActions } from '@/app/(pages)/experience/_hooks/useExperienceBoardActions';
 import { useExperienceBoardInfiniteScroll } from '@/app/(pages)/experience/_hooks/useExperienceBoardInfiniteScroll';
 import { useExperienceBoardListState } from '@/app/(pages)/experience/_hooks/useExperienceBoardListState';
 import { useExperienceBoardSelection } from '@/app/(pages)/experience/_hooks/useExperienceBoardSelection';
@@ -21,21 +21,16 @@ import {
   areExperienceOrderMapsEqual,
   createExperienceOrderMap,
   parseOrderedExperienceIds,
-  removeExperienceFromOrderMap,
   syncExperienceOrderMap,
 } from '@/app/(pages)/experience/_utils/experienceOrder';
-import { mapExperienceItemToUpdateRequest } from '@/app/(pages)/experience/_utils/mapExperienceItemToUpdateRequest';
 import type { PieceType } from '@/app/api/experience/types';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
 import { EmptyState } from '@/components/common/EmptyState';
 import { ErrorDialog } from '@/components/common/ErrorDialog';
 import {
-  useDeleteExperience,
   useExperienceDetail,
   useInfiniteExperiences,
-  useUpdateExperience,
   useUpdateExperienceOrder,
-  useUpdateExperienceTitle,
 } from '@/hooks/experience/useExperiences';
 import { cn } from '@/lib/utils';
 
@@ -92,10 +87,7 @@ export function ExperienceBoard({
   );
   const { data, fetchNextPage, hasNextPage, isError, isFetching, isFetchingNextPage, isPending } =
     useInfiniteExperiences(experienceParams);
-  const deleteExperienceMutation = useDeleteExperience();
-  const updateExperienceMutation = useUpdateExperience();
   const updateExperienceOrderMutation = useUpdateExperienceOrder();
-  const updateExperienceTitleMutation = useUpdateExperienceTitle();
   const experiences = React.useMemo(
     () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
     [data],
@@ -103,10 +95,6 @@ export function ExperienceBoard({
   const [experienceOrderMap, setExperienceOrderMap] = React.useState(() =>
     createExperienceOrderMap(experiences),
   );
-  const [deleteTargetExperience, setDeleteTargetExperience] = React.useState<ExperienceItem | null>(
-    null,
-  );
-  const [errorMessage, setErrorMessage] = React.useState('');
   const selectedExperienceNumericId = selectedExperienceId ? Number(selectedExperienceId) : null;
   const {
     data: selectedExperienceDetail,
@@ -180,6 +168,22 @@ export function ExperienceBoard({
     panelOpen &&
     Boolean(selectedExperienceId) &&
     (isDetailPending || (isDetailFetching && !selectedExperienceDetailMatches));
+  const {
+    deleteTargetExperience,
+    errorMessage,
+    isDeletingExperience,
+    handleExperienceTitleSave,
+    handleExperienceDeleteRequest,
+    handleDeleteDialogOpenChange,
+    handleExperienceDeleteConfirm,
+    handleExperienceDetailSave,
+    handleErrorDialogOpenChange,
+  } = useExperienceBoardActions({
+    panelExperience,
+    selectedExperienceId,
+    closeSelectedExperience,
+    setExperienceOrderMap,
+  });
 
   const handleExperienceReorder = React.useCallback(
     (orderedExperienceIds: string[]) => {
@@ -211,91 +215,6 @@ export function ExperienceBoard({
       );
     },
     [experienceOrderMap, selectedCategory, updateExperienceOrderMutation],
-  );
-
-  const handleExperienceTitleSave = React.useCallback(
-    async (experience: ExperienceItem, nextTitle: string) => {
-      const experienceId = Number(experience.id);
-
-      if (!Number.isInteger(experienceId) || experienceId <= 0) {
-        throw new Error('수정할 경험 정보를 확인하지 못했습니다.');
-      }
-
-      await updateExperienceTitleMutation.mutateAsync({
-        experienceId,
-        request: { title: nextTitle },
-      });
-    },
-    [updateExperienceTitleMutation],
-  );
-
-  const handleExperienceDeleteRequest = React.useCallback((experience: ExperienceItem) => {
-    setDeleteTargetExperience(experience);
-  }, []);
-
-  const handleDeleteDialogOpenChange = React.useCallback(
-    (open: boolean) => {
-      if (!open && !deleteExperienceMutation.isPending) {
-        setDeleteTargetExperience(null);
-      }
-    },
-    [deleteExperienceMutation.isPending],
-  );
-
-  const handleExperienceDeleteConfirm = React.useCallback(
-    async (experience: ExperienceItem) => {
-      const experienceId = Number(experience.id);
-
-      if (!Number.isInteger(experienceId) || experienceId <= 0) {
-        setErrorMessage('삭제할 경험 정보를 확인하지 못했습니다.');
-        setDeleteTargetExperience(null);
-        return;
-      }
-
-      try {
-        await deleteExperienceMutation.mutateAsync(experienceId);
-
-        setExperienceOrderMap((currentOrderMap) =>
-          removeExperienceFromOrderMap(currentOrderMap, experience.id),
-        );
-
-        if (selectedExperienceId === experience.id) {
-          closeSelectedExperience();
-        }
-      } catch (error) {
-        setErrorMessage(
-          error instanceof Error ? error.message : '경험 삭제 중 오류가 발생했습니다.',
-        );
-      } finally {
-        setDeleteTargetExperience(null);
-      }
-    },
-    [closeSelectedExperience, deleteExperienceMutation, selectedExperienceId],
-  );
-
-  const handleExperienceDetailSave = React.useCallback(
-    async (nextExperience: ExperienceDetailSaveValue) => {
-      if (!panelExperience) {
-        throw new Error('수정할 경험 정보를 확인하지 못했습니다.');
-      }
-
-      const experienceId = Number(panelExperience.id);
-
-      if (!Number.isInteger(experienceId) || experienceId <= 0) {
-        throw new Error('수정할 경험 정보를 확인하지 못했습니다.');
-      }
-
-      const updatedExperience = {
-        ...panelExperience,
-        ...nextExperience,
-      };
-
-      await updateExperienceMutation.mutateAsync({
-        experienceId,
-        request: mapExperienceItemToUpdateRequest(updatedExperience),
-      });
-    },
-    [panelExperience, updateExperienceMutation],
   );
 
   return (
@@ -363,7 +282,7 @@ export function ExperienceBoard({
         title="정말로 삭제하시겠습니까?"
         description="삭제시 모든 기록과 분석 내용이 소멸됩니다."
         confirmLabel="삭제하기"
-        confirming={deleteExperienceMutation.isPending}
+        confirming={isDeletingExperience}
         destructive
         onOpenChange={handleDeleteDialogOpenChange}
         onConfirm={() => {
@@ -375,11 +294,7 @@ export function ExperienceBoard({
       <ErrorDialog
         open={errorMessage.length > 0}
         message={errorMessage}
-        onOpenChange={(open) => {
-          if (!open) {
-            setErrorMessage('');
-          }
-        }}
+        onOpenChange={handleErrorDialogOpenChange}
       />
     </section>
   );

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -10,6 +10,7 @@ import type { ExperienceCategory } from '@/app/(pages)/experience/_components/Ex
 import { ExperienceCategoryTabs } from '@/app/(pages)/experience/_components/ExperienceCategoryTabs';
 import type { ExperienceDetailSaveValue } from '@/app/(pages)/experience/_components/ExperienceDetailContent';
 import { ExperienceDetailPanel } from '@/app/(pages)/experience/_components/ExperienceDetailPanel';
+import { useExperienceBoardInfiniteScroll } from '@/app/(pages)/experience/_hooks/useExperienceBoardInfiniteScroll';
 import { useExperienceBoardSelection } from '@/app/(pages)/experience/_hooks/useExperienceBoardSelection';
 import {
   mapExperienceCardToItem,
@@ -107,7 +108,6 @@ export function ExperienceBoard({
     null,
   );
   const [errorMessage, setErrorMessage] = React.useState('');
-  const loadMoreRef = React.useRef<HTMLDivElement>(null);
   const selectedExperienceNumericId = selectedExperienceId ? Number(selectedExperienceId) : null;
   const {
     data: selectedExperienceDetail,
@@ -172,29 +172,12 @@ export function ExperienceBoard({
         .filter((experience): experience is ExperienceItem => Boolean(experience)),
     [experienceMap, experienceOrderMap, selectedCategory],
   );
-
-  React.useEffect(() => {
-    const loadMoreElement = loadMoreRef.current;
-
-    if (!loadMoreElement || !hasNextPage || isFetchingNextPage) {
-      return;
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          void fetchNextPage();
-        }
-      },
-      { rootMargin: '240px 0px' },
-    );
-
-    observer.observe(loadMoreElement);
-
-    return () => {
-      observer.disconnect();
-    };
-  }, [fetchNextPage, filteredExperiences.length, hasNextPage, isFetchingNextPage]);
+  const { loadMoreRef } = useExperienceBoardInfiniteScroll({
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    observedItemCount: filteredExperiences.length,
+  });
 
   const selectedExperience = filteredExperiences.find(
     (experience) => experience.id === selectedExperienceId,

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -15,6 +15,14 @@ import {
   mapExperienceCardToItem,
   mapExperienceDetailToItem,
 } from '@/app/(pages)/experience/_utils/mapExperienceResponse';
+import {
+  areExperienceOrderMapsEqual,
+  createExperienceOrderMap,
+  EXPERIENCE_ORDER_CATEGORIES,
+  parseOrderedExperienceIds,
+  removeExperienceFromOrderMap,
+  syncExperienceOrderMap,
+} from '@/app/(pages)/experience/_utils/experienceOrder';
 import { mapExperienceItemToUpdateRequest } from '@/app/(pages)/experience/_utils/mapExperienceItemToUpdateRequest';
 import type { PieceType } from '@/app/api/experience/types';
 import { ConfirmDialog } from '@/components/common/ConfirmDialog';
@@ -35,9 +43,6 @@ export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
   keyword?: string;
 }
 
-type ExperienceOrderMap = Record<ExperienceCategory, string[]>;
-
-const sortableCategories: ExperienceCategory[] = ['all', 'activity', 'career', 'education', 'etc'];
 const orderPieceTypeByCategory: Record<ExperienceCategory, PieceType> = {
   all: 'ALL',
   activity: 'ACTIVITY',
@@ -45,7 +50,10 @@ const orderPieceTypeByCategory: Record<ExperienceCategory, PieceType> = {
   education: 'EDUCATION',
   etc: 'ETC',
 };
-const filterPieceTypeByCategory: Record<Exclude<ExperienceCategory, 'all'>, Exclude<PieceType, 'ALL'>> = {
+const filterPieceTypeByCategory: Record<
+  Exclude<ExperienceCategory, 'all'>,
+  Exclude<PieceType, 'ALL'>
+> = {
   activity: 'ACTIVITY',
   career: 'CAREER',
   education: 'EDUCATION',
@@ -53,7 +61,7 @@ const filterPieceTypeByCategory: Record<Exclude<ExperienceCategory, 'all'>, Excl
 };
 
 function isExperienceCategory(category: string | null): category is ExperienceCategory {
-  return sortableCategories.includes(category as ExperienceCategory);
+  return EXPERIENCE_ORDER_CATEGORIES.includes(category as ExperienceCategory);
 }
 
 export function ExperienceBoard({
@@ -99,8 +107,9 @@ export function ExperienceBoard({
     createExperienceOrderMap(experiences),
   );
   const [panelOpen, setPanelOpen] = React.useState(Boolean(selectedExperienceIdFromQuery));
-  const [deleteTargetExperience, setDeleteTargetExperience] =
-    React.useState<ExperienceItem | null>(null);
+  const [deleteTargetExperience, setDeleteTargetExperience] = React.useState<ExperienceItem | null>(
+    null,
+  );
   const [errorMessage, setErrorMessage] = React.useState('');
   const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const loadMoreRef = React.useRef<HTMLDivElement>(null);
@@ -296,13 +305,9 @@ export function ExperienceBoard({
   const handleExperienceReorder = React.useCallback(
     (orderedExperienceIds: string[]) => {
       const previousOrderIds = experienceOrderMap[selectedCategory];
-      const parsedExperienceIds = orderedExperienceIds.map(Number);
+      const parsedExperienceIds = parseOrderedExperienceIds(orderedExperienceIds);
 
-      if (
-        parsedExperienceIds.some(
-          (experienceId) => !Number.isInteger(experienceId) || experienceId <= 0,
-        )
-      ) {
+      if (!parsedExperienceIds) {
         return;
       }
 
@@ -349,11 +354,14 @@ export function ExperienceBoard({
     setDeleteTargetExperience(experience);
   }, []);
 
-  const handleDeleteDialogOpenChange = React.useCallback((open: boolean) => {
-    if (!open && !deleteExperienceMutation.isPending) {
-      setDeleteTargetExperience(null);
-    }
-  }, [deleteExperienceMutation.isPending]);
+  const handleDeleteDialogOpenChange = React.useCallback(
+    (open: boolean) => {
+      if (!open && !deleteExperienceMutation.isPending) {
+        setDeleteTargetExperience(null);
+      }
+    },
+    [deleteExperienceMutation.isPending],
+  );
 
   const handleExperienceDeleteConfirm = React.useCallback(
     async (experience: ExperienceItem) => {
@@ -369,12 +377,7 @@ export function ExperienceBoard({
         await deleteExperienceMutation.mutateAsync(experienceId);
 
         setExperienceOrderMap((currentOrderMap) =>
-          sortableCategories.reduce<ExperienceOrderMap>((nextOrderMap, category) => {
-            nextOrderMap[category] = currentOrderMap[category].filter(
-              (id) => id !== experience.id,
-            );
-            return nextOrderMap;
-          }, {} as ExperienceOrderMap),
+          removeExperienceFromOrderMap(currentOrderMap, experience.id),
         );
 
         if (selectedExperienceId === experience.id) {
@@ -388,7 +391,9 @@ export function ExperienceBoard({
           router.replace('/experience', { scroll: false });
         }
       } catch (error) {
-        setErrorMessage(error instanceof Error ? error.message : '경험 삭제 중 오류가 발생했습니다.');
+        setErrorMessage(
+          error instanceof Error ? error.message : '경험 삭제 중 오류가 발생했습니다.',
+        );
       } finally {
         setDeleteTargetExperience(null);
       }
@@ -532,64 +537,5 @@ export function ExperienceBoard({
         }}
       />
     </section>
-  );
-}
-
-function areStringArraysEqual(source: string[], target: string[]) {
-  return source.length === target.length && source.every((item, index) => item === target[index]);
-}
-
-function createExperienceOrderMap(experiences: ExperienceItem[]): ExperienceOrderMap {
-  return {
-    all: experiences.map((experience) => experience.id),
-    activity: getExperienceIdsByCategory(experiences, 'activity'),
-    career: getExperienceIdsByCategory(experiences, 'career'),
-    education: getExperienceIdsByCategory(experiences, 'education'),
-    etc: getExperienceIdsByCategory(experiences, 'etc'),
-  };
-}
-
-function syncExperienceOrderMap(
-  currentOrderMap: ExperienceOrderMap,
-  experiences: ExperienceItem[],
-  syncedCategory: ExperienceCategory,
-): ExperienceOrderMap {
-  const defaultOrderMap = createExperienceOrderMap(experiences);
-
-  if (syncedCategory === 'all') {
-    return defaultOrderMap;
-  }
-
-  return sortableCategories.reduce<ExperienceOrderMap>((nextOrderMap, category) => {
-    if (category === syncedCategory) {
-      nextOrderMap[category] = defaultOrderMap[category];
-      return nextOrderMap;
-    }
-
-    const nextIds = defaultOrderMap[category];
-    const nextIdSet = new Set(nextIds);
-    const currentIds = currentOrderMap[category] ?? [];
-    const currentIdSet = new Set(currentIds);
-    const preservedIds = currentIds.filter((id) => nextIdSet.has(id));
-    const addedIds = nextIds.filter((id) => !currentIdSet.has(id));
-
-    nextOrderMap[category] = [...preservedIds, ...addedIds];
-
-    return nextOrderMap;
-  }, {} as ExperienceOrderMap);
-}
-
-function getExperienceIdsByCategory(
-  experiences: ExperienceItem[],
-  category: Exclude<ExperienceCategory, 'all'>,
-) {
-  return experiences
-    .filter((experience) => experience.type === category)
-    .map((experience) => experience.id);
-}
-
-function areExperienceOrderMapsEqual(source: ExperienceOrderMap, target: ExperienceOrderMap) {
-  return sortableCategories.every((category) =>
-    areStringArraysEqual(source[category], target[category]),
   );
 }

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -11,6 +11,7 @@ import { ExperienceCategoryTabs } from '@/app/(pages)/experience/_components/Exp
 import type { ExperienceDetailSaveValue } from '@/app/(pages)/experience/_components/ExperienceDetailContent';
 import { ExperienceDetailPanel } from '@/app/(pages)/experience/_components/ExperienceDetailPanel';
 import { useExperienceBoardInfiniteScroll } from '@/app/(pages)/experience/_hooks/useExperienceBoardInfiniteScroll';
+import { useExperienceBoardListState } from '@/app/(pages)/experience/_hooks/useExperienceBoardListState';
 import { useExperienceBoardSelection } from '@/app/(pages)/experience/_hooks/useExperienceBoardSelection';
 import {
   mapExperienceCardToItem,
@@ -99,8 +100,6 @@ export function ExperienceBoard({
     () => data?.pages.flatMap((page) => page.experiences.map(mapExperienceCardToItem)) ?? [],
     [data],
   );
-  const keywordKey = keyword ?? '';
-  const [emptyAllKeywordKey, setEmptyAllKeywordKey] = React.useState<string | null>(null);
   const [experienceOrderMap, setExperienceOrderMap] = React.useState(() =>
     createExperienceOrderMap(experiences),
   );
@@ -143,23 +142,6 @@ export function ExperienceBoard({
     });
   }, [experiences, selectedCategory]);
 
-  React.useEffect(() => {
-    if (selectedCategory !== 'all' || !data || isError || isPending) {
-      return;
-    }
-
-    const isAllExperienceEmpty =
-      !hasNextPage && data.pages.every((page) => page.experiences.length === 0);
-
-    setEmptyAllKeywordKey((currentKeywordKey) => {
-      if (isAllExperienceEmpty) {
-        return keywordKey;
-      }
-
-      return currentKeywordKey === keywordKey ? null : currentKeywordKey;
-    });
-  }, [data, hasNextPage, isError, isPending, keywordKey, selectedCategory]);
-
   const experienceMap = React.useMemo(
     () => new Map(experiences.map((experience) => [experience.id, experience])),
     [experiences],
@@ -178,6 +160,17 @@ export function ExperienceBoard({
     isFetchingNextPage,
     observedItemCount: filteredExperiences.length,
   });
+  const { showListLoading } = useExperienceBoardListState({
+    data,
+    hasNextPage,
+    isError,
+    isFetching,
+    isFetchingNextPage,
+    isPending,
+    keyword,
+    selectedCategory,
+    filteredExperienceCount: filteredExperiences.length,
+  });
 
   const selectedExperience = filteredExperiences.find(
     (experience) => experience.id === selectedExperienceId,
@@ -187,13 +180,6 @@ export function ExperienceBoard({
     panelOpen &&
     Boolean(selectedExperienceId) &&
     (isDetailPending || (isDetailFetching && !selectedExperienceDetailMatches));
-  const showKnownAllEmpty =
-    selectedCategory !== 'all' &&
-    emptyAllKeywordKey === keywordKey &&
-    filteredExperiences.length === 0;
-  const showListLoading =
-    !showKnownAllEmpty &&
-    (isPending || (isFetching && !isFetchingNextPage && filteredExperiences.length === 0));
 
   const handleExperienceReorder = React.useCallback(
     (orderedExperienceIds: string[]) => {

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -1,39 +1,20 @@
 'use client';
 
-import Image from 'next/image';
 import * as React from 'react';
 
 import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
-import { EditableTagGroup } from '@/app/(pages)/experience/_components/EditableTagGroup';
+import { ExperienceDetailFields } from '@/app/(pages)/experience/_components/ExperienceDetailFields';
+import { ExperienceDetailHeader } from '@/app/(pages)/experience/_components/ExperienceDetailHeader';
+import { ExperienceDetailSummary } from '@/app/(pages)/experience/_components/ExperienceDetailSummary';
+import { ExperienceDetailTags } from '@/app/(pages)/experience/_components/ExperienceDetailTags';
 import {
-  type BasicDetailKey,
   type ExperienceDetailSaveValue as ExperienceDetailSaveValueType,
   useExperienceDetailForm,
 } from '@/app/(pages)/experience/_hooks/useExperienceDetailForm';
-import { getExperienceCategoryMeta } from '@/app/(pages)/experience/_utils/ExperienceCategory';
-import {
-  EXPERIENCE_FIELD_MAX_LENGTHS,
-  getExperienceFieldMaxLength,
-} from '@/app/(pages)/experience/_utils/experienceFieldLimits';
-import { DetailInput } from '@/components/common/DetailInput';
 import { ErrorDialog } from '@/components/common/ErrorDialog';
-import { CalendarIcon } from '@/components/common/icons/CalendarIcon';
-import { Tag } from '@/components/common/Tag';
-import { SingleMonthRangeCalendar } from '@/components/common/SingleMonthRangeCalendar';
-import { RangeCalendar } from '@/components/common/RangeCalendar';
-import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
 
 export type { ExperienceDetailSaveValue } from '@/app/(pages)/experience/_hooks/useExperienceDetailForm';
-
-const detailFields = [
-  ['Situation', 'situation'],
-  ['Task', 'task'],
-  ['Action', 'action'],
-  ['Result', 'result'],
-  ['Taken', 'taken'],
-] as const;
-const DETAIL_FIELD_MAX_LENGTH = 1000;
 
 export interface ExperienceDetailContentProps extends React.ComponentProps<'div'> {
   experience: ExperienceItem;
@@ -52,7 +33,6 @@ export function ExperienceDetailContent({
   className,
   ...props
 }: ExperienceDetailContentProps) {
-  const category = getExperienceCategoryMeta(experience.type);
   const isPage = variant === 'page';
   const {
     title,
@@ -89,10 +69,6 @@ export function ExperienceDetailContent({
     onEdit,
     onSave,
   });
-  const detailInfoItems = React.useMemo(
-    () => getDetailInfoItems(experience.type, basicDetail, periodLabel),
-    [basicDetail, experience.type, periodLabel],
-  );
 
   return (
     <div
@@ -101,366 +77,56 @@ export function ExperienceDetailContent({
       {...props}
     >
       <div className={cn('flex flex-col', isPage ? 'gap-7' : 'gap-6')}>
-        <div className="flex min-w-0 items-start justify-between gap-4">
-          <div className="flex min-w-0 flex-1 flex-col gap-1">
-            {isEditing ? (
-              <InlineTextArea
-                value={title}
-                ariaLabel="제목"
-                maxLength={EXPERIENCE_FIELD_MAX_LENGTHS.title}
-                className={cn('text-strong', isPage ? 'heading-2-bold' : 'title-1-bold')}
-                onChange={updateTitle}
-              />
-            ) : (
-              <h3
-                className={cn(
-                  'w-full min-w-0 leading-[1.48] wrap-break-word text-strong',
-                  isPage ? 'heading-2-bold' : 'title-1-bold',
-                )}
-              >
-                {title}
-              </h3>
-            )}
-            {isEditing ? (
-              <InlineTextArea
-                value={description}
-                ariaLabel="한 줄 설명"
-                maxLength={EXPERIENCE_FIELD_MAX_LENGTHS.description}
-                className={cn('text-quaternary', isPage ? 'body-1-bold' : 'body-3-regular')}
-                onChange={updateDescription}
-              />
-            ) : (
-              <p
-                className={cn(
-                  'w-full min-w-0 leading-[1.48] wrap-break-word text-quaternary',
-                  isPage ? 'body-1-bold' : 'body-3-regular',
-                )}
-              >
-                {description}
-              </p>
-            )}
-          </div>
-
-          {isEditing ? (
-            <Button type="button" disabled={isSaving} onClick={handleSaveEdit}>
-              {isSaving ? '저장 중...' : '저장하기'}
-            </Button>
-          ) : (
-            <Button type="button" variant="secondary" onClick={handleEditClick}>
-              수정하기
-            </Button>
-          )}
-        </div>
-
-        <div className={cn('flex items-start gap-5', isPage && 'items-center')}>
-          <div
-            className={cn(
-              'flex shrink-0 flex-col items-center gap-0.5',
-              isPage ? 'w-[109px]' : 'w-[83px]',
-            )}
-          >
-            <Image
-              src={category.selectedIconSrc}
-              alt=""
-              width={isPage ? 109 : 72}
-              height={isPage ? 109 : 72}
-              className={cn(isPage ? 'size-[109px]' : 'size-[72px]')}
-            />
-            <span className={cn('font-bold text-strong', isPage ? 'body-2-bold' : 'body-3-bold')}>
-              {category.label}
-            </span>
-          </div>
-
-          <dl className="flex w-full flex-col gap-1.5">
-            {detailInfoItems.map((item) => (
-              <div key={item.label} className="flex w-full items-start gap-4">
-                <dt
-                  className={cn(
-                    'shrink-0 font-bold text-strong',
-                    isPage ? 'body-1-bold' : 'body-3-bold',
-                  )}
-                >
-                  {item.label}
-                </dt>
-                <dd
-                  className={cn(
-                    'relative flex min-w-0 flex-1 items-center gap-1 text-secondary',
-                    isPage ? 'body-1-regular' : 'body-3-regular',
-                  )}
-                >
-                  {isEditing && item.type === 'period' ? (
-                    <div ref={datePickerRootRef} className="relative flex items-center gap-1">
-                      <button
-                        ref={datePickerButtonRef}
-                        type="button"
-                        aria-label="기간 선택"
-                        aria-expanded={datePickerOpen}
-                        className="flex min-w-0 cursor-pointer items-center gap-1 rounded-sm text-secondary focus-visible:shadow-focus-ring focus-visible:outline-none"
-                        onClick={toggleDatePicker}
-                      >
-                        <CalendarIcon className="size-[21px] shrink-0 text-tertiary" />
-                        <span>{item.value}</span>
-                      </button>
-                      {datePickerOpen && (
-                        <div
-                          role="dialog"
-                          aria-label="기간 선택"
-                          className={cn(
-                            'z-60',
-                            isPage
-                              ? 'absolute top-full left-0 mt-2'
-                              : 'fixed right-[max(1rem,calc((min(100vw,500px)-24rem)/2))]',
-                          )}
-                          style={isPage ? undefined : { top: datePickerTop ?? undefined }}
-                        >
-                          {isPage ? (
-                            <RangeCalendar
-                              value={selectedDateRange}
-                              defaultVisibleMonth={selectedDateRange?.start ?? new Date()}
-                              onChange={handleDateRangeChange}
-                            />
-                          ) : (
-                            <SingleMonthRangeCalendar
-                              value={selectedDateRange}
-                              defaultVisibleMonth={selectedDateRange?.start ?? new Date()}
-                              onChange={handleDateRangeChange}
-                            />
-                          )}
-                        </div>
-                      )}
-                    </div>
-                  ) : null}
-                  {isEditing && item.type === 'field' ? (
-                    <InlineTextArea
-                      value={item.value}
-                      ariaLabel={item.label}
-                      maxLength={getExperienceFieldMaxLength(item.name)}
-                      className="text-secondary"
-                      onChange={(value) => updateBasicDetail(item.name, value)}
-                    />
-                  ) : (
-                    !isEditing && (
-                      <span>{item.type === 'field' ? item.displayValue : item.value}</span>
-                    )
-                  )}
-                </dd>
-              </div>
-            ))}
-          </dl>
-        </div>
-
-        {isEditing ? (
-          <div className="flex flex-col gap-2.5">
-            <EditableTagGroup
-              label="기술"
-              tone="skill"
-              tags={skillTags}
-              editing={editingTagGroup === 'skill'}
-              variant="bordered-row"
-              viewTagSize="large"
-              onChange={setSkillTags}
-              onEdit={() => setEditingTagGroup('skill')}
-              onRequestClose={() => setEditingTagGroup(null)}
-            />
-            <EditableTagGroup
-              label="역량"
-              tone="competency"
-              tags={competencyTags}
-              editing={editingTagGroup === 'competency'}
-              variant="bordered-row"
-              viewTagSize="large"
-              borderBottom
-              onChange={setCompetencyTags}
-              onEdit={() => setEditingTagGroup('competency')}
-              onRequestClose={() => setEditingTagGroup(null)}
-            />
-          </div>
-        ) : (
-          <div className="flex flex-col gap-2">
-            <div className="flex flex-wrap gap-1">
-              {skillTags.map((tag, index) => (
-                <Tag key={`skill-${tag}-${index}`} tone="skill" size="large">
-                  {tag}
-                </Tag>
-              ))}
-            </div>
-
-            <div className="flex flex-wrap gap-1">
-              {competencyTags.map((tag, index) => (
-                <Tag key={`competency-${tag}-${index}`} tone="competency" size="large">
-                  {tag}
-                </Tag>
-              ))}
-            </div>
-          </div>
-        )}
+        <ExperienceDetailHeader
+          title={title}
+          description={description}
+          isEditing={isEditing}
+          isSaving={isSaving}
+          isPage={isPage}
+          onTitleChange={updateTitle}
+          onDescriptionChange={updateDescription}
+          onEditClick={handleEditClick}
+          onSaveClick={handleSaveEdit}
+        />
+        <ExperienceDetailSummary
+          type={experience.type}
+          basicDetail={basicDetail}
+          periodLabel={periodLabel}
+          isEditing={isEditing}
+          isPage={isPage}
+          datePickerOpen={datePickerOpen}
+          datePickerTop={datePickerTop}
+          datePickerRootRef={datePickerRootRef}
+          datePickerButtonRef={datePickerButtonRef}
+          selectedDateRange={selectedDateRange}
+          onDatePickerToggle={toggleDatePicker}
+          onDateRangeChange={handleDateRangeChange}
+          onBasicDetailChange={updateBasicDetail}
+        />
+        <ExperienceDetailTags
+          skillTags={skillTags}
+          competencyTags={competencyTags}
+          isEditing={isEditing}
+          editingTagGroup={editingTagGroup}
+          onSkillTagsChange={setSkillTags}
+          onCompetencyTagsChange={setCompetencyTags}
+          onEditingTagGroupChange={setEditingTagGroup}
+        />
       </div>
 
       {!isEditing ? <div className="mt-4 h-px w-full shrink-0 bg-gray-300" /> : null}
 
-      <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-x-hidden py-6">
-        {detailFields.map(([label, key]) => {
-          const fieldValue = detail[key] ?? '';
-          const characterCount = fieldValue.length;
-          const isMaxLength = characterCount >= DETAIL_FIELD_MAX_LENGTH;
-
-          return (
-            <div key={key} className="flex w-full flex-col gap-1.5">
-              <div className="flex items-end gap-3 px-2">
-                <h3
-                  className={cn('font-bold text-primary', isPage ? 'title-2-bold' : 'body-2-bold')}
-                >
-                  {label}
-                </h3>
-                <p className={cn('caption-bold', isMaxLength ? 'text-danger' : 'text-quaternary')}>
-                  {characterCount}자 / {DETAIL_FIELD_MAX_LENGTH}자
-                </p>
-              </div>
-              <DetailInput
-                value={fieldValue}
-                maxLength={DETAIL_FIELD_MAX_LENGTH}
-                readOnly={!isEditing}
-                onChange={handleDetailChange(key)}
-              />
-            </div>
-          );
-        })}
-      </div>
+      <ExperienceDetailFields
+        detail={detail}
+        isEditing={isEditing}
+        isPage={isPage}
+        onDetailChange={handleDetailChange}
+      />
       <ErrorDialog
         open={errorMessage.length > 0}
         message={errorMessage}
         onOpenChange={handleErrorDialogOpenChange}
       />
     </div>
-  );
-}
-
-type EditableDetailInfoItem =
-  | {
-      type: 'period';
-      label: string;
-      value: string;
-    }
-  | {
-      type: 'field';
-      label: string;
-      value: string;
-      displayValue: string;
-      name: BasicDetailKey;
-    };
-
-function getDetailInfoItems(
-  type: ExperienceItem['type'],
-  basicDetail: ExperienceItem['basicDetail'],
-  periodLabel: string,
-): EditableDetailInfoItem[] {
-  switch (type) {
-    case 'activity': {
-      const teamNum = basicDetail.teamNum ?? '';
-      const contributionRate = basicDetail.contributionRate ?? '';
-
-      return [
-        { type: 'period', label: '기간', value: periodLabel },
-        {
-          type: 'field',
-          label: '팀원 수',
-          value: teamNum,
-          displayValue: teamNum ? `${teamNum}명` : '',
-          name: 'teamNum',
-        },
-        {
-          type: 'field',
-          label: '내 역할',
-          value: basicDetail.role ?? '',
-          displayValue: basicDetail.role ?? '',
-          name: 'role',
-        },
-        {
-          type: 'field',
-          label: '기여도',
-          value: contributionRate,
-          displayValue: contributionRate ? `${contributionRate}%` : '',
-          name: 'contributionRate',
-        },
-      ];
-    }
-    case 'career':
-      return [
-        { type: 'period', label: '기간', value: periodLabel },
-        {
-          type: 'field',
-          label: '회사/기관/단체명',
-          value: basicDetail.company ?? '',
-          displayValue: basicDetail.company ?? '',
-          name: 'company',
-        },
-        {
-          type: 'field',
-          label: '고용 형태',
-          value: basicDetail.employmentStatus ?? '',
-          displayValue: basicDetail.employmentStatus ?? '',
-          name: 'employmentStatus',
-        },
-      ];
-    case 'education':
-      return [
-        { type: 'period', label: '기간', value: periodLabel },
-        {
-          type: 'field',
-          label: '기관명',
-          value: basicDetail.organizationName ?? '',
-          displayValue: basicDetail.organizationName ?? '',
-          name: 'organizationName',
-        },
-        {
-          type: 'field',
-          label: '수강명',
-          value: basicDetail.name ?? '',
-          displayValue: basicDetail.name ?? '',
-          name: 'name',
-        },
-      ];
-    case 'etc':
-      return [{ type: 'period', label: '기간', value: periodLabel }];
-  }
-}
-
-function InlineTextArea({
-  value,
-  ariaLabel,
-  maxLength,
-  className,
-  onChange,
-}: {
-  value: string;
-  ariaLabel: string;
-  maxLength?: number;
-  className?: string;
-  onChange: (value: string) => void;
-}) {
-  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
-
-  React.useLayoutEffect(() => {
-    const textarea = textareaRef.current;
-
-    if (!textarea) return;
-
-    textarea.style.height = '0px';
-    textarea.style.height = `${textarea.scrollHeight}px`;
-  }, [value]);
-
-  return (
-    <textarea
-      ref={textareaRef}
-      value={value}
-      aria-label={ariaLabel}
-      maxLength={maxLength}
-      rows={1}
-      className={cn(
-        'block min-h-[1.48em] w-full min-w-0 resize-none overflow-hidden bg-transparent p-0 leading-[1.48] outline-none',
-        className,
-      )}
-      onChange={(event) => onChange(event.currentTarget.value.slice(0, maxLength))}
-    />
   );
 }

--- a/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailContent.tsx
@@ -5,25 +5,26 @@ import * as React from 'react';
 
 import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
 import { EditableTagGroup } from '@/app/(pages)/experience/_components/EditableTagGroup';
+import {
+  type BasicDetailKey,
+  type ExperienceDetailSaveValue as ExperienceDetailSaveValueType,
+  useExperienceDetailForm,
+} from '@/app/(pages)/experience/_hooks/useExperienceDetailForm';
 import { getExperienceCategoryMeta } from '@/app/(pages)/experience/_utils/ExperienceCategory';
 import {
   EXPERIENCE_FIELD_MAX_LENGTHS,
   getExperienceFieldMaxLength,
-  limitExperienceFieldText,
 } from '@/app/(pages)/experience/_utils/experienceFieldLimits';
-import { formatExperiencePeriod } from '@/app/(pages)/experience/_utils/formatExperiencePeriod';
-import { sanitizeNumberText } from '@/app/(pages)/experience/_utils/sanitizeNumberText';
 import { DetailInput } from '@/components/common/DetailInput';
 import { ErrorDialog } from '@/components/common/ErrorDialog';
 import { CalendarIcon } from '@/components/common/icons/CalendarIcon';
 import { Tag } from '@/components/common/Tag';
-import {
-  type SingleMonthCalendarDateRange,
-  SingleMonthRangeCalendar,
-} from '@/components/common/SingleMonthRangeCalendar';
-import { type CalendarDateRange, RangeCalendar } from '@/components/common/RangeCalendar';
+import { SingleMonthRangeCalendar } from '@/components/common/SingleMonthRangeCalendar';
+import { RangeCalendar } from '@/components/common/RangeCalendar';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
+
+export type { ExperienceDetailSaveValue } from '@/app/(pages)/experience/_hooks/useExperienceDetailForm';
 
 const detailFields = [
   ['Situation', 'situation'],
@@ -34,26 +35,12 @@ const detailFields = [
 ] as const;
 const DETAIL_FIELD_MAX_LENGTH = 1000;
 
-type EditableTagGroupKey = 'skill' | 'competency';
-type BasicDetailKey = keyof ExperienceItem['basicDetail'];
-export type ExperienceDetailSaveValue = Pick<
-  ExperienceItem,
-  | 'title'
-  | 'description'
-  | 'basicDetail'
-  | 'detail'
-  | 'skillTags'
-  | 'competencyTags'
-  | 'startDate'
-  | 'endDate'
->;
-
 export interface ExperienceDetailContentProps extends React.ComponentProps<'div'> {
   experience: ExperienceItem;
   variant?: 'panel' | 'page';
   defaultEditing?: boolean;
   onEdit?: () => void;
-  onSave?: (experience: ExperienceDetailSaveValue) => Promise<void> | void;
+  onSave?: (experience: ExperienceDetailSaveValueType) => Promise<void> | void;
 }
 
 export function ExperienceDetailContent({
@@ -67,163 +54,41 @@ export function ExperienceDetailContent({
 }: ExperienceDetailContentProps) {
   const category = getExperienceCategoryMeta(experience.type);
   const isPage = variant === 'page';
-  const [title, setTitle] = React.useState(experience.title);
-  const [description, setDescription] = React.useState(experience.description);
-  const [detail, setDetail] = React.useState(experience.detail);
-  const [basicDetail, setBasicDetail] = React.useState(experience.basicDetail);
-  const [startDate, setStartDate] = React.useState(experience.startDate);
-  const [endDate, setEndDate] = React.useState(experience.endDate);
-  const [skillTags, setSkillTags] = React.useState(experience.skillTags);
-  const [competencyTags, setCompetencyTags] = React.useState(experience.competencyTags);
-  const [isEditing, setIsEditing] = React.useState(defaultEditing);
-  const [isSaving, setIsSaving] = React.useState(false);
-  const [editingTagGroup, setEditingTagGroup] = React.useState<EditableTagGroupKey | null>(null);
-  const [datePickerOpen, setDatePickerOpen] = React.useState(false);
-  const [datePickerTop, setDatePickerTop] = React.useState<number | null>(null);
-  const [errorMessage, setErrorMessage] = React.useState('');
-  const datePickerRootRef = React.useRef<HTMLDivElement>(null);
-  const datePickerButtonRef = React.useRef<HTMLButtonElement>(null);
-  const previousExperienceIdRef = React.useRef(experience.id);
-
-  React.useEffect(() => {
-    const isSameExperience = previousExperienceIdRef.current === experience.id;
-
-    if (isSameExperience && isEditing) {
-      return;
-    }
-
-    previousExperienceIdRef.current = experience.id;
-    setTitle(experience.title);
-    setDescription(experience.description);
-    setDetail(experience.detail);
-    setBasicDetail(experience.basicDetail);
-    setStartDate(experience.startDate);
-    setEndDate(experience.endDate);
-    setSkillTags(experience.skillTags);
-    setCompetencyTags(experience.competencyTags);
-    setIsEditing(defaultEditing);
-    setIsSaving(false);
-    setEditingTagGroup(null);
-    setDatePickerOpen(false);
-    setDatePickerTop(null);
-  }, [
-    defaultEditing,
-    experience.basicDetail,
-    experience.competencyTags,
-    experience.description,
-    experience.detail,
-    experience.endDate,
-    experience.id,
-    experience.skillTags,
-    experience.startDate,
-    experience.title,
+  const {
+    title,
+    description,
+    detail,
+    basicDetail,
+    skillTags,
+    competencyTags,
     isEditing,
-  ]);
-
-  React.useEffect(() => {
-    if (!datePickerOpen) return;
-
-    const handlePointerDown = (event: PointerEvent) => {
-      const root = datePickerRootRef.current;
-
-      if (root && !root.contains(event.target as Node)) {
-        setDatePickerOpen(false);
-      }
-    };
-
-    document.addEventListener('pointerdown', handlePointerDown, true);
-
-    return () => {
-      document.removeEventListener('pointerdown', handlePointerDown, true);
-    };
-  }, [datePickerOpen]);
-
-  React.useEffect(() => {
-    if (!datePickerOpen) return;
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        setDatePickerOpen(false);
-      }
-    };
-
-    document.addEventListener('keydown', handleKeyDown);
-
-    return () => {
-      document.removeEventListener('keydown', handleKeyDown);
-    };
-  }, [datePickerOpen]);
-
-  const selectedDateRange = React.useMemo<
-    CalendarDateRange | SingleMonthCalendarDateRange | null
-  >(() => {
-    const parsedStartDate = parseDateValue(startDate);
-    const parsedEndDate = parseDateValue(endDate);
-
-    if (!parsedStartDate || !parsedEndDate) return null;
-
-    return { start: parsedStartDate, end: parsedEndDate };
-  }, [endDate, startDate]);
-
-  const handleDetailChange =
-    (key: keyof ExperienceItem['detail']): React.ChangeEventHandler<HTMLTextAreaElement> =>
-    (event) => {
-      setDetail((prev) => ({
-        ...prev,
-        [key]: event.target.value,
-      }));
-    };
-
-  const updateBasicDetail = (key: BasicDetailKey, value: string) => {
-    const nextValue = getSanitizedBasicDetailValue(key, value);
-
-    setBasicDetail((currentBasicDetail) => ({
-      ...currentBasicDetail,
-      [key]: nextValue,
-    }));
-  };
-
-  const handleEditClick = () => {
-    onEdit?.();
-    setIsEditing(true);
-    setEditingTagGroup(null);
-  };
-
-  const handleSaveEdit = async () => {
-    try {
-      setIsSaving(true);
-      await onSave?.({
-        title,
-        description,
-        detail,
-        basicDetail,
-        startDate,
-        endDate,
-        skillTags,
-        competencyTags,
-      });
-      setIsEditing(false);
-      setEditingTagGroup(null);
-      setDatePickerOpen(false);
-      setDatePickerTop(null);
-    } catch (error) {
-      setErrorMessage(error instanceof Error ? error.message : '경험 수정 중 오류가 발생했습니다.');
-    } finally {
-      setIsSaving(false);
-    }
-  };
-
-  const toggleDatePicker = () => {
-    const buttonRect = datePickerButtonRef.current?.getBoundingClientRect();
-
-    if (buttonRect) {
-      setDatePickerTop(buttonRect.bottom + 8);
-    }
-
-    setDatePickerOpen((open) => !open);
-  };
-
-  const periodLabel = formatExperiencePeriod(startDate, endDate);
+    isSaving,
+    editingTagGroup,
+    datePickerOpen,
+    datePickerTop,
+    errorMessage,
+    datePickerRootRef,
+    datePickerButtonRef,
+    selectedDateRange,
+    periodLabel,
+    setSkillTags,
+    setCompetencyTags,
+    setEditingTagGroup,
+    updateTitle,
+    updateDescription,
+    handleDetailChange,
+    updateBasicDetail,
+    handleEditClick,
+    handleSaveEdit,
+    toggleDatePicker,
+    handleDateRangeChange,
+    handleErrorDialogOpenChange,
+  } = useExperienceDetailForm({
+    experience,
+    defaultEditing,
+    onEdit,
+    onSave,
+  });
   const detailInfoItems = React.useMemo(
     () => getDetailInfoItems(experience.type, basicDetail, periodLabel),
     [basicDetail, experience.type, periodLabel],
@@ -244,12 +109,12 @@ export function ExperienceDetailContent({
                 ariaLabel="제목"
                 maxLength={EXPERIENCE_FIELD_MAX_LENGTHS.title}
                 className={cn('text-strong', isPage ? 'heading-2-bold' : 'title-1-bold')}
-                onChange={(value) => setTitle(limitExperienceFieldText('title', value))}
+                onChange={updateTitle}
               />
             ) : (
               <h3
                 className={cn(
-                  'w-full min-w-0 wrap-break-word leading-[1.48] text-strong',
+                  'w-full min-w-0 leading-[1.48] wrap-break-word text-strong',
                   isPage ? 'heading-2-bold' : 'title-1-bold',
                 )}
               >
@@ -262,14 +127,12 @@ export function ExperienceDetailContent({
                 ariaLabel="한 줄 설명"
                 maxLength={EXPERIENCE_FIELD_MAX_LENGTHS.description}
                 className={cn('text-quaternary', isPage ? 'body-1-bold' : 'body-3-regular')}
-                onChange={(value) =>
-                  setDescription(limitExperienceFieldText('description', value))
-                }
+                onChange={updateDescription}
               />
             ) : (
               <p
                 className={cn(
-                  'w-full min-w-0 wrap-break-word leading-[1.48] text-quaternary',
+                  'w-full min-w-0 leading-[1.48] wrap-break-word text-quaternary',
                   isPage ? 'body-1-bold' : 'body-3-regular',
                 )}
               >
@@ -354,25 +217,13 @@ export function ExperienceDetailContent({
                             <RangeCalendar
                               value={selectedDateRange}
                               defaultVisibleMonth={selectedDateRange?.start ?? new Date()}
-                              onChange={(nextRange) => {
-                                if (!nextRange) return;
-
-                                setStartDate(formatDateValue(nextRange.start));
-                                setEndDate(formatDateValue(nextRange.end));
-                                setDatePickerOpen(false);
-                              }}
+                              onChange={handleDateRangeChange}
                             />
                           ) : (
                             <SingleMonthRangeCalendar
                               value={selectedDateRange}
                               defaultVisibleMonth={selectedDateRange?.start ?? new Date()}
-                              onChange={(nextRange) => {
-                                if (!nextRange) return;
-
-                                setStartDate(formatDateValue(nextRange.start));
-                                setEndDate(formatDateValue(nextRange.end));
-                                setDatePickerOpen(false);
-                              }}
+                              onChange={handleDateRangeChange}
                             />
                           )}
                         </div>
@@ -388,7 +239,9 @@ export function ExperienceDetailContent({
                       onChange={(value) => updateBasicDetail(item.name, value)}
                     />
                   ) : (
-                    !isEditing && <span>{item.type === 'field' ? item.displayValue : item.value}</span>
+                    !isEditing && (
+                      <span>{item.type === 'field' ? item.displayValue : item.value}</span>
+                    )
                   )}
                 </dd>
               </div>
@@ -426,7 +279,7 @@ export function ExperienceDetailContent({
           <div className="flex flex-col gap-2">
             <div className="flex flex-wrap gap-1">
               {skillTags.map((tag, index) => (
-                <Tag key={`skill-${tag}-${index}`} tone="skill" size='large'>
+                <Tag key={`skill-${tag}-${index}`} tone="skill" size="large">
                   {tag}
                 </Tag>
               ))}
@@ -434,11 +287,7 @@ export function ExperienceDetailContent({
 
             <div className="flex flex-wrap gap-1">
               {competencyTags.map((tag, index) => (
-                <Tag
-                  key={`competency-${tag}-${index}`}
-                  tone="competency"
-                  size='large'
-                >
+                <Tag key={`competency-${tag}-${index}`} tone="competency" size="large">
                   {tag}
                 </Tag>
               ))}
@@ -458,7 +307,9 @@ export function ExperienceDetailContent({
           return (
             <div key={key} className="flex w-full flex-col gap-1.5">
               <div className="flex items-end gap-3 px-2">
-                <h3 className={cn('font-bold text-primary', isPage ? 'title-2-bold' : 'body-2-bold')}>
+                <h3
+                  className={cn('font-bold text-primary', isPage ? 'title-2-bold' : 'body-2-bold')}
+                >
                   {label}
                 </h3>
                 <p className={cn('caption-bold', isMaxLength ? 'text-danger' : 'text-quaternary')}>
@@ -478,22 +329,10 @@ export function ExperienceDetailContent({
       <ErrorDialog
         open={errorMessage.length > 0}
         message={errorMessage}
-        onOpenChange={(open) => {
-          if (!open) {
-            setErrorMessage('');
-          }
-        }}
+        onOpenChange={handleErrorDialogOpenChange}
       />
     </div>
   );
-}
-
-function getSanitizedBasicDetailValue(key: BasicDetailKey, value: string) {
-  if (key === 'teamNum' || key === 'contributionRate') {
-    return sanitizeNumberText(value, 100);
-  }
-
-  return limitExperienceFieldText(key, value);
 }
 
 type EditableDetailInfoItem =
@@ -624,20 +463,4 @@ function InlineTextArea({
       onChange={(event) => onChange(event.currentTarget.value.slice(0, maxLength))}
     />
   );
-}
-
-function parseDateValue(value: string) {
-  if (!value) return null;
-
-  const date = new Date(`${value}T00:00:00`);
-
-  return Number.isNaN(date.getTime()) ? null : date;
-}
-
-function formatDateValue(date: Date) {
-  const year = date.getFullYear();
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  const day = String(date.getDate()).padStart(2, '0');
-
-  return `${year}-${month}-${day}`;
 }

--- a/src/app/(pages)/experience/_components/ExperienceDetailFields.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailFields.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import * as React from 'react';
+
+import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+import { DetailInput } from '@/components/common/DetailInput';
+import { cn } from '@/lib/utils';
+
+const detailFields = [
+  ['Situation', 'situation'],
+  ['Task', 'task'],
+  ['Action', 'action'],
+  ['Result', 'result'],
+  ['Taken', 'taken'],
+] as const;
+const DETAIL_FIELD_MAX_LENGTH = 1000;
+
+interface ExperienceDetailFieldsProps {
+  detail: ExperienceItem['detail'];
+  isEditing: boolean;
+  isPage: boolean;
+  onDetailChange: (
+    key: keyof ExperienceItem['detail'],
+  ) => React.ChangeEventHandler<HTMLTextAreaElement>;
+}
+
+export function ExperienceDetailFields({
+  detail,
+  isEditing,
+  isPage,
+  onDetailChange,
+}: ExperienceDetailFieldsProps) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-x-hidden py-6">
+      {detailFields.map(([label, key]) => {
+        const fieldValue = detail[key] ?? '';
+        const characterCount = fieldValue.length;
+        const isMaxLength = characterCount >= DETAIL_FIELD_MAX_LENGTH;
+
+        return (
+          <div key={key} className="flex w-full flex-col gap-1.5">
+            <div className="flex items-end gap-3 px-2">
+              <h3 className={cn('font-bold text-primary', isPage ? 'title-2-bold' : 'body-2-bold')}>
+                {label}
+              </h3>
+              <p className={cn('caption-bold', isMaxLength ? 'text-danger' : 'text-quaternary')}>
+                {characterCount}자 / {DETAIL_FIELD_MAX_LENGTH}자
+              </p>
+            </div>
+            <DetailInput
+              value={fieldValue}
+              maxLength={DETAIL_FIELD_MAX_LENGTH}
+              readOnly={!isEditing}
+              onChange={onDetailChange(key)}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/app/(pages)/experience/_components/ExperienceDetailHeader.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailHeader.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { ExperienceDetailInlineTextArea } from '@/app/(pages)/experience/_components/ExperienceDetailInlineTextArea';
+import { EXPERIENCE_FIELD_MAX_LENGTHS } from '@/app/(pages)/experience/_utils/experienceFieldLimits';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface ExperienceDetailHeaderProps {
+  title: string;
+  description: string;
+  isEditing: boolean;
+  isSaving: boolean;
+  isPage: boolean;
+  onTitleChange: (value: string) => void;
+  onDescriptionChange: (value: string) => void;
+  onEditClick: () => void;
+  onSaveClick: () => void;
+}
+
+export function ExperienceDetailHeader({
+  title,
+  description,
+  isEditing,
+  isSaving,
+  isPage,
+  onTitleChange,
+  onDescriptionChange,
+  onEditClick,
+  onSaveClick,
+}: ExperienceDetailHeaderProps) {
+  return (
+    <div className="flex min-w-0 items-start justify-between gap-4">
+      <div className="flex min-w-0 flex-1 flex-col gap-1">
+        {isEditing ? (
+          <ExperienceDetailInlineTextArea
+            value={title}
+            ariaLabel="제목"
+            maxLength={EXPERIENCE_FIELD_MAX_LENGTHS.title}
+            className={cn('text-strong', isPage ? 'heading-2-bold' : 'title-1-bold')}
+            onChange={onTitleChange}
+          />
+        ) : (
+          <h3
+            className={cn(
+              'w-full min-w-0 leading-[1.48] wrap-break-word text-strong',
+              isPage ? 'heading-2-bold' : 'title-1-bold',
+            )}
+          >
+            {title}
+          </h3>
+        )}
+
+        {isEditing ? (
+          <ExperienceDetailInlineTextArea
+            value={description}
+            ariaLabel="한 줄 설명"
+            maxLength={EXPERIENCE_FIELD_MAX_LENGTHS.description}
+            className={cn('text-quaternary', isPage ? 'body-1-bold' : 'body-3-regular')}
+            onChange={onDescriptionChange}
+          />
+        ) : (
+          <p
+            className={cn(
+              'w-full min-w-0 leading-[1.48] wrap-break-word text-quaternary',
+              isPage ? 'body-1-bold' : 'body-3-regular',
+            )}
+          >
+            {description}
+          </p>
+        )}
+      </div>
+
+      {isEditing ? (
+        <Button type="button" disabled={isSaving} onClick={onSaveClick}>
+          {isSaving ? '저장 중...' : '저장하기'}
+        </Button>
+      ) : (
+        <Button type="button" variant="secondary" onClick={onEditClick}>
+          수정하기
+        </Button>
+      )}
+    </div>
+  );
+}

--- a/src/app/(pages)/experience/_components/ExperienceDetailInlineTextArea.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailInlineTextArea.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface ExperienceDetailInlineTextAreaProps {
+  value: string;
+  ariaLabel: string;
+  maxLength?: number;
+  className?: string;
+  onChange: (value: string) => void;
+}
+
+export function ExperienceDetailInlineTextArea({
+  value,
+  ariaLabel,
+  maxLength,
+  className,
+  onChange,
+}: ExperienceDetailInlineTextAreaProps) {
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  React.useLayoutEffect(() => {
+    const textarea = textareaRef.current;
+
+    if (!textarea) return;
+
+    textarea.style.height = '0px';
+    textarea.style.height = `${textarea.scrollHeight}px`;
+  }, [value]);
+
+  return (
+    <textarea
+      ref={textareaRef}
+      value={value}
+      aria-label={ariaLabel}
+      maxLength={maxLength}
+      rows={1}
+      className={cn(
+        'block min-h-[1.48em] w-full min-w-0 resize-none overflow-hidden bg-transparent p-0 leading-[1.48] outline-none',
+        className,
+      )}
+      onChange={(event) => onChange(event.currentTarget.value.slice(0, maxLength))}
+    />
+  );
+}

--- a/src/app/(pages)/experience/_components/ExperienceDetailPeriodPicker.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailPeriodPicker.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import * as React from 'react';
+
+import { CalendarIcon } from '@/components/common/icons/CalendarIcon';
+import { type CalendarDateRange, RangeCalendar } from '@/components/common/RangeCalendar';
+import {
+  type SingleMonthCalendarDateRange,
+  SingleMonthRangeCalendar,
+} from '@/components/common/SingleMonthRangeCalendar';
+import { cn } from '@/lib/utils';
+
+export type ExperienceDetailDateRange = CalendarDateRange | SingleMonthCalendarDateRange;
+
+interface ExperienceDetailPeriodPickerProps {
+  value: string;
+  isPage: boolean;
+  open: boolean;
+  top: number | null;
+  rootRef: React.RefObject<HTMLDivElement | null>;
+  buttonRef: React.RefObject<HTMLButtonElement | null>;
+  selectedDateRange: CalendarDateRange | null;
+  onToggle: () => void;
+  onChange: (nextRange: ExperienceDetailDateRange | null) => void;
+}
+
+export function ExperienceDetailPeriodPicker({
+  value,
+  isPage,
+  open,
+  top,
+  rootRef,
+  buttonRef,
+  selectedDateRange,
+  onToggle,
+  onChange,
+}: ExperienceDetailPeriodPickerProps) {
+  return (
+    <div ref={rootRef} className="relative flex items-center gap-1">
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-label="기간 선택"
+        aria-expanded={open}
+        className="flex min-w-0 cursor-pointer items-center gap-1 rounded-sm text-secondary focus-visible:shadow-focus-ring focus-visible:outline-none"
+        onClick={onToggle}
+      >
+        <CalendarIcon className="size-[21px] shrink-0 text-tertiary" />
+        <span>{value}</span>
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label="기간 선택"
+          className={cn(
+            'z-60',
+            isPage
+              ? 'absolute top-full left-0 mt-2'
+              : 'fixed right-[max(1rem,calc((min(100vw,500px)-24rem)/2))]',
+          )}
+          style={isPage ? undefined : { top: top ?? undefined }}
+        >
+          {isPage ? (
+            <RangeCalendar
+              value={selectedDateRange}
+              defaultVisibleMonth={selectedDateRange?.start ?? new Date()}
+              onChange={onChange}
+            />
+          ) : (
+            <SingleMonthRangeCalendar
+              value={selectedDateRange}
+              defaultVisibleMonth={selectedDateRange?.start ?? new Date()}
+              onChange={onChange}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(pages)/experience/_components/ExperienceDetailSummary.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailSummary.tsx
@@ -5,18 +5,17 @@ import * as React from 'react';
 
 import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
 import { ExperienceDetailInlineTextArea } from '@/app/(pages)/experience/_components/ExperienceDetailInlineTextArea';
+import {
+  type ExperienceDetailDateRange,
+  ExperienceDetailPeriodPicker,
+} from '@/app/(pages)/experience/_components/ExperienceDetailPeriodPicker';
 import { getExperienceCategoryMeta } from '@/app/(pages)/experience/_utils/ExperienceCategory';
 import {
   type BasicDetailKey,
   getExperienceDetailInfoItems,
 } from '@/app/(pages)/experience/_utils/experienceDetailInfoItems';
 import { getExperienceFieldMaxLength } from '@/app/(pages)/experience/_utils/experienceFieldLimits';
-import { CalendarIcon } from '@/components/common/icons/CalendarIcon';
-import { type CalendarDateRange, RangeCalendar } from '@/components/common/RangeCalendar';
-import {
-  type SingleMonthCalendarDateRange,
-  SingleMonthRangeCalendar,
-} from '@/components/common/SingleMonthRangeCalendar';
+import type { CalendarDateRange } from '@/components/common/RangeCalendar';
 import { cn } from '@/lib/utils';
 
 interface ExperienceDetailSummaryProps {
@@ -31,7 +30,7 @@ interface ExperienceDetailSummaryProps {
   datePickerButtonRef: React.RefObject<HTMLButtonElement | null>;
   selectedDateRange: CalendarDateRange | null;
   onDatePickerToggle: () => void;
-  onDateRangeChange: (nextRange: CalendarDateRange | SingleMonthCalendarDateRange | null) => void;
+  onDateRangeChange: (nextRange: ExperienceDetailDateRange | null) => void;
   onBasicDetailChange: (key: BasicDetailKey, value: string) => void;
 }
 
@@ -94,46 +93,17 @@ export function ExperienceDetailSummary({
               )}
             >
               {isEditing && item.type === 'period' ? (
-                <div ref={datePickerRootRef} className="relative flex items-center gap-1">
-                  <button
-                    ref={datePickerButtonRef}
-                    type="button"
-                    aria-label="기간 선택"
-                    aria-expanded={datePickerOpen}
-                    className="flex min-w-0 cursor-pointer items-center gap-1 rounded-sm text-secondary focus-visible:shadow-focus-ring focus-visible:outline-none"
-                    onClick={onDatePickerToggle}
-                  >
-                    <CalendarIcon className="size-[21px] shrink-0 text-tertiary" />
-                    <span>{item.value}</span>
-                  </button>
-                  {datePickerOpen && (
-                    <div
-                      role="dialog"
-                      aria-label="기간 선택"
-                      className={cn(
-                        'z-60',
-                        isPage
-                          ? 'absolute top-full left-0 mt-2'
-                          : 'fixed right-[max(1rem,calc((min(100vw,500px)-24rem)/2))]',
-                      )}
-                      style={isPage ? undefined : { top: datePickerTop ?? undefined }}
-                    >
-                      {isPage ? (
-                        <RangeCalendar
-                          value={selectedDateRange}
-                          defaultVisibleMonth={selectedDateRange?.start ?? new Date()}
-                          onChange={onDateRangeChange}
-                        />
-                      ) : (
-                        <SingleMonthRangeCalendar
-                          value={selectedDateRange}
-                          defaultVisibleMonth={selectedDateRange?.start ?? new Date()}
-                          onChange={onDateRangeChange}
-                        />
-                      )}
-                    </div>
-                  )}
-                </div>
+                <ExperienceDetailPeriodPicker
+                  value={item.value}
+                  isPage={isPage}
+                  open={datePickerOpen}
+                  top={datePickerTop}
+                  rootRef={datePickerRootRef}
+                  buttonRef={datePickerButtonRef}
+                  selectedDateRange={selectedDateRange}
+                  onToggle={onDatePickerToggle}
+                  onChange={onDateRangeChange}
+                />
               ) : null}
               {isEditing && item.type === 'field' ? (
                 <ExperienceDetailInlineTextArea

--- a/src/app/(pages)/experience/_components/ExperienceDetailSummary.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailSummary.tsx
@@ -5,8 +5,11 @@ import * as React from 'react';
 
 import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
 import { ExperienceDetailInlineTextArea } from '@/app/(pages)/experience/_components/ExperienceDetailInlineTextArea';
-import type { BasicDetailKey } from '@/app/(pages)/experience/_hooks/useExperienceDetailForm';
 import { getExperienceCategoryMeta } from '@/app/(pages)/experience/_utils/ExperienceCategory';
+import {
+  type BasicDetailKey,
+  getExperienceDetailInfoItems,
+} from '@/app/(pages)/experience/_utils/experienceDetailInfoItems';
 import { getExperienceFieldMaxLength } from '@/app/(pages)/experience/_utils/experienceFieldLimits';
 import { CalendarIcon } from '@/components/common/icons/CalendarIcon';
 import { type CalendarDateRange, RangeCalendar } from '@/components/common/RangeCalendar';
@@ -49,7 +52,7 @@ export function ExperienceDetailSummary({
 }: ExperienceDetailSummaryProps) {
   const category = getExperienceCategoryMeta(type);
   const detailInfoItems = React.useMemo(
-    () => getDetailInfoItems(type, basicDetail, periodLabel),
+    () => getExperienceDetailInfoItems(type, basicDetail, periodLabel),
     [basicDetail, periodLabel, type],
   );
 
@@ -149,94 +152,4 @@ export function ExperienceDetailSummary({
       </dl>
     </div>
   );
-}
-
-type EditableDetailInfoItem =
-  | {
-      type: 'period';
-      label: string;
-      value: string;
-    }
-  | {
-      type: 'field';
-      label: string;
-      value: string;
-      displayValue: string;
-      name: BasicDetailKey;
-    };
-
-function getDetailInfoItems(
-  type: ExperienceItem['type'],
-  basicDetail: ExperienceItem['basicDetail'],
-  periodLabel: string,
-): EditableDetailInfoItem[] {
-  switch (type) {
-    case 'activity': {
-      const teamNum = basicDetail.teamNum ?? '';
-      const contributionRate = basicDetail.contributionRate ?? '';
-
-      return [
-        { type: 'period', label: '기간', value: periodLabel },
-        {
-          type: 'field',
-          label: '팀원 수',
-          value: teamNum,
-          displayValue: teamNum ? `${teamNum}명` : '',
-          name: 'teamNum',
-        },
-        {
-          type: 'field',
-          label: '내 역할',
-          value: basicDetail.role ?? '',
-          displayValue: basicDetail.role ?? '',
-          name: 'role',
-        },
-        {
-          type: 'field',
-          label: '기여도',
-          value: contributionRate,
-          displayValue: contributionRate ? `${contributionRate}%` : '',
-          name: 'contributionRate',
-        },
-      ];
-    }
-    case 'career':
-      return [
-        { type: 'period', label: '기간', value: periodLabel },
-        {
-          type: 'field',
-          label: '회사/기관/단체명',
-          value: basicDetail.company ?? '',
-          displayValue: basicDetail.company ?? '',
-          name: 'company',
-        },
-        {
-          type: 'field',
-          label: '고용 형태',
-          value: basicDetail.employmentStatus ?? '',
-          displayValue: basicDetail.employmentStatus ?? '',
-          name: 'employmentStatus',
-        },
-      ];
-    case 'education':
-      return [
-        { type: 'period', label: '기간', value: periodLabel },
-        {
-          type: 'field',
-          label: '기관명',
-          value: basicDetail.organizationName ?? '',
-          displayValue: basicDetail.organizationName ?? '',
-          name: 'organizationName',
-        },
-        {
-          type: 'field',
-          label: '수강명',
-          value: basicDetail.name ?? '',
-          displayValue: basicDetail.name ?? '',
-          name: 'name',
-        },
-      ];
-    case 'etc':
-      return [{ type: 'period', label: '기간', value: periodLabel }];
-  }
 }

--- a/src/app/(pages)/experience/_components/ExperienceDetailSummary.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailSummary.tsx
@@ -1,0 +1,242 @@
+'use client';
+
+import Image from 'next/image';
+import * as React from 'react';
+
+import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+import { ExperienceDetailInlineTextArea } from '@/app/(pages)/experience/_components/ExperienceDetailInlineTextArea';
+import type { BasicDetailKey } from '@/app/(pages)/experience/_hooks/useExperienceDetailForm';
+import { getExperienceCategoryMeta } from '@/app/(pages)/experience/_utils/ExperienceCategory';
+import { getExperienceFieldMaxLength } from '@/app/(pages)/experience/_utils/experienceFieldLimits';
+import { CalendarIcon } from '@/components/common/icons/CalendarIcon';
+import { type CalendarDateRange, RangeCalendar } from '@/components/common/RangeCalendar';
+import {
+  type SingleMonthCalendarDateRange,
+  SingleMonthRangeCalendar,
+} from '@/components/common/SingleMonthRangeCalendar';
+import { cn } from '@/lib/utils';
+
+interface ExperienceDetailSummaryProps {
+  type: ExperienceItem['type'];
+  basicDetail: ExperienceItem['basicDetail'];
+  periodLabel: string;
+  isEditing: boolean;
+  isPage: boolean;
+  datePickerOpen: boolean;
+  datePickerTop: number | null;
+  datePickerRootRef: React.RefObject<HTMLDivElement | null>;
+  datePickerButtonRef: React.RefObject<HTMLButtonElement | null>;
+  selectedDateRange: CalendarDateRange | null;
+  onDatePickerToggle: () => void;
+  onDateRangeChange: (nextRange: CalendarDateRange | SingleMonthCalendarDateRange | null) => void;
+  onBasicDetailChange: (key: BasicDetailKey, value: string) => void;
+}
+
+export function ExperienceDetailSummary({
+  type,
+  basicDetail,
+  periodLabel,
+  isEditing,
+  isPage,
+  datePickerOpen,
+  datePickerTop,
+  datePickerRootRef,
+  datePickerButtonRef,
+  selectedDateRange,
+  onDatePickerToggle,
+  onDateRangeChange,
+  onBasicDetailChange,
+}: ExperienceDetailSummaryProps) {
+  const category = getExperienceCategoryMeta(type);
+  const detailInfoItems = React.useMemo(
+    () => getDetailInfoItems(type, basicDetail, periodLabel),
+    [basicDetail, periodLabel, type],
+  );
+
+  return (
+    <div className={cn('flex items-start gap-5', isPage && 'items-center')}>
+      <div
+        className={cn(
+          'flex shrink-0 flex-col items-center gap-0.5',
+          isPage ? 'w-[109px]' : 'w-[83px]',
+        )}
+      >
+        <Image
+          src={category.selectedIconSrc}
+          alt=""
+          width={isPage ? 109 : 72}
+          height={isPage ? 109 : 72}
+          className={cn(isPage ? 'size-[109px]' : 'size-[72px]')}
+        />
+        <span className={cn('font-bold text-strong', isPage ? 'body-2-bold' : 'body-3-bold')}>
+          {category.label}
+        </span>
+      </div>
+
+      <dl className="flex w-full flex-col gap-1.5">
+        {detailInfoItems.map((item) => (
+          <div key={item.label} className="flex w-full items-start gap-4">
+            <dt
+              className={cn(
+                'shrink-0 font-bold text-strong',
+                isPage ? 'body-1-bold' : 'body-3-bold',
+              )}
+            >
+              {item.label}
+            </dt>
+            <dd
+              className={cn(
+                'relative flex min-w-0 flex-1 items-center gap-1 text-secondary',
+                isPage ? 'body-1-regular' : 'body-3-regular',
+              )}
+            >
+              {isEditing && item.type === 'period' ? (
+                <div ref={datePickerRootRef} className="relative flex items-center gap-1">
+                  <button
+                    ref={datePickerButtonRef}
+                    type="button"
+                    aria-label="기간 선택"
+                    aria-expanded={datePickerOpen}
+                    className="flex min-w-0 cursor-pointer items-center gap-1 rounded-sm text-secondary focus-visible:shadow-focus-ring focus-visible:outline-none"
+                    onClick={onDatePickerToggle}
+                  >
+                    <CalendarIcon className="size-[21px] shrink-0 text-tertiary" />
+                    <span>{item.value}</span>
+                  </button>
+                  {datePickerOpen && (
+                    <div
+                      role="dialog"
+                      aria-label="기간 선택"
+                      className={cn(
+                        'z-60',
+                        isPage
+                          ? 'absolute top-full left-0 mt-2'
+                          : 'fixed right-[max(1rem,calc((min(100vw,500px)-24rem)/2))]',
+                      )}
+                      style={isPage ? undefined : { top: datePickerTop ?? undefined }}
+                    >
+                      {isPage ? (
+                        <RangeCalendar
+                          value={selectedDateRange}
+                          defaultVisibleMonth={selectedDateRange?.start ?? new Date()}
+                          onChange={onDateRangeChange}
+                        />
+                      ) : (
+                        <SingleMonthRangeCalendar
+                          value={selectedDateRange}
+                          defaultVisibleMonth={selectedDateRange?.start ?? new Date()}
+                          onChange={onDateRangeChange}
+                        />
+                      )}
+                    </div>
+                  )}
+                </div>
+              ) : null}
+              {isEditing && item.type === 'field' ? (
+                <ExperienceDetailInlineTextArea
+                  value={item.value}
+                  ariaLabel={item.label}
+                  maxLength={getExperienceFieldMaxLength(item.name)}
+                  className="text-secondary"
+                  onChange={(value) => onBasicDetailChange(item.name, value)}
+                />
+              ) : (
+                !isEditing && <span>{item.type === 'field' ? item.displayValue : item.value}</span>
+              )}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+type EditableDetailInfoItem =
+  | {
+      type: 'period';
+      label: string;
+      value: string;
+    }
+  | {
+      type: 'field';
+      label: string;
+      value: string;
+      displayValue: string;
+      name: BasicDetailKey;
+    };
+
+function getDetailInfoItems(
+  type: ExperienceItem['type'],
+  basicDetail: ExperienceItem['basicDetail'],
+  periodLabel: string,
+): EditableDetailInfoItem[] {
+  switch (type) {
+    case 'activity': {
+      const teamNum = basicDetail.teamNum ?? '';
+      const contributionRate = basicDetail.contributionRate ?? '';
+
+      return [
+        { type: 'period', label: '기간', value: periodLabel },
+        {
+          type: 'field',
+          label: '팀원 수',
+          value: teamNum,
+          displayValue: teamNum ? `${teamNum}명` : '',
+          name: 'teamNum',
+        },
+        {
+          type: 'field',
+          label: '내 역할',
+          value: basicDetail.role ?? '',
+          displayValue: basicDetail.role ?? '',
+          name: 'role',
+        },
+        {
+          type: 'field',
+          label: '기여도',
+          value: contributionRate,
+          displayValue: contributionRate ? `${contributionRate}%` : '',
+          name: 'contributionRate',
+        },
+      ];
+    }
+    case 'career':
+      return [
+        { type: 'period', label: '기간', value: periodLabel },
+        {
+          type: 'field',
+          label: '회사/기관/단체명',
+          value: basicDetail.company ?? '',
+          displayValue: basicDetail.company ?? '',
+          name: 'company',
+        },
+        {
+          type: 'field',
+          label: '고용 형태',
+          value: basicDetail.employmentStatus ?? '',
+          displayValue: basicDetail.employmentStatus ?? '',
+          name: 'employmentStatus',
+        },
+      ];
+    case 'education':
+      return [
+        { type: 'period', label: '기간', value: periodLabel },
+        {
+          type: 'field',
+          label: '기관명',
+          value: basicDetail.organizationName ?? '',
+          displayValue: basicDetail.organizationName ?? '',
+          name: 'organizationName',
+        },
+        {
+          type: 'field',
+          label: '수강명',
+          value: basicDetail.name ?? '',
+          displayValue: basicDetail.name ?? '',
+          name: 'name',
+        },
+      ];
+    case 'etc':
+      return [{ type: 'period', label: '기간', value: periodLabel }];
+  }
+}

--- a/src/app/(pages)/experience/_components/ExperienceDetailTags.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailTags.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { EditableTagGroup } from '@/app/(pages)/experience/_components/EditableTagGroup';
-import type { EditableTagGroupKey } from '@/app/(pages)/experience/_hooks/useExperienceDetailForm';
 import { Tag } from '@/components/common/Tag';
+
+type EditableTagGroupKey = 'skill' | 'competency';
 
 interface ExperienceDetailTagsProps {
   skillTags: string[];

--- a/src/app/(pages)/experience/_components/ExperienceDetailTags.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailTags.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { EditableTagGroup } from '@/app/(pages)/experience/_components/EditableTagGroup';
+import type { EditableTagGroupKey } from '@/app/(pages)/experience/_hooks/useExperienceDetailForm';
+import { Tag } from '@/components/common/Tag';
+
+interface ExperienceDetailTagsProps {
+  skillTags: string[];
+  competencyTags: string[];
+  isEditing: boolean;
+  editingTagGroup: EditableTagGroupKey | null;
+  onSkillTagsChange: (tags: string[]) => void;
+  onCompetencyTagsChange: (tags: string[]) => void;
+  onEditingTagGroupChange: (tagGroup: EditableTagGroupKey | null) => void;
+}
+
+export function ExperienceDetailTags({
+  skillTags,
+  competencyTags,
+  isEditing,
+  editingTagGroup,
+  onSkillTagsChange,
+  onCompetencyTagsChange,
+  onEditingTagGroupChange,
+}: ExperienceDetailTagsProps) {
+  if (isEditing) {
+    return (
+      <div className="flex flex-col gap-2.5">
+        <EditableTagGroup
+          label="기술"
+          tone="skill"
+          tags={skillTags}
+          editing={editingTagGroup === 'skill'}
+          variant="bordered-row"
+          viewTagSize="large"
+          onChange={onSkillTagsChange}
+          onEdit={() => onEditingTagGroupChange('skill')}
+          onRequestClose={() => onEditingTagGroupChange(null)}
+        />
+        <EditableTagGroup
+          label="역량"
+          tone="competency"
+          tags={competencyTags}
+          editing={editingTagGroup === 'competency'}
+          variant="bordered-row"
+          viewTagSize="large"
+          borderBottom
+          onChange={onCompetencyTagsChange}
+          onEdit={() => onEditingTagGroupChange('competency')}
+          onRequestClose={() => onEditingTagGroupChange(null)}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap gap-1">
+        {skillTags.map((tag, index) => (
+          <Tag key={`skill-${tag}-${index}`} tone="skill" size="large">
+            {tag}
+          </Tag>
+        ))}
+      </div>
+
+      <div className="flex flex-wrap gap-1">
+        {competencyTags.map((tag, index) => (
+          <Tag key={`competency-${tag}-${index}`} tone="competency" size="large">
+            {tag}
+          </Tag>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(pages)/experience/_hooks/useExperienceBoardActions.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceBoardActions.ts
@@ -1,0 +1,146 @@
+'use client';
+
+import * as React from 'react';
+
+import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+import type { ExperienceDetailSaveValue } from '@/app/(pages)/experience/_components/ExperienceDetailContent';
+import { mapExperienceItemToUpdateRequest } from '@/app/(pages)/experience/_utils/mapExperienceItemToUpdateRequest';
+import {
+  removeExperienceFromOrderMap,
+  type ExperienceOrderMap,
+} from '@/app/(pages)/experience/_utils/experienceOrder';
+import {
+  useDeleteExperience,
+  useUpdateExperience,
+  useUpdateExperienceTitle,
+} from '@/hooks/experience/useExperiences';
+
+interface UseExperienceBoardActionsParams {
+  panelExperience?: ExperienceItem | null;
+  selectedExperienceId?: string;
+  closeSelectedExperience: () => void;
+  setExperienceOrderMap: React.Dispatch<React.SetStateAction<ExperienceOrderMap>>;
+}
+
+export function useExperienceBoardActions({
+  panelExperience,
+  selectedExperienceId,
+  closeSelectedExperience,
+  setExperienceOrderMap,
+}: UseExperienceBoardActionsParams) {
+  const deleteExperienceMutation = useDeleteExperience();
+  const updateExperienceMutation = useUpdateExperience();
+  const updateExperienceTitleMutation = useUpdateExperienceTitle();
+  const [deleteTargetExperience, setDeleteTargetExperience] = React.useState<ExperienceItem | null>(
+    null,
+  );
+  const [errorMessage, setErrorMessage] = React.useState('');
+
+  const handleExperienceTitleSave = React.useCallback(
+    async (experience: ExperienceItem, nextTitle: string) => {
+      const experienceId = Number(experience.id);
+
+      if (!Number.isInteger(experienceId) || experienceId <= 0) {
+        throw new Error('수정할 경험 정보를 확인하지 못했습니다.');
+      }
+
+      await updateExperienceTitleMutation.mutateAsync({
+        experienceId,
+        request: { title: nextTitle },
+      });
+    },
+    [updateExperienceTitleMutation],
+  );
+
+  const handleExperienceDeleteRequest = React.useCallback((experience: ExperienceItem) => {
+    setDeleteTargetExperience(experience);
+  }, []);
+
+  const handleDeleteDialogOpenChange = React.useCallback(
+    (open: boolean) => {
+      if (!open && !deleteExperienceMutation.isPending) {
+        setDeleteTargetExperience(null);
+      }
+    },
+    [deleteExperienceMutation.isPending],
+  );
+
+  const handleExperienceDeleteConfirm = React.useCallback(
+    async (experience: ExperienceItem) => {
+      const experienceId = Number(experience.id);
+
+      if (!Number.isInteger(experienceId) || experienceId <= 0) {
+        setErrorMessage('삭제할 경험 정보를 확인하지 못했습니다.');
+        setDeleteTargetExperience(null);
+        return;
+      }
+
+      try {
+        await deleteExperienceMutation.mutateAsync(experienceId);
+
+        setExperienceOrderMap((currentOrderMap) =>
+          removeExperienceFromOrderMap(currentOrderMap, experience.id),
+        );
+
+        if (selectedExperienceId === experience.id) {
+          closeSelectedExperience();
+        }
+      } catch (error) {
+        setErrorMessage(
+          error instanceof Error ? error.message : '경험 삭제 중 오류가 발생했습니다.',
+        );
+      } finally {
+        setDeleteTargetExperience(null);
+      }
+    },
+    [
+      closeSelectedExperience,
+      deleteExperienceMutation,
+      selectedExperienceId,
+      setExperienceOrderMap,
+    ],
+  );
+
+  const handleExperienceDetailSave = React.useCallback(
+    async (nextExperience: ExperienceDetailSaveValue) => {
+      if (!panelExperience) {
+        throw new Error('수정할 경험 정보를 확인하지 못했습니다.');
+      }
+
+      const experienceId = Number(panelExperience.id);
+
+      if (!Number.isInteger(experienceId) || experienceId <= 0) {
+        throw new Error('수정할 경험 정보를 확인하지 못했습니다.');
+      }
+
+      const updatedExperience = {
+        ...panelExperience,
+        ...nextExperience,
+      };
+
+      await updateExperienceMutation.mutateAsync({
+        experienceId,
+        request: mapExperienceItemToUpdateRequest(updatedExperience),
+      });
+    },
+    [panelExperience, updateExperienceMutation],
+  );
+
+  const handleErrorDialogOpenChange = React.useCallback((open: boolean) => {
+    if (!open) {
+      setErrorMessage('');
+    }
+  }, []);
+
+  return {
+    deleteTargetExperience,
+    errorMessage,
+    isDeletingExperience: deleteExperienceMutation.isPending,
+    handleExperienceTitleSave,
+    handleExperienceDeleteRequest,
+    handleDeleteDialogOpenChange,
+    handleExperienceDeleteConfirm,
+    handleExperienceDetailSave,
+    handleErrorDialogOpenChange,
+  };
+}

--- a/src/app/(pages)/experience/_hooks/useExperienceBoardDetail.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceBoardDetail.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import * as React from 'react';
+
+import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+import { mapExperienceDetailToItem } from '@/app/(pages)/experience/_utils/mapExperienceResponse';
+import { useExperienceDetail } from '@/hooks/experience/useExperiences';
+
+interface UseExperienceBoardDetailParams {
+  selectedExperienceId?: string;
+  selectedExperience?: ExperienceItem;
+  panelOpen: boolean;
+}
+
+export function useExperienceBoardDetail({
+  selectedExperienceId,
+  selectedExperience,
+  panelOpen,
+}: UseExperienceBoardDetailParams) {
+  const selectedExperienceNumericId = selectedExperienceId ? Number(selectedExperienceId) : null;
+  const {
+    data: selectedExperienceDetail,
+    isError: isDetailError,
+    isFetching: isDetailFetching,
+    isPending: isDetailPending,
+  } = useExperienceDetail(
+    Number.isFinite(selectedExperienceNumericId) ? selectedExperienceNumericId : null,
+  );
+  const selectedExperienceDetailMatches =
+    selectedExperienceDetail?.experienceId === selectedExperienceNumericId;
+  const selectedExperienceDetailItem = React.useMemo(
+    () =>
+      selectedExperienceDetail && selectedExperienceDetailMatches
+        ? mapExperienceDetailToItem(selectedExperienceDetail)
+        : null,
+    [selectedExperienceDetail, selectedExperienceDetailMatches],
+  );
+
+  const panelExperience = selectedExperienceDetailItem ?? selectedExperience;
+  const showDetailLoading =
+    panelOpen &&
+    Boolean(selectedExperienceId) &&
+    (isDetailPending || (isDetailFetching && !selectedExperienceDetailMatches));
+
+  return {
+    panelExperience,
+    isDetailError,
+    showDetailLoading,
+  };
+}

--- a/src/app/(pages)/experience/_hooks/useExperienceBoardDetail.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceBoardDetail.ts
@@ -18,16 +18,17 @@ export function useExperienceBoardDetail({
   panelOpen,
 }: UseExperienceBoardDetailParams) {
   const selectedExperienceNumericId = selectedExperienceId ? Number(selectedExperienceId) : null;
+  const selectedExperienceDetailId = isValidExperienceId(selectedExperienceNumericId)
+    ? selectedExperienceNumericId
+    : null;
   const {
     data: selectedExperienceDetail,
     isError: isDetailError,
     isFetching: isDetailFetching,
     isPending: isDetailPending,
-  } = useExperienceDetail(
-    Number.isFinite(selectedExperienceNumericId) ? selectedExperienceNumericId : null,
-  );
+  } = useExperienceDetail(selectedExperienceDetailId);
   const selectedExperienceDetailMatches =
-    selectedExperienceDetail?.experienceId === selectedExperienceNumericId;
+    selectedExperienceDetail?.experienceId === selectedExperienceDetailId;
   const selectedExperienceDetailItem = React.useMemo(
     () =>
       selectedExperienceDetail && selectedExperienceDetailMatches
@@ -39,7 +40,7 @@ export function useExperienceBoardDetail({
   const panelExperience = selectedExperienceDetailItem ?? selectedExperience;
   const showDetailLoading =
     panelOpen &&
-    Boolean(selectedExperienceId) &&
+    selectedExperienceDetailId !== null &&
     (isDetailPending || (isDetailFetching && !selectedExperienceDetailMatches));
 
   return {
@@ -47,4 +48,8 @@ export function useExperienceBoardDetail({
     isDetailError,
     showDetailLoading,
   };
+}
+
+function isValidExperienceId(experienceId: number | null) {
+  return experienceId !== null && Number.isInteger(experienceId) && experienceId > 0;
 }

--- a/src/app/(pages)/experience/_hooks/useExperienceBoardInfiniteScroll.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceBoardInfiniteScroll.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import * as React from 'react';
+
+interface UseExperienceBoardInfiniteScrollParams {
+  fetchNextPage: () => Promise<unknown> | unknown;
+  hasNextPage?: boolean;
+  isFetchingNextPage: boolean;
+  observedItemCount: number;
+}
+
+export function useExperienceBoardInfiniteScroll({
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+  observedItemCount,
+}: UseExperienceBoardInfiniteScrollParams) {
+  const loadMoreRef = React.useRef<HTMLDivElement>(null);
+
+  React.useEffect(() => {
+    const loadMoreElement = loadMoreRef.current;
+
+    if (!loadMoreElement || !hasNextPage || isFetchingNextPage) {
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          void fetchNextPage();
+        }
+      },
+      { rootMargin: '240px 0px' },
+    );
+
+    observer.observe(loadMoreElement);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [fetchNextPage, hasNextPage, isFetchingNextPage, observedItemCount]);
+
+  return {
+    loadMoreRef,
+  };
+}

--- a/src/app/(pages)/experience/_hooks/useExperienceBoardListState.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceBoardListState.ts
@@ -1,0 +1,67 @@
+'use client';
+
+import * as React from 'react';
+
+import type { ExperienceCategory } from '@/app/(pages)/experience/_utils/ExperienceCategory';
+
+interface ExperienceBoardListData {
+  pages: readonly {
+    experiences: readonly unknown[];
+  }[];
+}
+
+interface UseExperienceBoardListStateParams {
+  data?: ExperienceBoardListData | null;
+  hasNextPage?: boolean;
+  isError: boolean;
+  isFetching: boolean;
+  isFetchingNextPage: boolean;
+  isPending: boolean;
+  keyword?: string;
+  selectedCategory: ExperienceCategory;
+  filteredExperienceCount: number;
+}
+
+export function useExperienceBoardListState({
+  data,
+  hasNextPage,
+  isError,
+  isFetching,
+  isFetchingNextPage,
+  isPending,
+  keyword,
+  selectedCategory,
+  filteredExperienceCount,
+}: UseExperienceBoardListStateParams) {
+  const keywordKey = keyword ?? '';
+  const [emptyAllKeywordKey, setEmptyAllKeywordKey] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (selectedCategory !== 'all' || !data || isError || isPending) {
+      return;
+    }
+
+    const isAllExperienceEmpty =
+      !hasNextPage && data.pages.every((page) => page.experiences.length === 0);
+
+    setEmptyAllKeywordKey((currentKeywordKey) => {
+      if (isAllExperienceEmpty) {
+        return keywordKey;
+      }
+
+      return currentKeywordKey === keywordKey ? null : currentKeywordKey;
+    });
+  }, [data, hasNextPage, isError, isPending, keywordKey, selectedCategory]);
+
+  const showKnownAllEmpty =
+    selectedCategory !== 'all' &&
+    emptyAllKeywordKey === keywordKey &&
+    filteredExperienceCount === 0;
+  const showListLoading =
+    !showKnownAllEmpty &&
+    (isPending || (isFetching && !isFetchingNextPage && filteredExperienceCount === 0));
+
+  return {
+    showListLoading,
+  };
+}

--- a/src/app/(pages)/experience/_hooks/useExperienceBoardOrder.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceBoardOrder.ts
@@ -1,0 +1,56 @@
+'use client';
+
+import * as React from 'react';
+
+import type { ExperienceCategory } from '@/app/(pages)/experience/_utils/ExperienceCategory';
+import {
+  areExperienceOrderMapsEqual,
+  createExperienceOrderMap,
+  syncExperienceOrderMap,
+  type ExperienceOrderItem,
+} from '@/app/(pages)/experience/_utils/experienceOrder';
+
+interface UseExperienceBoardOrderParams<TExperience extends ExperienceOrderItem> {
+  experiences: readonly TExperience[];
+  selectedCategory: ExperienceCategory;
+}
+
+export function useExperienceBoardOrder<TExperience extends ExperienceOrderItem>({
+  experiences,
+  selectedCategory,
+}: UseExperienceBoardOrderParams<TExperience>) {
+  const [experienceOrderMap, setExperienceOrderMap] = React.useState(() =>
+    createExperienceOrderMap(experiences),
+  );
+
+  React.useEffect(() => {
+    setExperienceOrderMap((currentOrderMap) => {
+      const nextOrderMap = syncExperienceOrderMap(currentOrderMap, experiences, selectedCategory);
+
+      if (areExperienceOrderMapsEqual(currentOrderMap, nextOrderMap)) {
+        return currentOrderMap;
+      }
+
+      return nextOrderMap;
+    });
+  }, [experiences, selectedCategory]);
+
+  const experienceMap = React.useMemo(
+    () => new Map(experiences.map((experience) => [experience.id, experience])),
+    [experiences],
+  );
+
+  const filteredExperiences = React.useMemo(
+    () =>
+      experienceOrderMap[selectedCategory]
+        .map((id) => experienceMap.get(id))
+        .filter((experience): experience is TExperience => Boolean(experience)),
+    [experienceMap, experienceOrderMap, selectedCategory],
+  );
+
+  return {
+    experienceOrderMap,
+    setExperienceOrderMap,
+    filteredExperiences,
+  };
+}

--- a/src/app/(pages)/experience/_hooks/useExperienceBoardReorder.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceBoardReorder.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import * as React from 'react';
+
+import type { ExperienceCategory } from '@/app/(pages)/experience/_utils/ExperienceCategory';
+import {
+  parseOrderedExperienceIds,
+  type ExperienceOrderMap,
+} from '@/app/(pages)/experience/_utils/experienceOrder';
+import type { PieceType } from '@/app/api/experience/types';
+import { useUpdateExperienceOrder } from '@/hooks/experience/useExperiences';
+
+const orderPieceTypeByCategory: Record<ExperienceCategory, PieceType> = {
+  all: 'ALL',
+  activity: 'ACTIVITY',
+  career: 'CAREER',
+  education: 'EDUCATION',
+  etc: 'ETC',
+};
+
+interface UseExperienceBoardReorderParams {
+  selectedCategory: ExperienceCategory;
+  experienceOrderMap: ExperienceOrderMap;
+  setExperienceOrderMap: React.Dispatch<React.SetStateAction<ExperienceOrderMap>>;
+}
+
+export function useExperienceBoardReorder({
+  selectedCategory,
+  experienceOrderMap,
+  setExperienceOrderMap,
+}: UseExperienceBoardReorderParams) {
+  const updateExperienceOrderMutation = useUpdateExperienceOrder();
+
+  const handleExperienceReorder = React.useCallback(
+    (orderedExperienceIds: string[]) => {
+      const previousOrderIds = experienceOrderMap[selectedCategory];
+      const parsedExperienceIds = parseOrderedExperienceIds(orderedExperienceIds);
+
+      if (!parsedExperienceIds) {
+        return;
+      }
+
+      setExperienceOrderMap((currentOrderMap) => ({
+        ...currentOrderMap,
+        [selectedCategory]: orderedExperienceIds,
+      }));
+
+      updateExperienceOrderMutation.mutate(
+        {
+          type: orderPieceTypeByCategory[selectedCategory],
+          experienceIds: parsedExperienceIds,
+        },
+        {
+          onError: () => {
+            setExperienceOrderMap((currentOrderMap) => ({
+              ...currentOrderMap,
+              [selectedCategory]: previousOrderIds,
+            }));
+          },
+        },
+      );
+    },
+    [experienceOrderMap, selectedCategory, setExperienceOrderMap, updateExperienceOrderMutation],
+  );
+
+  return {
+    handleExperienceReorder,
+  };
+}

--- a/src/app/(pages)/experience/_hooks/useExperienceBoardSelection.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceBoardSelection.ts
@@ -1,0 +1,168 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import * as React from 'react';
+
+import type { ExperienceCategory } from '@/app/(pages)/experience/_utils/ExperienceCategory';
+import { EXPERIENCE_ORDER_CATEGORIES } from '@/app/(pages)/experience/_utils/experienceOrder';
+
+interface ExperienceSelectionItem {
+  id: string;
+}
+
+interface UseExperienceBoardSelectionParams {
+  initialSelectedExperienceId?: string;
+  keyword?: string;
+}
+
+function isExperienceCategory(category: string | null): category is ExperienceCategory {
+  return EXPERIENCE_ORDER_CATEGORIES.includes(category as ExperienceCategory);
+}
+
+export function useExperienceBoardSelection({
+  initialSelectedExperienceId,
+  keyword,
+}: UseExperienceBoardSelectionParams) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const selectedExperienceIdFromQuery = searchParams.get('selected') ?? initialSelectedExperienceId;
+  const selectedCategoryFromQuery = searchParams.get('category');
+  const initialSelectedCategory = isExperienceCategory(selectedCategoryFromQuery)
+    ? selectedCategoryFromQuery
+    : 'all';
+  const [selectedCategory, setSelectedCategory] =
+    React.useState<ExperienceCategory>(initialSelectedCategory);
+  const [selectedExperienceId, setSelectedExperienceId] = React.useState<string | undefined>(
+    selectedExperienceIdFromQuery,
+  );
+  const [panelOpen, setPanelOpen] = React.useState(Boolean(selectedExperienceIdFromQuery));
+  const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+  const hasAppliedInitialSelectionRef = React.useRef(false);
+  const previousKeywordRef = React.useRef(keyword);
+
+  const clearCloseTimer = React.useCallback(() => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current);
+      closeTimerRef.current = null;
+    }
+  }, []);
+
+  const applyInitialSelectedExperience = React.useCallback(
+    (experiences: readonly ExperienceSelectionItem[]) => {
+      if (hasAppliedInitialSelectionRef.current || !selectedExperienceIdFromQuery) {
+        return;
+      }
+
+      const initialSelectedExperience = experiences.find(
+        (experience) => experience.id === selectedExperienceIdFromQuery,
+      );
+
+      if (!initialSelectedExperience) {
+        return;
+      }
+
+      clearCloseTimer();
+      setSelectedCategory(initialSelectedCategory);
+      setSelectedExperienceId(initialSelectedExperience.id);
+      setPanelOpen(true);
+      hasAppliedInitialSelectionRef.current = true;
+    },
+    [clearCloseTimer, initialSelectedCategory, selectedExperienceIdFromQuery],
+  );
+
+  React.useEffect(() => {
+    if (previousKeywordRef.current === keyword) {
+      return;
+    }
+
+    previousKeywordRef.current = keyword;
+    clearCloseTimer();
+    setSelectedExperienceId(undefined);
+    setPanelOpen(false);
+
+    const params = new URLSearchParams(searchParams.toString());
+
+    params.delete('selected');
+
+    if (selectedCategory !== 'all') {
+      params.set('category', selectedCategory);
+    } else {
+      params.delete('category');
+    }
+
+    router.replace(params.size > 0 ? `/experience?${params.toString()}` : '/experience', {
+      scroll: false,
+    });
+  }, [clearCloseTimer, keyword, router, searchParams, selectedCategory]);
+
+  React.useEffect(() => clearCloseTimer, [clearCloseTimer]);
+
+  const handleCategoryChange = React.useCallback(
+    (category: ExperienceCategory) => {
+      clearCloseTimer();
+      router.replace('/experience', { scroll: false });
+      setSelectedCategory(category);
+      setSelectedExperienceId(undefined);
+      setPanelOpen(false);
+    },
+    [clearCloseTimer, router],
+  );
+
+  const handleExperienceSelect = React.useCallback(
+    (experience: ExperienceSelectionItem) => {
+      clearCloseTimer();
+      setSelectedExperienceId(experience.id);
+      setPanelOpen(true);
+      router.replace(`/experience?selected=${experience.id}&category=${selectedCategory}`, {
+        scroll: false,
+      });
+    },
+    [clearCloseTimer, router, selectedCategory],
+  );
+
+  const closeSelectedExperience = React.useCallback(() => {
+    clearCloseTimer();
+    setPanelOpen(false);
+    setSelectedExperienceId(undefined);
+    router.replace('/experience', { scroll: false });
+  }, [clearCloseTimer, router]);
+
+  const handlePanelClose = React.useCallback(() => {
+    clearCloseTimer();
+    setPanelOpen(false);
+    closeTimerRef.current = setTimeout(() => {
+      setSelectedExperienceId(undefined);
+      closeTimerRef.current = null;
+    }, 300);
+    router.replace('/experience', { scroll: false });
+  }, [clearCloseTimer, router]);
+
+  const handlePanelExpand = React.useCallback(
+    (experienceId?: string) => {
+      if (!experienceId) {
+        return;
+      }
+
+      const params = new URLSearchParams(searchParams.toString());
+
+      params.set('selected', experienceId);
+      params.set('category', selectedCategory);
+      params.set('view', 'detail');
+
+      router.push(`/experience?${params.toString()}`);
+    },
+    [router, searchParams, selectedCategory],
+  );
+
+  return {
+    selectedCategory,
+    selectedExperienceId,
+    panelOpen,
+    applyInitialSelectedExperience,
+    handleCategoryChange,
+    handleExperienceSelect,
+    closeSelectedExperience,
+    handlePanelClose,
+    handlePanelExpand,
+  };
+}

--- a/src/app/(pages)/experience/_hooks/useExperienceBoardSelection.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceBoardSelection.ts
@@ -100,7 +100,9 @@ export function useExperienceBoardSelection({
   const handleCategoryChange = React.useCallback(
     (category: ExperienceCategory) => {
       clearCloseTimer();
-      router.replace('/experience', { scroll: false });
+      const nextPath = category === 'all' ? '/experience' : `/experience?category=${category}`;
+
+      router.replace(nextPath, { scroll: false });
       setSelectedCategory(category);
       setSelectedExperienceId(undefined);
       setPanelOpen(false);

--- a/src/app/(pages)/experience/_hooks/useExperienceDetailForm.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceDetailForm.ts
@@ -10,7 +10,7 @@ import { sanitizeNumberText } from '@/app/(pages)/experience/_utils/sanitizeNumb
 import type { CalendarDateRange } from '@/components/common/RangeCalendar';
 import type { SingleMonthCalendarDateRange } from '@/components/common/SingleMonthRangeCalendar';
 
-export type EditableTagGroupKey = 'skill' | 'competency';
+type EditableTagGroupKey = 'skill' | 'competency';
 export type { BasicDetailKey } from '@/app/(pages)/experience/_utils/experienceDetailInfoItems';
 export type ExperienceDetailSaveValue = Pick<
   ExperienceItem,

--- a/src/app/(pages)/experience/_hooks/useExperienceDetailForm.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceDetailForm.ts
@@ -3,6 +3,7 @@
 import * as React from 'react';
 
 import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+import type { BasicDetailKey } from '@/app/(pages)/experience/_utils/experienceDetailInfoItems';
 import { limitExperienceFieldText } from '@/app/(pages)/experience/_utils/experienceFieldLimits';
 import { formatExperiencePeriod } from '@/app/(pages)/experience/_utils/formatExperiencePeriod';
 import { sanitizeNumberText } from '@/app/(pages)/experience/_utils/sanitizeNumberText';
@@ -10,7 +11,7 @@ import type { CalendarDateRange } from '@/components/common/RangeCalendar';
 import type { SingleMonthCalendarDateRange } from '@/components/common/SingleMonthRangeCalendar';
 
 export type EditableTagGroupKey = 'skill' | 'competency';
-export type BasicDetailKey = keyof ExperienceItem['basicDetail'];
+export type { BasicDetailKey } from '@/app/(pages)/experience/_utils/experienceDetailInfoItems';
 export type ExperienceDetailSaveValue = Pick<
   ExperienceItem,
   | 'title'

--- a/src/app/(pages)/experience/_hooks/useExperienceDetailForm.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceDetailForm.ts
@@ -1,0 +1,285 @@
+'use client';
+
+import * as React from 'react';
+
+import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+import { limitExperienceFieldText } from '@/app/(pages)/experience/_utils/experienceFieldLimits';
+import { formatExperiencePeriod } from '@/app/(pages)/experience/_utils/formatExperiencePeriod';
+import { sanitizeNumberText } from '@/app/(pages)/experience/_utils/sanitizeNumberText';
+import type { CalendarDateRange } from '@/components/common/RangeCalendar';
+import type { SingleMonthCalendarDateRange } from '@/components/common/SingleMonthRangeCalendar';
+
+export type EditableTagGroupKey = 'skill' | 'competency';
+export type BasicDetailKey = keyof ExperienceItem['basicDetail'];
+export type ExperienceDetailSaveValue = Pick<
+  ExperienceItem,
+  | 'title'
+  | 'description'
+  | 'basicDetail'
+  | 'detail'
+  | 'skillTags'
+  | 'competencyTags'
+  | 'startDate'
+  | 'endDate'
+>;
+
+interface UseExperienceDetailFormParams {
+  experience: ExperienceItem;
+  defaultEditing: boolean;
+  onEdit?: () => void;
+  onSave?: (experience: ExperienceDetailSaveValue) => Promise<void> | void;
+}
+
+export function useExperienceDetailForm({
+  experience,
+  defaultEditing,
+  onEdit,
+  onSave,
+}: UseExperienceDetailFormParams) {
+  const [title, setTitle] = React.useState(experience.title);
+  const [description, setDescription] = React.useState(experience.description);
+  const [detail, setDetail] = React.useState(experience.detail);
+  const [basicDetail, setBasicDetail] = React.useState(experience.basicDetail);
+  const [startDate, setStartDate] = React.useState(experience.startDate);
+  const [endDate, setEndDate] = React.useState(experience.endDate);
+  const [skillTags, setSkillTags] = React.useState(experience.skillTags);
+  const [competencyTags, setCompetencyTags] = React.useState(experience.competencyTags);
+  const [isEditing, setIsEditing] = React.useState(defaultEditing);
+  const [isSaving, setIsSaving] = React.useState(false);
+  const [editingTagGroup, setEditingTagGroup] = React.useState<EditableTagGroupKey | null>(null);
+  const [datePickerOpen, setDatePickerOpen] = React.useState(false);
+  const [datePickerTop, setDatePickerTop] = React.useState<number | null>(null);
+  const [errorMessage, setErrorMessage] = React.useState('');
+  const datePickerRootRef = React.useRef<HTMLDivElement>(null);
+  const datePickerButtonRef = React.useRef<HTMLButtonElement>(null);
+  const previousExperienceIdRef = React.useRef(experience.id);
+
+  React.useEffect(() => {
+    const isSameExperience = previousExperienceIdRef.current === experience.id;
+
+    if (isSameExperience && isEditing) {
+      return;
+    }
+
+    previousExperienceIdRef.current = experience.id;
+    setTitle(experience.title);
+    setDescription(experience.description);
+    setDetail(experience.detail);
+    setBasicDetail(experience.basicDetail);
+    setStartDate(experience.startDate);
+    setEndDate(experience.endDate);
+    setSkillTags(experience.skillTags);
+    setCompetencyTags(experience.competencyTags);
+    setIsEditing(defaultEditing);
+    setIsSaving(false);
+    setEditingTagGroup(null);
+    setDatePickerOpen(false);
+    setDatePickerTop(null);
+  }, [
+    defaultEditing,
+    experience.basicDetail,
+    experience.competencyTags,
+    experience.description,
+    experience.detail,
+    experience.endDate,
+    experience.id,
+    experience.skillTags,
+    experience.startDate,
+    experience.title,
+    isEditing,
+  ]);
+
+  React.useEffect(() => {
+    if (!datePickerOpen) return;
+
+    const handlePointerDown = (event: PointerEvent) => {
+      const root = datePickerRootRef.current;
+
+      if (root && !root.contains(event.target as Node)) {
+        setDatePickerOpen(false);
+      }
+    };
+
+    document.addEventListener('pointerdown', handlePointerDown, true);
+
+    return () => {
+      document.removeEventListener('pointerdown', handlePointerDown, true);
+    };
+  }, [datePickerOpen]);
+
+  React.useEffect(() => {
+    if (!datePickerOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setDatePickerOpen(false);
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [datePickerOpen]);
+
+  const selectedDateRange = React.useMemo<CalendarDateRange | null>(() => {
+    const parsedStartDate = parseDateValue(startDate);
+    const parsedEndDate = parseDateValue(endDate);
+
+    if (!parsedStartDate || !parsedEndDate) return null;
+
+    return { start: parsedStartDate, end: parsedEndDate };
+  }, [endDate, startDate]);
+  const periodLabel = formatExperiencePeriod(startDate, endDate);
+
+  const updateTitle = React.useCallback((value: string) => {
+    setTitle(limitExperienceFieldText('title', value));
+  }, []);
+
+  const updateDescription = React.useCallback((value: string) => {
+    setDescription(limitExperienceFieldText('description', value));
+  }, []);
+
+  const handleDetailChange = React.useCallback(
+    (key: keyof ExperienceItem['detail']): React.ChangeEventHandler<HTMLTextAreaElement> =>
+      (event) => {
+        setDetail((prev) => ({
+          ...prev,
+          [key]: event.target.value,
+        }));
+      },
+    [],
+  );
+
+  const updateBasicDetail = React.useCallback((key: BasicDetailKey, value: string) => {
+    const nextValue = getSanitizedBasicDetailValue(key, value);
+
+    setBasicDetail((currentBasicDetail) => ({
+      ...currentBasicDetail,
+      [key]: nextValue,
+    }));
+  }, []);
+
+  const handleEditClick = React.useCallback(() => {
+    onEdit?.();
+    setIsEditing(true);
+    setEditingTagGroup(null);
+  }, [onEdit]);
+
+  const handleSaveEdit = React.useCallback(async () => {
+    try {
+      setIsSaving(true);
+      await onSave?.({
+        title,
+        description,
+        detail,
+        basicDetail,
+        startDate,
+        endDate,
+        skillTags,
+        competencyTags,
+      });
+      setIsEditing(false);
+      setEditingTagGroup(null);
+      setDatePickerOpen(false);
+      setDatePickerTop(null);
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : '경험 수정 중 오류가 발생했습니다.');
+    } finally {
+      setIsSaving(false);
+    }
+  }, [
+    basicDetail,
+    competencyTags,
+    description,
+    detail,
+    endDate,
+    onSave,
+    skillTags,
+    startDate,
+    title,
+  ]);
+
+  const toggleDatePicker = React.useCallback(() => {
+    const buttonRect = datePickerButtonRef.current?.getBoundingClientRect();
+
+    if (buttonRect) {
+      setDatePickerTop(buttonRect.bottom + 8);
+    }
+
+    setDatePickerOpen((open) => !open);
+  }, []);
+
+  const handleDateRangeChange = React.useCallback(
+    (nextRange: CalendarDateRange | SingleMonthCalendarDateRange | null) => {
+      if (!nextRange) return;
+
+      setStartDate(formatDateValue(nextRange.start));
+      setEndDate(formatDateValue(nextRange.end));
+      setDatePickerOpen(false);
+    },
+    [],
+  );
+
+  const handleErrorDialogOpenChange = React.useCallback((open: boolean) => {
+    if (!open) {
+      setErrorMessage('');
+    }
+  }, []);
+
+  return {
+    title,
+    description,
+    detail,
+    basicDetail,
+    skillTags,
+    competencyTags,
+    isEditing,
+    isSaving,
+    editingTagGroup,
+    datePickerOpen,
+    datePickerTop,
+    errorMessage,
+    datePickerRootRef,
+    datePickerButtonRef,
+    selectedDateRange,
+    periodLabel,
+    setSkillTags,
+    setCompetencyTags,
+    setEditingTagGroup,
+    updateTitle,
+    updateDescription,
+    handleDetailChange,
+    updateBasicDetail,
+    handleEditClick,
+    handleSaveEdit,
+    toggleDatePicker,
+    handleDateRangeChange,
+    handleErrorDialogOpenChange,
+  };
+}
+
+function getSanitizedBasicDetailValue(key: BasicDetailKey, value: string) {
+  if (key === 'teamNum' || key === 'contributionRate') {
+    return sanitizeNumberText(value, 100);
+  }
+
+  return limitExperienceFieldText(key, value);
+}
+
+function parseDateValue(value: string) {
+  if (!value) return null;
+
+  const date = new Date(`${value}T00:00:00`);
+
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function formatDateValue(date: Date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day}`;
+}

--- a/src/app/(pages)/experience/_hooks/useExperienceDetailForm.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceDetailForm.ts
@@ -11,6 +11,7 @@ import type { CalendarDateRange } from '@/components/common/RangeCalendar';
 import type { SingleMonthCalendarDateRange } from '@/components/common/SingleMonthRangeCalendar';
 
 type EditableTagGroupKey = 'skill' | 'competency';
+type DateRangeChangeValue = Partial<CalendarDateRange | SingleMonthCalendarDateRange> | null;
 export type { BasicDetailKey } from '@/app/(pages)/experience/_utils/experienceDetailInfoItems';
 export type ExperienceDetailSaveValue = Pick<
   ExperienceItem,
@@ -212,16 +213,13 @@ export function useExperienceDetailForm({
     setDatePickerOpen((open) => !open);
   }, []);
 
-  const handleDateRangeChange = React.useCallback(
-    (nextRange: CalendarDateRange | SingleMonthCalendarDateRange | null) => {
-      if (!nextRange) return;
+  const handleDateRangeChange = React.useCallback((nextRange: DateRangeChangeValue) => {
+    if (!isCompleteDateRange(nextRange)) return;
 
-      setStartDate(formatDateValue(nextRange.start));
-      setEndDate(formatDateValue(nextRange.end));
-      setDatePickerOpen(false);
-    },
-    [],
-  );
+    setStartDate(formatDateValue(nextRange.start));
+    setEndDate(formatDateValue(nextRange.end));
+    setDatePickerOpen(false);
+  }, []);
 
   const handleErrorDialogOpenChange = React.useCallback((open: boolean) => {
     if (!open) {
@@ -283,4 +281,14 @@ function formatDateValue(date: Date) {
   const day = String(date.getDate()).padStart(2, '0');
 
   return `${year}-${month}-${day}`;
+}
+
+function isCompleteDateRange(
+  range: DateRangeChangeValue,
+): range is CalendarDateRange | SingleMonthCalendarDateRange {
+  return isValidDate(range?.start) && isValidDate(range?.end);
+}
+
+function isValidDate(value: unknown): value is Date {
+  return value instanceof Date && !Number.isNaN(value.getTime());
 }

--- a/src/app/(pages)/experience/_utils/experienceDetailInfoItems.ts
+++ b/src/app/(pages)/experience/_utils/experienceDetailInfoItems.ts
@@ -1,0 +1,93 @@
+import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+
+export type BasicDetailKey = keyof ExperienceItem['basicDetail'];
+
+export type ExperienceDetailInfoItem =
+  | {
+      type: 'period';
+      label: string;
+      value: string;
+    }
+  | {
+      type: 'field';
+      label: string;
+      value: string;
+      displayValue: string;
+      name: BasicDetailKey;
+    };
+
+export function getExperienceDetailInfoItems(
+  type: ExperienceItem['type'],
+  basicDetail: ExperienceItem['basicDetail'],
+  periodLabel: string,
+): ExperienceDetailInfoItem[] {
+  switch (type) {
+    case 'activity': {
+      const teamNum = basicDetail.teamNum ?? '';
+      const contributionRate = basicDetail.contributionRate ?? '';
+
+      return [
+        { type: 'period', label: '기간', value: periodLabel },
+        {
+          type: 'field',
+          label: '팀원 수',
+          value: teamNum,
+          displayValue: teamNum ? `${teamNum}명` : '',
+          name: 'teamNum',
+        },
+        {
+          type: 'field',
+          label: '내 역할',
+          value: basicDetail.role ?? '',
+          displayValue: basicDetail.role ?? '',
+          name: 'role',
+        },
+        {
+          type: 'field',
+          label: '기여도',
+          value: contributionRate,
+          displayValue: contributionRate ? `${contributionRate}%` : '',
+          name: 'contributionRate',
+        },
+      ];
+    }
+    case 'career':
+      return [
+        { type: 'period', label: '기간', value: periodLabel },
+        {
+          type: 'field',
+          label: '회사/기관/단체명',
+          value: basicDetail.company ?? '',
+          displayValue: basicDetail.company ?? '',
+          name: 'company',
+        },
+        {
+          type: 'field',
+          label: '고용 형태',
+          value: basicDetail.employmentStatus ?? '',
+          displayValue: basicDetail.employmentStatus ?? '',
+          name: 'employmentStatus',
+        },
+      ];
+    case 'education':
+      return [
+        { type: 'period', label: '기간', value: periodLabel },
+        {
+          type: 'field',
+          label: '기관명',
+          value: basicDetail.organizationName ?? '',
+          displayValue: basicDetail.organizationName ?? '',
+          name: 'organizationName',
+        },
+        {
+          type: 'field',
+          label: '수강명',
+          value: basicDetail.name ?? '',
+          displayValue: basicDetail.name ?? '',
+          name: 'name',
+        },
+      ];
+    case 'etc':
+      return [{ type: 'period', label: '기간', value: periodLabel }];
+  }
+}

--- a/src/app/(pages)/experience/_utils/experienceOrder.ts
+++ b/src/app/(pages)/experience/_utils/experienceOrder.ts
@@ -85,7 +85,7 @@ export function removeExperienceFromOrderMap(
   experienceId: string,
 ): ExperienceOrderMap {
   return EXPERIENCE_ORDER_CATEGORIES.reduce<ExperienceOrderMap>((nextOrderMap, category) => {
-    nextOrderMap[category] = orderMap[category].filter((id) => id !== experienceId);
+    nextOrderMap[category] = (orderMap[category] ?? []).filter((id) => id !== experienceId);
     return nextOrderMap;
   }, createEmptyExperienceOrderMap());
 }

--- a/src/app/(pages)/experience/_utils/experienceOrder.ts
+++ b/src/app/(pages)/experience/_utils/experienceOrder.ts
@@ -1,0 +1,112 @@
+import type { ExperienceCategory } from '@/app/(pages)/experience/_utils/ExperienceCategory';
+
+export type ExperienceOrderMap = Record<ExperienceCategory, string[]>;
+
+export interface ExperienceOrderItem {
+  id: string;
+  type: Exclude<ExperienceCategory, 'all'>;
+}
+
+export const EXPERIENCE_ORDER_CATEGORIES = [
+  'all',
+  'activity',
+  'career',
+  'education',
+  'etc',
+] as const satisfies readonly ExperienceCategory[];
+
+function areStringArraysEqual(source: string[], target: string[]) {
+  return source.length === target.length && source.every((item, index) => item === target[index]);
+}
+
+function createEmptyExperienceOrderMap(): ExperienceOrderMap {
+  return {
+    all: [],
+    activity: [],
+    career: [],
+    education: [],
+    etc: [],
+  };
+}
+
+function getExperienceIdsByCategory(
+  experiences: readonly ExperienceOrderItem[],
+  category: Exclude<ExperienceCategory, 'all'>,
+) {
+  return experiences
+    .filter((experience) => experience.type === category)
+    .map((experience) => experience.id);
+}
+
+export function createExperienceOrderMap(
+  experiences: readonly ExperienceOrderItem[],
+): ExperienceOrderMap {
+  return {
+    all: experiences.map((experience) => experience.id),
+    activity: getExperienceIdsByCategory(experiences, 'activity'),
+    career: getExperienceIdsByCategory(experiences, 'career'),
+    education: getExperienceIdsByCategory(experiences, 'education'),
+    etc: getExperienceIdsByCategory(experiences, 'etc'),
+  };
+}
+
+export function syncExperienceOrderMap(
+  currentOrderMap: ExperienceOrderMap,
+  experiences: readonly ExperienceOrderItem[],
+  syncedCategory: ExperienceCategory,
+): ExperienceOrderMap {
+  const defaultOrderMap = createExperienceOrderMap(experiences);
+
+  if (syncedCategory === 'all') {
+    return defaultOrderMap;
+  }
+
+  return EXPERIENCE_ORDER_CATEGORIES.reduce<ExperienceOrderMap>((nextOrderMap, category) => {
+    if (category === syncedCategory) {
+      nextOrderMap[category] = defaultOrderMap[category];
+      return nextOrderMap;
+    }
+
+    const nextIds = defaultOrderMap[category];
+    const nextIdSet = new Set(nextIds);
+    const currentIds = currentOrderMap[category] ?? [];
+    const currentIdSet = new Set(currentIds);
+    const preservedIds = currentIds.filter((id) => nextIdSet.has(id));
+    const addedIds = nextIds.filter((id) => !currentIdSet.has(id));
+
+    nextOrderMap[category] = [...preservedIds, ...addedIds];
+
+    return nextOrderMap;
+  }, createEmptyExperienceOrderMap());
+}
+
+export function removeExperienceFromOrderMap(
+  orderMap: ExperienceOrderMap,
+  experienceId: string,
+): ExperienceOrderMap {
+  return EXPERIENCE_ORDER_CATEGORIES.reduce<ExperienceOrderMap>((nextOrderMap, category) => {
+    nextOrderMap[category] = orderMap[category].filter((id) => id !== experienceId);
+    return nextOrderMap;
+  }, createEmptyExperienceOrderMap());
+}
+
+export function parseOrderedExperienceIds(orderedExperienceIds: readonly string[]) {
+  const parsedExperienceIds = orderedExperienceIds.map(Number);
+
+  if (
+    parsedExperienceIds.some((experienceId) => !Number.isInteger(experienceId) || experienceId <= 0)
+  ) {
+    return null;
+  }
+
+  return parsedExperienceIds;
+}
+
+export function areExperienceOrderMapsEqual(
+  source: ExperienceOrderMap,
+  target: ExperienceOrderMap,
+) {
+  return EXPERIENCE_ORDER_CATEGORIES.every((category) =>
+    areStringArraysEqual(source[category], target[category]),
+  );
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#144 

## 📝작업 내용

- 경험 보드의 정렬, 선택, 무한스크롤, 목록 상태, 액션, 순서 변경, 상세 조회 로직을 각각 훅/유틸로 분리했습니다.
- 경험 상세 화면의 폼 상태와 저장/수정 핸들러를 `useExperienceDetailForm`으로 분리했습니다.
- 경험 상세 UI를 Header, Summary, Tags, Fields, PeriodPicker 등 섹션 단위 컴포넌트로 분리했습니다.
- 경험 타입별 상세 정보 아이템 생성 로직을 `experienceDetailInfoItems` 유틸로 분리했습니다.
- 태그 편집 타입 의존성을 정리해 UI 컴포넌트가 훅 타입에 직접 의존하지 않도록 개선했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved experience management interface with enhanced component structure for better performance and stability.
  * Refined experience detail editing, form handling, and infinite-scroll loading for smoother interactions.
  * Optimized experience categorization and reordering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->