### PR TITLE
[Refactor] 경험 추가 플로우 상태 및 액션 로직 분리

### DIFF
--- a/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
@@ -11,15 +11,10 @@ import type {
 import { ExperienceAddProgress } from '@/app/(pages)/experience/add/_components/ExperienceAddProgress';
 import { ExperienceAddStepContent } from '@/app/(pages)/experience/add/_components/ExperienceAddStepContent';
 import { EXPERIENCE_ADD_STEPS } from '@/app/(pages)/experience/add/_constants/experienceAddSteps';
-import { CORE_EXPERIENCE_FIELDS } from '@/app/(pages)/experience/add/_constants/experienceCoreQuestions';
-import { EXPERIENCE_TYPE_FIELD_GROUPS } from '@/app/(pages)/experience/add/_constants/experienceTypeOptions';
 import {
   createEmptyBasicInfoForm,
   createEmptyCoreInfoForm,
   createEmptyResultInfoForm,
-  type ExperienceAddBasicInfoForm,
-  type ExperienceAddCoreInfoForm,
-  type ExperienceAddResultInfoForm,
 } from '@/app/(pages)/experience/add/_types/experienceAddForm';
 import {
   mapAnalyzeResponseToBasicInfoForm,
@@ -31,6 +26,11 @@ import {
   clearExperienceAddPdfDraft,
   getExperienceAddPdfDraft,
 } from '@/app/(pages)/experience/add/_utils/experienceAddPdfDraftStorage';
+import {
+  isBasicInfoComplete,
+  isCoreInfoComplete,
+  isResultStepComplete,
+} from '@/app/(pages)/experience/add/_utils/experienceAddValidation';
 import { ErrorDialog } from '@/components/common/ErrorDialog';
 import { ChevronLeftIcon } from '@/components/common/icons/ChevronLeftIcon';
 import { Button } from '@/components/ui/button';
@@ -236,12 +236,7 @@ export function ExperienceAddPageContent() {
               이전
             </Button>
           )}
-          <Button
-            type="button"
-            className="w-40"
-            disabled={isNextStepDisabled}
-            onClick={goNextStep}
-          >
+          <Button type="button" className="w-40" disabled={isNextStepDisabled} onClick={goNextStep}>
             {currentStepIndex === EXPERIENCE_ADD_STEPS.length - 1 ? '저장하기' : '다음'}
           </Button>
         </footer>
@@ -257,41 +252,4 @@ export function ExperienceAddPageContent() {
       />
     </div>
   );
-}
-
-function isBasicInfoComplete(basicInfo: ExperienceAddBasicInfoForm) {
-  if (!basicInfo.type) return false;
-
-  return EXPERIENCE_TYPE_FIELD_GROUPS[basicInfo.type].every((fieldGroup) =>
-    fieldGroup.fields.every((field) => hasText(basicInfo[field.name])),
-  );
-}
-
-function isCoreInfoComplete(coreInfo: ExperienceAddCoreInfoForm) {
-  return CORE_EXPERIENCE_FIELDS.every((field) => hasText(coreInfo[field.name]));
-}
-
-function isResultStepComplete({
-  basicInfo,
-  coreInfo,
-  resultInfo,
-}: {
-  basicInfo: ExperienceAddBasicInfoForm;
-  coreInfo: ExperienceAddCoreInfoForm;
-  resultInfo: ExperienceAddResultInfoForm;
-}) {
-  return (
-    isBasicInfoComplete(basicInfo) &&
-    isCoreInfoComplete(coreInfo) &&
-    hasTag(resultInfo.skillTags) &&
-    hasTag(resultInfo.competencyTags)
-  );
-}
-
-function hasText(value: string | null | undefined) {
-  return (value ?? '').trim().length > 0;
-}
-
-function hasTag(tags: string[]) {
-  return tags.some(hasText);
 }

--- a/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
@@ -3,19 +3,14 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
-import type {
-  ExperienceAddMaterialModalView,
-  ExperienceMaterial,
-} from '@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal';
+import type { ExperienceAddMaterialModalView } from '@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal';
 import { ExperienceAddProgress } from '@/app/(pages)/experience/add/_components/ExperienceAddProgress';
 import { ExperienceAddStepContent } from '@/app/(pages)/experience/add/_components/ExperienceAddStepContent';
 import { EXPERIENCE_ADD_STEPS } from '@/app/(pages)/experience/add/_constants/experienceAddSteps';
 import { useExperienceAddForm } from '@/app/(pages)/experience/add/_hooks/useExperienceAddForm';
+import { useExperienceAddMaterials } from '@/app/(pages)/experience/add/_hooks/useExperienceAddMaterials';
 import { mapExperienceAddFormToCreateRequest } from '@/app/(pages)/experience/add/_utils/mapExperienceAddFormToCreateRequest';
-import {
-  clearExperienceAddPdfDraft,
-  getExperienceAddPdfDraft,
-} from '@/app/(pages)/experience/add/_utils/experienceAddPdfDraftStorage';
+import { clearExperienceAddPdfDraft } from '@/app/(pages)/experience/add/_utils/experienceAddPdfDraftStorage';
 import {
   isBasicInfoComplete,
   isCoreInfoComplete,
@@ -38,7 +33,7 @@ export function ExperienceAddPageContent() {
   const isNotionConnected =
     searchParams.get('notion') === 'connected' || searchParams.get('success') === 'true';
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
-  const [materials, setMaterials] = useState<ExperienceMaterial[]>([]);
+  const { materials, setMaterials } = useExperienceAddMaterials();
   const [isMaterialModalOpen, setIsMaterialModalOpen] = useState(isNotionConnected);
   const [materialModalInitialView, setMaterialModalInitialView] =
     useState<ExperienceAddMaterialModalView>(isNotionConnected ? 'notion-pages' : 'material');
@@ -84,28 +79,6 @@ export function ExperienceAddPageContent() {
   useEffect(() => {
     window.scrollTo({ top: 0, behavior: 'auto' });
   }, [currentStepIndex]);
-
-  useEffect(() => {
-    const restorePdfDraft = async () => {
-      try {
-        const pdfMaterial = await getExperienceAddPdfDraft();
-
-        if (!pdfMaterial) return;
-
-        setMaterials((currentMaterials) => {
-          const hasPdf = currentMaterials.some((material) => material.type === 'pdf');
-
-          if (hasPdf) return currentMaterials;
-
-          return [pdfMaterial, ...currentMaterials];
-        });
-      } catch (error) {
-        console.warn('PDF 임시 저장 데이터를 복구하지 못했습니다.', error);
-      }
-    };
-
-    void restorePdfDraft();
-  }, []);
 
   const goPreviousStep = () => {
     setCurrentStepIndex((stepIndex) => Math.max(stepIndex - 1, 0));

--- a/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
@@ -6,9 +6,9 @@ import { useEffect, useRef, useState } from 'react';
 import type { ExperienceAddMaterialModalView } from '@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal';
 import { ExperienceAddProgress } from '@/app/(pages)/experience/add/_components/ExperienceAddProgress';
 import { ExperienceAddStepContent } from '@/app/(pages)/experience/add/_components/ExperienceAddStepContent';
-import { EXPERIENCE_ADD_STEPS } from '@/app/(pages)/experience/add/_constants/experienceAddSteps';
 import { useExperienceAddForm } from '@/app/(pages)/experience/add/_hooks/useExperienceAddForm';
 import { useExperienceAddMaterials } from '@/app/(pages)/experience/add/_hooks/useExperienceAddMaterials';
+import { useExperienceAddStep } from '@/app/(pages)/experience/add/_hooks/useExperienceAddStep';
 import { mapExperienceAddFormToCreateRequest } from '@/app/(pages)/experience/add/_utils/mapExperienceAddFormToCreateRequest';
 import { clearExperienceAddPdfDraft } from '@/app/(pages)/experience/add/_utils/experienceAddPdfDraftStorage';
 import {
@@ -32,7 +32,16 @@ export function ExperienceAddPageContent() {
   const searchParams = useSearchParams();
   const isNotionConnected =
     searchParams.get('notion') === 'connected' || searchParams.get('success') === 'true';
-  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const {
+    currentStepIndex,
+    isFirstStep,
+    isCompleteStep,
+    isBasicInfoStep,
+    isCoreInfoStep,
+    isResultStep,
+    goPreviousStep,
+    goNextStep: goToNextStep,
+  } = useExperienceAddStep();
   const { materials, setMaterials } = useExperienceAddMaterials();
   const [isMaterialModalOpen, setIsMaterialModalOpen] = useState(isNotionConnected);
   const [materialModalInitialView, setMaterialModalInitialView] =
@@ -58,11 +67,6 @@ export function ExperienceAddPageContent() {
     analyzeNotionMutation.isPending ||
     analyzeMaterialsMutation.isPending;
   const isSaving = createExperienceMutation.isPending;
-  const isFirstStep = currentStepIndex === 0;
-  const isCompleteStep = currentStepIndex === EXPERIENCE_ADD_STEPS.length;
-  const isBasicInfoStep = currentStepIndex === 1;
-  const isCoreInfoStep = currentStepIndex === 2;
-  const isResultStep = currentStepIndex === EXPERIENCE_ADD_STEPS.length - 1;
   const isNextStepDisabled =
     isAnalyzing ||
     isSaving ||
@@ -75,14 +79,6 @@ export function ExperienceAddPageContent() {
 
     router.replace('/experience/add', { scroll: false });
   }, [isNotionConnected, router]);
-
-  useEffect(() => {
-    window.scrollTo({ top: 0, behavior: 'auto' });
-  }, [currentStepIndex]);
-
-  const goPreviousStep = () => {
-    setCurrentStepIndex((stepIndex) => Math.max(stepIndex - 1, 0));
-  };
 
   const goNextStep = async () => {
     if (isProcessingRef.current) return;
@@ -125,7 +121,7 @@ export function ExperienceAddPageContent() {
         }
       }
 
-      if (currentStepIndex === EXPERIENCE_ADD_STEPS.length - 1) {
+      if (isResultStep) {
         try {
           await createExperienceMutation.mutateAsync(
             mapExperienceAddFormToCreateRequest({
@@ -145,7 +141,7 @@ export function ExperienceAddPageContent() {
         }
       }
 
-      setCurrentStepIndex((stepIndex) => Math.min(stepIndex + 1, EXPERIENCE_ADD_STEPS.length));
+      goToNextStep();
     } finally {
       isProcessingRef.current = false;
     }
@@ -199,7 +195,7 @@ export function ExperienceAddPageContent() {
             </Button>
           )}
           <Button type="button" className="w-40" disabled={isNextStepDisabled} onClick={goNextStep}>
-            {currentStepIndex === EXPERIENCE_ADD_STEPS.length - 1 ? '저장하기' : '다음'}
+            {isResultStep ? '저장하기' : '다음'}
           </Button>
         </footer>
       )}

--- a/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
@@ -3,7 +3,6 @@
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState } from 'react';
 
-import type { ExperienceAnalyzeResponse } from '@/app/api/experience/add/types';
 import type {
   ExperienceAddMaterialModalView,
   ExperienceMaterial,
@@ -11,16 +10,7 @@ import type {
 import { ExperienceAddProgress } from '@/app/(pages)/experience/add/_components/ExperienceAddProgress';
 import { ExperienceAddStepContent } from '@/app/(pages)/experience/add/_components/ExperienceAddStepContent';
 import { EXPERIENCE_ADD_STEPS } from '@/app/(pages)/experience/add/_constants/experienceAddSteps';
-import {
-  createEmptyBasicInfoForm,
-  createEmptyCoreInfoForm,
-  createEmptyResultInfoForm,
-} from '@/app/(pages)/experience/add/_types/experienceAddForm';
-import {
-  mapAnalyzeResponseToBasicInfoForm,
-  mapAnalyzeResponseToCoreInfoForm,
-  mapAnalyzeResponseToResultInfoForm,
-} from '@/app/(pages)/experience/add/_utils/mapAnalyzeResponseToBasicInfoForm';
+import { useExperienceAddForm } from '@/app/(pages)/experience/add/_hooks/useExperienceAddForm';
 import { mapExperienceAddFormToCreateRequest } from '@/app/(pages)/experience/add/_utils/mapExperienceAddFormToCreateRequest';
 import {
   clearExperienceAddPdfDraft,
@@ -52,9 +42,16 @@ export function ExperienceAddPageContent() {
   const [isMaterialModalOpen, setIsMaterialModalOpen] = useState(isNotionConnected);
   const [materialModalInitialView, setMaterialModalInitialView] =
     useState<ExperienceAddMaterialModalView>(isNotionConnected ? 'notion-pages' : 'material');
-  const [basicInfo, setBasicInfo] = useState(createEmptyBasicInfoForm);
-  const [coreInfo, setCoreInfo] = useState(createEmptyCoreInfoForm);
-  const [resultInfo, setResultInfo] = useState(createEmptyResultInfoForm);
+  const {
+    basicInfo,
+    coreInfo,
+    resultInfo,
+    setBasicInfo,
+    setCoreInfo,
+    setResultInfo,
+    applyAnalyzeResponse,
+    resetForm,
+  } = useExperienceAddForm();
   const [errorMessage, setErrorMessage] = useState('');
   const isProcessingRef = useRef(false);
   const analyzePdfMutation = useAnalyzeExperiencePdf();
@@ -114,12 +111,6 @@ export function ExperienceAddPageContent() {
     setCurrentStepIndex((stepIndex) => Math.max(stepIndex - 1, 0));
   };
 
-  const applyAnalyzeResponse = (analyzeResponse: ExperienceAnalyzeResponse) => {
-    setBasicInfo(mapAnalyzeResponseToBasicInfoForm(analyzeResponse));
-    setCoreInfo(mapAnalyzeResponseToCoreInfoForm(analyzeResponse));
-    setResultInfo(mapAnalyzeResponseToResultInfoForm(analyzeResponse));
-  };
-
   const goNextStep = async () => {
     if (isProcessingRef.current) return;
 
@@ -151,9 +142,7 @@ export function ExperienceAddPageContent() {
             const analyzeResponse = await analyzeNotionMutation.mutateAsync(notionMaterial.pageId);
             applyAnalyzeResponse(analyzeResponse);
           } else {
-            setBasicInfo(createEmptyBasicInfoForm());
-            setCoreInfo(createEmptyCoreInfoForm());
-            setResultInfo(createEmptyResultInfoForm());
+            resetForm();
           }
         } catch (error) {
           setErrorMessage(

--- a/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
@@ -10,11 +10,7 @@ import { useExperienceAddActions } from '@/app/(pages)/experience/add/_hooks/use
 import { useExperienceAddForm } from '@/app/(pages)/experience/add/_hooks/useExperienceAddForm';
 import { useExperienceAddMaterials } from '@/app/(pages)/experience/add/_hooks/useExperienceAddMaterials';
 import { useExperienceAddStep } from '@/app/(pages)/experience/add/_hooks/useExperienceAddStep';
-import {
-  isBasicInfoComplete,
-  isCoreInfoComplete,
-  isResultStepComplete,
-} from '@/app/(pages)/experience/add/_utils/experienceAddValidation';
+import { getExperienceAddNextStepDisabled } from '@/app/(pages)/experience/add/_utils/experienceAddValidation';
 import { ErrorDialog } from '@/components/common/ErrorDialog';
 import { ChevronLeftIcon } from '@/components/common/icons/ChevronLeftIcon';
 import { Button } from '@/components/ui/button';
@@ -60,12 +56,16 @@ export function ExperienceAddPageContent() {
       resetForm,
       goToNextStep,
     });
-  const isNextStepDisabled =
-    isAnalyzing ||
-    isSaving ||
-    (isBasicInfoStep && !isBasicInfoComplete(basicInfo)) ||
-    (isCoreInfoStep && !isCoreInfoComplete(coreInfo)) ||
-    (isResultStep && !isResultStepComplete({ basicInfo, coreInfo, resultInfo }));
+  const isNextStepDisabled = getExperienceAddNextStepDisabled({
+    isAnalyzing,
+    isSaving,
+    isBasicInfoStep,
+    isCoreInfoStep,
+    isResultStep,
+    basicInfo,
+    coreInfo,
+    resultInfo,
+  });
 
   useEffect(() => {
     if (!isNotionConnected) return;

--- a/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
@@ -1,16 +1,15 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { ExperienceAddMaterialModalView } from '@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal';
 import { ExperienceAddProgress } from '@/app/(pages)/experience/add/_components/ExperienceAddProgress';
 import { ExperienceAddStepContent } from '@/app/(pages)/experience/add/_components/ExperienceAddStepContent';
+import { useExperienceAddActions } from '@/app/(pages)/experience/add/_hooks/useExperienceAddActions';
 import { useExperienceAddForm } from '@/app/(pages)/experience/add/_hooks/useExperienceAddForm';
 import { useExperienceAddMaterials } from '@/app/(pages)/experience/add/_hooks/useExperienceAddMaterials';
 import { useExperienceAddStep } from '@/app/(pages)/experience/add/_hooks/useExperienceAddStep';
-import { mapExperienceAddFormToCreateRequest } from '@/app/(pages)/experience/add/_utils/mapExperienceAddFormToCreateRequest';
-import { clearExperienceAddPdfDraft } from '@/app/(pages)/experience/add/_utils/experienceAddPdfDraftStorage';
 import {
   isBasicInfoComplete,
   isCoreInfoComplete,
@@ -19,13 +18,6 @@ import {
 import { ErrorDialog } from '@/components/common/ErrorDialog';
 import { ChevronLeftIcon } from '@/components/common/icons/ChevronLeftIcon';
 import { Button } from '@/components/ui/button';
-import {
-  useAnalyzeExperienceMaterials,
-  useAnalyzeExperienceNotion,
-  useAnalyzeExperiencePdf,
-  useCreateExperience,
-} from '@/hooks/experience/useExperienceAdd';
-import { trackEvent } from '@/lib/analytics';
 
 export function ExperienceAddPageContent() {
   const router = useRouter();
@@ -56,17 +48,18 @@ export function ExperienceAddPageContent() {
     applyAnalyzeResponse,
     resetForm,
   } = useExperienceAddForm();
-  const [errorMessage, setErrorMessage] = useState('');
-  const isProcessingRef = useRef(false);
-  const analyzePdfMutation = useAnalyzeExperiencePdf();
-  const analyzeNotionMutation = useAnalyzeExperienceNotion();
-  const analyzeMaterialsMutation = useAnalyzeExperienceMaterials();
-  const createExperienceMutation = useCreateExperience();
-  const isAnalyzing =
-    analyzePdfMutation.isPending ||
-    analyzeNotionMutation.isPending ||
-    analyzeMaterialsMutation.isPending;
-  const isSaving = createExperienceMutation.isPending;
+  const { isAnalyzing, isSaving, errorMessage, setErrorMessage, handleNextStep } =
+    useExperienceAddActions({
+      currentStepIndex,
+      isResultStep,
+      materials,
+      basicInfo,
+      coreInfo,
+      resultInfo,
+      applyAnalyzeResponse,
+      resetForm,
+      goToNextStep,
+    });
   const isNextStepDisabled =
     isAnalyzing ||
     isSaving ||
@@ -79,73 +72,6 @@ export function ExperienceAddPageContent() {
 
     router.replace('/experience/add', { scroll: false });
   }, [isNotionConnected, router]);
-
-  const goNextStep = async () => {
-    if (isProcessingRef.current) return;
-
-    isProcessingRef.current = true;
-
-    try {
-      if (currentStepIndex === 0) {
-        const pdfMaterial = materials.find((material) => material.type === 'pdf');
-        const notionMaterial = materials.find((material) => material.type === 'notion');
-
-        try {
-          if (pdfMaterial && notionMaterial) {
-            const analyzeResponse = await analyzeMaterialsMutation.mutateAsync({
-              file: pdfMaterial?.file,
-              pageId: notionMaterial?.pageId,
-            });
-
-            applyAnalyzeResponse(analyzeResponse);
-            void clearExperienceAddPdfDraft().catch((error: unknown) => {
-              console.warn('PDF 임시 저장 데이터를 삭제하지 못했습니다.', error);
-            });
-          } else if (pdfMaterial) {
-            const analyzeResponse = await analyzePdfMutation.mutateAsync(pdfMaterial.file);
-            applyAnalyzeResponse(analyzeResponse);
-            void clearExperienceAddPdfDraft().catch((error: unknown) => {
-              console.warn('PDF 임시 저장 데이터를 삭제하지 못했습니다.', error);
-            });
-          } else if (notionMaterial) {
-            const analyzeResponse = await analyzeNotionMutation.mutateAsync(notionMaterial.pageId);
-            applyAnalyzeResponse(analyzeResponse);
-          } else {
-            resetForm();
-          }
-        } catch (error) {
-          setErrorMessage(
-            error instanceof Error ? error.message : '자료 분석 중 오류가 발생했습니다.',
-          );
-          return;
-        }
-      }
-
-      if (isResultStep) {
-        try {
-          await createExperienceMutation.mutateAsync(
-            mapExperienceAddFormToCreateRequest({
-              basicInfo,
-              coreInfo,
-              resultInfo,
-            }),
-          );
-          trackEvent('experience_create', {
-            source: 'experience_add',
-          });
-        } catch (error) {
-          setErrorMessage(
-            error instanceof Error ? error.message : '경험 저장 중 오류가 발생했습니다.',
-          );
-          return;
-        }
-      }
-
-      goToNextStep();
-    } finally {
-      isProcessingRef.current = false;
-    }
-  };
 
   return (
     <div className="flex min-h-dvh flex-col py-5">
@@ -194,7 +120,12 @@ export function ExperienceAddPageContent() {
               이전
             </Button>
           )}
-          <Button type="button" className="w-40" disabled={isNextStepDisabled} onClick={goNextStep}>
+          <Button
+            type="button"
+            className="w-40"
+            disabled={isNextStepDisabled}
+            onClick={handleNextStep}
+          >
             {isResultStep ? '저장하기' : '다음'}
           </Button>
         </footer>

--- a/src/app/(pages)/experience/add/_hooks/useExperienceAddActions.ts
+++ b/src/app/(pages)/experience/add/_hooks/useExperienceAddActions.ts
@@ -3,7 +3,11 @@
 import { useCallback, useRef, useState } from 'react';
 
 import type { ExperienceAnalyzeResponse } from '@/app/api/experience/add/types';
-import type { ExperienceMaterial } from '@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal';
+import type {
+  ExperienceMaterial,
+  NotionMaterial,
+  PdfMaterial,
+} from '@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal';
 import type {
   ExperienceAddBasicInfoForm,
   ExperienceAddCoreInfoForm,
@@ -61,8 +65,12 @@ export function useExperienceAddActions({
 
     try {
       if (currentStepIndex === 0) {
-        const pdfMaterial = materials.find((material) => material.type === 'pdf');
-        const notionMaterial = materials.find((material) => material.type === 'notion');
+        const pdfMaterial = materials.find(
+          (material): material is PdfMaterial => material.type === 'pdf',
+        );
+        const notionMaterial = materials.find(
+          (material): material is NotionMaterial => material.type === 'notion',
+        );
 
         try {
           if (pdfMaterial && notionMaterial) {

--- a/src/app/(pages)/experience/add/_hooks/useExperienceAddActions.ts
+++ b/src/app/(pages)/experience/add/_hooks/useExperienceAddActions.ts
@@ -1,0 +1,147 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+import type { ExperienceAnalyzeResponse } from '@/app/api/experience/add/types';
+import type { ExperienceMaterial } from '@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal';
+import type {
+  ExperienceAddBasicInfoForm,
+  ExperienceAddCoreInfoForm,
+  ExperienceAddResultInfoForm,
+} from '@/app/(pages)/experience/add/_types/experienceAddForm';
+import { clearExperienceAddPdfDraft } from '@/app/(pages)/experience/add/_utils/experienceAddPdfDraftStorage';
+import { mapExperienceAddFormToCreateRequest } from '@/app/(pages)/experience/add/_utils/mapExperienceAddFormToCreateRequest';
+import {
+  useAnalyzeExperienceMaterials,
+  useAnalyzeExperienceNotion,
+  useAnalyzeExperiencePdf,
+  useCreateExperience,
+} from '@/hooks/experience/useExperienceAdd';
+import { trackEvent } from '@/lib/analytics';
+
+interface UseExperienceAddActionsParams {
+  currentStepIndex: number;
+  isResultStep: boolean;
+  materials: ExperienceMaterial[];
+  basicInfo: ExperienceAddBasicInfoForm;
+  coreInfo: ExperienceAddCoreInfoForm;
+  resultInfo: ExperienceAddResultInfoForm;
+  applyAnalyzeResponse: (analyzeResponse: ExperienceAnalyzeResponse) => void;
+  resetForm: () => void;
+  goToNextStep: () => void;
+}
+
+export function useExperienceAddActions({
+  currentStepIndex,
+  isResultStep,
+  materials,
+  basicInfo,
+  coreInfo,
+  resultInfo,
+  applyAnalyzeResponse,
+  resetForm,
+  goToNextStep,
+}: UseExperienceAddActionsParams) {
+  const [errorMessage, setErrorMessage] = useState('');
+  const isProcessingRef = useRef(false);
+  const analyzePdfMutation = useAnalyzeExperiencePdf();
+  const analyzeNotionMutation = useAnalyzeExperienceNotion();
+  const analyzeMaterialsMutation = useAnalyzeExperienceMaterials();
+  const createExperienceMutation = useCreateExperience();
+  const isAnalyzing =
+    analyzePdfMutation.isPending ||
+    analyzeNotionMutation.isPending ||
+    analyzeMaterialsMutation.isPending;
+  const isSaving = createExperienceMutation.isPending;
+
+  const handleNextStep = useCallback(async () => {
+    if (isProcessingRef.current) return;
+
+    isProcessingRef.current = true;
+
+    try {
+      if (currentStepIndex === 0) {
+        const pdfMaterial = materials.find((material) => material.type === 'pdf');
+        const notionMaterial = materials.find((material) => material.type === 'notion');
+
+        try {
+          if (pdfMaterial && notionMaterial) {
+            const analyzeResponse = await analyzeMaterialsMutation.mutateAsync({
+              file: pdfMaterial.file,
+              pageId: notionMaterial.pageId,
+            });
+
+            applyAnalyzeResponse(analyzeResponse);
+            clearPdfDraft();
+          } else if (pdfMaterial) {
+            const analyzeResponse = await analyzePdfMutation.mutateAsync(pdfMaterial.file);
+            applyAnalyzeResponse(analyzeResponse);
+            clearPdfDraft();
+          } else if (notionMaterial) {
+            const analyzeResponse = await analyzeNotionMutation.mutateAsync(notionMaterial.pageId);
+            applyAnalyzeResponse(analyzeResponse);
+          } else {
+            resetForm();
+          }
+        } catch (error) {
+          setErrorMessage(
+            error instanceof Error ? error.message : '자료 분석 중 오류가 발생했습니다.',
+          );
+          return;
+        }
+      }
+
+      if (isResultStep) {
+        try {
+          await createExperienceMutation.mutateAsync(
+            mapExperienceAddFormToCreateRequest({
+              basicInfo,
+              coreInfo,
+              resultInfo,
+            }),
+          );
+          trackEvent('experience_create', {
+            source: 'experience_add',
+          });
+        } catch (error) {
+          setErrorMessage(
+            error instanceof Error ? error.message : '경험 저장 중 오류가 발생했습니다.',
+          );
+          return;
+        }
+      }
+
+      goToNextStep();
+    } finally {
+      isProcessingRef.current = false;
+    }
+  }, [
+    analyzeMaterialsMutation,
+    analyzeNotionMutation,
+    analyzePdfMutation,
+    applyAnalyzeResponse,
+    basicInfo,
+    coreInfo,
+    createExperienceMutation,
+    currentStepIndex,
+    goToNextStep,
+    isResultStep,
+    materials,
+    resetForm,
+    resultInfo,
+  ]);
+
+  return {
+    isAnalyzing,
+    isSaving,
+    errorMessage,
+    setErrorMessage,
+    handleNextStep,
+  };
+}
+
+function clearPdfDraft() {
+  void clearExperienceAddPdfDraft().catch((error: unknown) => {
+    console.warn('PDF 임시 저장 데이터를 삭제하지 못했습니다.', error);
+  });
+}

--- a/src/app/(pages)/experience/add/_hooks/useExperienceAddForm.ts
+++ b/src/app/(pages)/experience/add/_hooks/useExperienceAddForm.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import type { ExperienceAnalyzeResponse } from '@/app/api/experience/add/types';
+import {
+  createEmptyBasicInfoForm,
+  createEmptyCoreInfoForm,
+  createEmptyResultInfoForm,
+} from '@/app/(pages)/experience/add/_types/experienceAddForm';
+import {
+  mapAnalyzeResponseToBasicInfoForm,
+  mapAnalyzeResponseToCoreInfoForm,
+  mapAnalyzeResponseToResultInfoForm,
+} from '@/app/(pages)/experience/add/_utils/mapAnalyzeResponseToBasicInfoForm';
+
+export function useExperienceAddForm() {
+  const [basicInfo, setBasicInfo] = useState(createEmptyBasicInfoForm);
+  const [coreInfo, setCoreInfo] = useState(createEmptyCoreInfoForm);
+  const [resultInfo, setResultInfo] = useState(createEmptyResultInfoForm);
+
+  const applyAnalyzeResponse = useCallback((analyzeResponse: ExperienceAnalyzeResponse) => {
+    setBasicInfo(mapAnalyzeResponseToBasicInfoForm(analyzeResponse));
+    setCoreInfo(mapAnalyzeResponseToCoreInfoForm(analyzeResponse));
+    setResultInfo(mapAnalyzeResponseToResultInfoForm(analyzeResponse));
+  }, []);
+
+  const resetForm = useCallback(() => {
+    setBasicInfo(createEmptyBasicInfoForm());
+    setCoreInfo(createEmptyCoreInfoForm());
+    setResultInfo(createEmptyResultInfoForm());
+  }, []);
+
+  return {
+    basicInfo,
+    coreInfo,
+    resultInfo,
+    setBasicInfo,
+    setCoreInfo,
+    setResultInfo,
+    applyAnalyzeResponse,
+    resetForm,
+  };
+}

--- a/src/app/(pages)/experience/add/_hooks/useExperienceAddMaterials.ts
+++ b/src/app/(pages)/experience/add/_hooks/useExperienceAddMaterials.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import type { ExperienceMaterial } from '@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal';
+import { getExperienceAddPdfDraft } from '@/app/(pages)/experience/add/_utils/experienceAddPdfDraftStorage';
+
+export function useExperienceAddMaterials() {
+  const [materials, setMaterials] = useState<ExperienceMaterial[]>([]);
+
+  useEffect(() => {
+    const restorePdfDraft = async () => {
+      try {
+        const pdfMaterial = await getExperienceAddPdfDraft();
+
+        if (!pdfMaterial) return;
+
+        setMaterials((currentMaterials) => {
+          const hasPdf = currentMaterials.some((material) => material.type === 'pdf');
+
+          if (hasPdf) return currentMaterials;
+
+          return [pdfMaterial, ...currentMaterials];
+        });
+      } catch (error) {
+        console.warn('PDF 임시 저장 데이터를 복구하지 못했습니다.', error);
+      }
+    };
+
+    void restorePdfDraft();
+  }, []);
+
+  return {
+    materials,
+    setMaterials,
+  };
+}

--- a/src/app/(pages)/experience/add/_hooks/useExperienceAddStep.ts
+++ b/src/app/(pages)/experience/add/_hooks/useExperienceAddStep.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { EXPERIENCE_ADD_STEPS } from '@/app/(pages)/experience/add/_constants/experienceAddSteps';
+
+export function useExperienceAddStep() {
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+  const isFirstStep = currentStepIndex === 0;
+  const isCompleteStep = currentStepIndex === EXPERIENCE_ADD_STEPS.length;
+  const isBasicInfoStep = currentStepIndex === 1;
+  const isCoreInfoStep = currentStepIndex === 2;
+  const isResultStep = currentStepIndex === EXPERIENCE_ADD_STEPS.length - 1;
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'auto' });
+  }, [currentStepIndex]);
+
+  const goPreviousStep = useCallback(() => {
+    setCurrentStepIndex((stepIndex) => Math.max(stepIndex - 1, 0));
+  }, []);
+
+  const goNextStep = useCallback(() => {
+    setCurrentStepIndex((stepIndex) => Math.min(stepIndex + 1, EXPERIENCE_ADD_STEPS.length));
+  }, []);
+
+  return {
+    currentStepIndex,
+    isFirstStep,
+    isCompleteStep,
+    isBasicInfoStep,
+    isCoreInfoStep,
+    isResultStep,
+    goPreviousStep,
+    goNextStep,
+  };
+}

--- a/src/app/(pages)/experience/add/_utils/experienceAddValidation.ts
+++ b/src/app/(pages)/experience/add/_utils/experienceAddValidation.ts
@@ -1,0 +1,44 @@
+import { CORE_EXPERIENCE_FIELDS } from '@/app/(pages)/experience/add/_constants/experienceCoreQuestions';
+import { EXPERIENCE_TYPE_FIELD_GROUPS } from '@/app/(pages)/experience/add/_constants/experienceTypeOptions';
+import type {
+  ExperienceAddBasicInfoForm,
+  ExperienceAddCoreInfoForm,
+  ExperienceAddResultInfoForm,
+} from '@/app/(pages)/experience/add/_types/experienceAddForm';
+
+export function isBasicInfoComplete(basicInfo: ExperienceAddBasicInfoForm) {
+  if (!basicInfo.type) return false;
+
+  return EXPERIENCE_TYPE_FIELD_GROUPS[basicInfo.type].every((fieldGroup) =>
+    fieldGroup.fields.every((field) => hasText(basicInfo[field.name])),
+  );
+}
+
+export function isCoreInfoComplete(coreInfo: ExperienceAddCoreInfoForm) {
+  return CORE_EXPERIENCE_FIELDS.every((field) => hasText(coreInfo[field.name]));
+}
+
+export function isResultStepComplete({
+  basicInfo,
+  coreInfo,
+  resultInfo,
+}: {
+  basicInfo: ExperienceAddBasicInfoForm;
+  coreInfo: ExperienceAddCoreInfoForm;
+  resultInfo: ExperienceAddResultInfoForm;
+}) {
+  return (
+    isBasicInfoComplete(basicInfo) &&
+    isCoreInfoComplete(coreInfo) &&
+    hasTag(resultInfo.skillTags) &&
+    hasTag(resultInfo.competencyTags)
+  );
+}
+
+function hasText(value: string | null | undefined) {
+  return (value ?? '').trim().length > 0;
+}
+
+function hasTag(tags: string[]) {
+  return tags.some(hasText);
+}

--- a/src/app/(pages)/experience/add/_utils/experienceAddValidation.ts
+++ b/src/app/(pages)/experience/add/_utils/experienceAddValidation.ts
@@ -6,6 +6,36 @@ import type {
   ExperienceAddResultInfoForm,
 } from '@/app/(pages)/experience/add/_types/experienceAddForm';
 
+interface GetExperienceAddNextStepDisabledParams {
+  isAnalyzing: boolean;
+  isSaving: boolean;
+  isBasicInfoStep: boolean;
+  isCoreInfoStep: boolean;
+  isResultStep: boolean;
+  basicInfo: ExperienceAddBasicInfoForm;
+  coreInfo: ExperienceAddCoreInfoForm;
+  resultInfo: ExperienceAddResultInfoForm;
+}
+
+export function getExperienceAddNextStepDisabled({
+  isAnalyzing,
+  isSaving,
+  isBasicInfoStep,
+  isCoreInfoStep,
+  isResultStep,
+  basicInfo,
+  coreInfo,
+  resultInfo,
+}: GetExperienceAddNextStepDisabledParams) {
+  return (
+    isAnalyzing ||
+    isSaving ||
+    (isBasicInfoStep && !isBasicInfoComplete(basicInfo)) ||
+    (isCoreInfoStep && !isCoreInfoComplete(coreInfo)) ||
+    (isResultStep && !isResultStepComplete({ basicInfo, coreInfo, resultInfo }))
+  );
+}
+
 export function isBasicInfoComplete(basicInfo: ExperienceAddBasicInfoForm) {
   if (!basicInfo.type) return false;
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#146 

## 📝작업 내용

- `ExperienceAddPageContent`에 모여 있던 경험 추가 플로우 로직을 역할별 훅/유틸로 분리했습니다.
- 경험 추가 폼 상태와 분석 응답 반영/초기화 로직을 `useExperienceAddForm`으로 분리했습니다.
- 자료 목록 상태와 PDF draft 복구 로직을 `useExperienceAddMaterials`로 분리했습니다.
- 단계 상태, 이전/다음 이동, step 변경 시 스크롤 처리 로직을 `useExperienceAddStep`으로 분리했습니다.
- 자료 분석, 경험 저장, analytics, 에러 처리, 중복 처리 방지 로직을 `useExperienceAddActions`로 분리했습니다.
- 단계별 완료 여부와 다음 버튼 비활성화 계산을 `experienceAddValidation` 유틸로 분리했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code organization for the experience creation workflow by extracting step management, form state handling, material management, and action coordination into dedicated utilities. This enhances maintainability and code reusability without altering user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->