### PR TITLE
[Refactor] 경험 도메인 유닛 테스트 추가

### DIFF
--- a/src/app/(pages)/experience/_utils/mapExperienceItemToUpdateRequest.test.ts
+++ b/src/app/(pages)/experience/_utils/mapExperienceItemToUpdateRequest.test.ts
@@ -1,0 +1,133 @@
+import { mapExperienceItemToUpdateRequest } from './mapExperienceItemToUpdateRequest';
+
+type ExperienceUpdateSource = Parameters<typeof mapExperienceItemToUpdateRequest>[0];
+
+function createExperience(override: Partial<ExperienceUpdateSource> = {}): ExperienceUpdateSource {
+  return {
+    type: 'activity',
+    title: '경험 제목',
+    description: '한 줄 소개',
+    startDate: '2024-01-01',
+    endDate: '2024-12-31',
+    basicDetail: {
+      name: '프로젝트',
+      teamNum: '4',
+      role: '프론트엔드',
+      contributionRate: '70',
+    },
+    skillTags: ['React', 'TypeScript'],
+    competencyTags: ['협업', '문제 해결'],
+    detail: {
+      situation: '상황',
+      task: '과제',
+      action: '행동',
+      result: '결과',
+      taken: '배운 점',
+    },
+    ...override,
+  };
+}
+
+describe('mapExperienceItemToUpdateRequest', () => {
+  test('maps common fields, tags, STAR fields, and activity detail', () => {
+    expect(mapExperienceItemToUpdateRequest(createExperience())).toEqual({
+      title: '경험 제목',
+      oneLineIntro: '한 줄 소개',
+      tags: [
+        { category: 'TECH', field: 'React' },
+        { category: 'TECH', field: 'TypeScript' },
+        { category: 'COMPETENCY', field: '협업' },
+        { category: 'COMPETENCY', field: '문제 해결' },
+      ],
+      situation: '상황',
+      task: '과제',
+      act: '행동',
+      result: '결과',
+      taken: '배운 점',
+      detail: {
+        name: '프로젝트',
+        teamNum: 4,
+        role: '프론트엔드',
+        contributionRate: 70,
+        startDate: '2024-01-01',
+        endDate: '2024-12-31',
+      },
+    });
+  });
+
+  test('omits invalid activity numeric fields as undefined', () => {
+    const request = mapExperienceItemToUpdateRequest(
+      createExperience({
+        basicDetail: {
+          name: '프로젝트',
+          teamNum: ' ',
+          role: '프론트엔드',
+          contributionRate: 'abc',
+        },
+      }),
+    );
+
+    expect(request.detail).toEqual({
+      name: '프로젝트',
+      teamNum: undefined,
+      role: '프론트엔드',
+      contributionRate: undefined,
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+    });
+  });
+
+  test('maps career detail', () => {
+    const request = mapExperienceItemToUpdateRequest(
+      createExperience({
+        type: 'career',
+        basicDetail: {
+          name: '인턴십',
+          company: '키움랩',
+          employmentStatus: '인턴',
+        },
+      }),
+    );
+
+    expect(request.detail).toEqual({
+      name: '인턴십',
+      company: '키움랩',
+      employmentStatus: '인턴',
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+    });
+  });
+
+  test('maps education detail', () => {
+    const request = mapExperienceItemToUpdateRequest(
+      createExperience({
+        type: 'education',
+        basicDetail: {
+          organizationName: '교육기관',
+          name: '프론트엔드 과정',
+        },
+      }),
+    );
+
+    expect(request.detail).toEqual({
+      organizationName: '교육기관',
+      name: '프론트엔드 과정',
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+    });
+  });
+
+  test('maps etc detail with only period fields', () => {
+    const request = mapExperienceItemToUpdateRequest(
+      createExperience({
+        type: 'etc',
+        basicDetail: {},
+      }),
+    );
+
+    expect(request.detail).toEqual({
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+    });
+  });
+});

--- a/src/app/(pages)/experience/_utils/mapExperiencePieceType.test.ts
+++ b/src/app/(pages)/experience/_utils/mapExperiencePieceType.test.ts
@@ -1,0 +1,41 @@
+import {
+  mapExperiencePieceTypeToCategory,
+  normalizeExperiencePieceType,
+} from './mapExperiencePieceType';
+
+describe('normalizeExperiencePieceType', () => {
+  test('normalizes known piece types', () => {
+    expect(normalizeExperiencePieceType('ACTIVITY')).toBe('ACTIVITY');
+    expect(normalizeExperiencePieceType('CAREER')).toBe('CAREER');
+    expect(normalizeExperiencePieceType('EDUCATION')).toBe('EDUCATION');
+    expect(normalizeExperiencePieceType('ETC')).toBe('ETC');
+  });
+
+  test('trims and uppercases string values', () => {
+    expect(normalizeExperiencePieceType(' activity ')).toBe('ACTIVITY');
+    expect(normalizeExperiencePieceType('career')).toBe('CAREER');
+  });
+
+  test('returns undefined for unsupported values', () => {
+    expect(normalizeExperiencePieceType('ALL')).toBeUndefined();
+    expect(normalizeExperiencePieceType('UNKNOWN')).toBeUndefined();
+    expect(normalizeExperiencePieceType('')).toBeUndefined();
+    expect(normalizeExperiencePieceType(null)).toBeUndefined();
+    expect(normalizeExperiencePieceType(1)).toBeUndefined();
+  });
+});
+
+describe('mapExperiencePieceTypeToCategory', () => {
+  test('maps backend piece types to UI categories', () => {
+    expect(mapExperiencePieceTypeToCategory('ACTIVITY')).toBe('activity');
+    expect(mapExperiencePieceTypeToCategory('CAREER')).toBe('career');
+    expect(mapExperiencePieceTypeToCategory('EDUCATION')).toBe('education');
+    expect(mapExperiencePieceTypeToCategory('ETC')).toBe('etc');
+  });
+
+  test('uses fallback for unsupported values', () => {
+    expect(mapExperiencePieceTypeToCategory('ALL')).toBe('etc');
+    expect(mapExperiencePieceTypeToCategory('UNKNOWN', 'career')).toBe('career');
+    expect(mapExperiencePieceTypeToCategory(undefined, 'activity')).toBe('activity');
+  });
+});

--- a/src/app/(pages)/experience/_utils/mapExperienceResponse.test.ts
+++ b/src/app/(pages)/experience/_utils/mapExperienceResponse.test.ts
@@ -1,0 +1,184 @@
+import type { ExperienceCardResponse, ExperienceDetailResponse } from '@/app/api/experience/types';
+
+import { mapExperienceCardToItem, mapExperienceDetailToItem } from './mapExperienceResponse';
+
+describe('mapExperienceCardToItem', () => {
+  test('maps list card response to experience item', () => {
+    const response: ExperienceCardResponse = {
+      pieceId: 1,
+      experienceId: 10,
+      type: 'ACTIVITY',
+      title: '프로젝트 경험',
+      oneLineIntro: '서비스 리뉴얼',
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+      tags: [
+        { category: 'TECH', field: 'React' },
+        { category: 'TECH', field: 'TypeScript' },
+        { category: 'COMPETENCY', field: '문제 해결' },
+      ],
+    };
+
+    expect(mapExperienceCardToItem(response)).toEqual({
+      id: '10',
+      type: 'activity',
+      title: '프로젝트 경험',
+      description: '서비스 리뉴얼',
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+      period: '2024.01.01~12.31',
+      detailInfo: [{ label: '기간', value: '2024.01.01~12.31' }],
+      basicDetail: {},
+      skillTags: ['React', 'TypeScript'],
+      competencyTags: ['문제 해결'],
+      detail: {
+        situation: '',
+        task: '',
+        action: '',
+        result: '',
+        taken: '',
+      },
+    });
+  });
+});
+
+describe('mapExperienceDetailToItem', () => {
+  const detailBase = {
+    pieceId: 1,
+    experienceId: 20,
+    title: '상세 경험',
+    oneLineIntro: '상세 한 줄 소개',
+    tags: [
+      { category: 'TECH', field: 'Next.js' },
+      { category: 'COMPETENCY', field: '협업' },
+    ],
+    situation: '상황',
+    task: '과제',
+    act: '행동',
+    result: '결과',
+    taken: '배운 점',
+  } satisfies Omit<ExperienceDetailResponse, 'type' | 'detail'>;
+
+  test('maps activity detail fields', () => {
+    const response: ExperienceDetailResponse = {
+      ...detailBase,
+      experienceId: 21,
+      type: 'ACTIVITY',
+      detail: {
+        name: '프로젝트',
+        teamNum: 4,
+        role: '프론트엔드',
+        contributionRate: 70,
+        startDate: '2023-03-01',
+        endDate: '2023-08-31',
+      },
+    };
+
+    const item = mapExperienceDetailToItem(response);
+
+    expect(item).toMatchObject({
+      id: '21',
+      type: 'activity',
+      title: '상세 경험',
+      description: '상세 한 줄 소개',
+      startDate: '2023-03-01',
+      endDate: '2023-08-31',
+      period: '2023.03.01~08.31',
+      basicDetail: {
+        name: '프로젝트',
+        teamNum: '4',
+        role: '프론트엔드',
+        contributionRate: '70',
+      },
+      skillTags: ['Next.js'],
+      competencyTags: ['협업'],
+      detail: {
+        situation: '상황',
+        task: '과제',
+        action: '행동',
+        result: '결과',
+        taken: '배운 점',
+      },
+    });
+    expect(item.detailInfo).toEqual([
+      { label: '기간', value: '2023.03.01~08.31' },
+      { label: '팀원 수', value: '4명' },
+      { label: '내 역할', value: '프론트엔드' },
+      { label: '기여도', value: '70%' },
+    ]);
+  });
+
+  test('maps career detail fields', () => {
+    const response: ExperienceDetailResponse = {
+      ...detailBase,
+      type: 'CAREER',
+      detail: {
+        name: '인턴십',
+        company: '키움랩',
+        employmentStatus: '인턴',
+        startDate: '2022-01-01',
+        endDate: '2023-02-28',
+      },
+    };
+
+    expect(mapExperienceDetailToItem(response)).toMatchObject({
+      type: 'career',
+      period: '2022.01.01~2023.02.28',
+      basicDetail: {
+        name: '인턴십',
+        company: '키움랩',
+        employmentStatus: '인턴',
+      },
+      detailInfo: [
+        { label: '기간', value: '2022.01.01~2023.02.28' },
+        { label: '회사/기관/단체명', value: '키움랩' },
+        { label: '고용 형태', value: '인턴' },
+      ],
+    });
+  });
+
+  test('maps education detail fields', () => {
+    const response: ExperienceDetailResponse = {
+      ...detailBase,
+      type: 'EDUCATION',
+      detail: {
+        organizationName: '교육기관',
+        name: '프론트엔드 과정',
+        startDate: '2024-04-01',
+        endDate: '2024-06-30',
+      },
+    };
+
+    expect(mapExperienceDetailToItem(response)).toMatchObject({
+      type: 'education',
+      period: '2024.04.01~06.30',
+      basicDetail: {
+        organizationName: '교육기관',
+        name: '프론트엔드 과정',
+      },
+      detailInfo: [
+        { label: '기간', value: '2024.04.01~06.30' },
+        { label: '기관명', value: '교육기관' },
+        { label: '수강명', value: '프론트엔드 과정' },
+      ],
+    });
+  });
+
+  test('maps etc detail fields', () => {
+    const response: ExperienceDetailResponse = {
+      ...detailBase,
+      type: 'ETC',
+      detail: {
+        startDate: '2024-07-01',
+        endDate: '2024-07-31',
+      },
+    };
+
+    expect(mapExperienceDetailToItem(response)).toMatchObject({
+      type: 'etc',
+      period: '2024.07.01~07.31',
+      basicDetail: {},
+      detailInfo: [{ label: '기간', value: '2024.07.01~07.31' }],
+    });
+  });
+});

--- a/src/app/(pages)/experience/add/_utils/experienceAddValidation.test.ts
+++ b/src/app/(pages)/experience/add/_utils/experienceAddValidation.test.ts
@@ -163,7 +163,7 @@ describe('isResultStepComplete', () => {
     ).toBe(true);
   });
 
-  test('returns false when a required tag group has no text', () => {
+  test('returns false when skillTags has no text', () => {
     expect(
       isResultStepComplete({
         basicInfo: createBasicInfo(),
@@ -171,6 +171,38 @@ describe('isResultStepComplete', () => {
         resultInfo: createResultInfo({
           skillTags: [' '],
         }),
+      }),
+    ).toBe(false);
+  });
+
+  test('returns false when competencyTags has no text', () => {
+    expect(
+      isResultStepComplete({
+        basicInfo: createBasicInfo(),
+        coreInfo: createCoreInfo(),
+        resultInfo: createResultInfo({
+          competencyTags: [' '],
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  test('returns false when basicInfo is incomplete', () => {
+    expect(
+      isResultStepComplete({
+        basicInfo: createBasicInfo({ title: '' }),
+        coreInfo: createCoreInfo(),
+        resultInfo: createResultInfo(),
+      }),
+    ).toBe(false);
+  });
+
+  test('returns false when coreInfo is incomplete', () => {
+    expect(
+      isResultStepComplete({
+        basicInfo: createBasicInfo(),
+        coreInfo: createCoreInfo({ situation: '' }),
+        resultInfo: createResultInfo(),
       }),
     ).toBe(false);
   });

--- a/src/app/(pages)/experience/add/_utils/experienceAddValidation.test.ts
+++ b/src/app/(pages)/experience/add/_utils/experienceAddValidation.test.ts
@@ -126,6 +126,20 @@ describe('isBasicInfoComplete', () => {
       ),
     ).toBe(true);
   });
+
+  test('returns false when an etc required common field is missing', () => {
+    expect(
+      isBasicInfoComplete(
+        createBasicInfo({
+          type: 'etc',
+          title: '',
+          teamNum: '',
+          role: '',
+          contributionRate: '',
+        }),
+      ),
+    ).toBe(false);
+  });
 });
 
 describe('isCoreInfoComplete', () => {

--- a/src/app/(pages)/experience/add/_utils/experienceAddValidation.test.ts
+++ b/src/app/(pages)/experience/add/_utils/experienceAddValidation.test.ts
@@ -1,0 +1,231 @@
+import {
+  createEmptyBasicInfoForm,
+  createEmptyCoreInfoForm,
+  createEmptyResultInfoForm,
+  type ExperienceAddBasicInfoForm,
+  type ExperienceAddCoreInfoForm,
+  type ExperienceAddResultInfoForm,
+} from '@/app/(pages)/experience/add/_types/experienceAddForm';
+
+import {
+  getExperienceAddNextStepDisabled,
+  isBasicInfoComplete,
+  isCoreInfoComplete,
+  isResultStepComplete,
+} from './experienceAddValidation';
+
+type NextStepDisabledParams = Parameters<typeof getExperienceAddNextStepDisabled>[0];
+
+function createBasicInfo(
+  override: Partial<ExperienceAddBasicInfoForm> = {},
+): ExperienceAddBasicInfoForm {
+  return {
+    ...createEmptyBasicInfoForm(),
+    type: 'activity',
+    title: '경험 제목',
+    oneLineIntro: '한 줄 소개',
+    teamNum: '5',
+    role: '프론트엔드',
+    contributionRate: '70',
+    startDate: '2024-01-01',
+    endDate: '2024-12-31',
+    ...override,
+  };
+}
+
+function createCoreInfo(
+  override: Partial<ExperienceAddCoreInfoForm> = {},
+): ExperienceAddCoreInfoForm {
+  return {
+    ...createEmptyCoreInfoForm(),
+    situation: '상황',
+    task: '과제',
+    act: '행동',
+    result: '결과',
+    taken: '배운 점',
+    ...override,
+  };
+}
+
+function createResultInfo(
+  override: Partial<ExperienceAddResultInfoForm> = {},
+): ExperienceAddResultInfoForm {
+  return {
+    ...createEmptyResultInfoForm(),
+    skillTags: ['React'],
+    competencyTags: ['협업'],
+    ...override,
+  };
+}
+
+function createNextStepDisabledParams(
+  override: Partial<NextStepDisabledParams> = {},
+): NextStepDisabledParams {
+  return {
+    isAnalyzing: false,
+    isSaving: false,
+    isBasicInfoStep: false,
+    isCoreInfoStep: false,
+    isResultStep: false,
+    basicInfo: createBasicInfo(),
+    coreInfo: createCoreInfo(),
+    resultInfo: createResultInfo(),
+    ...override,
+  };
+}
+
+describe('isBasicInfoComplete', () => {
+  test('returns false when experience type is missing', () => {
+    expect(isBasicInfoComplete(createBasicInfo({ type: null }))).toBe(false);
+  });
+
+  test('validates activity required fields', () => {
+    expect(isBasicInfoComplete(createBasicInfo())).toBe(true);
+    expect(isBasicInfoComplete(createBasicInfo({ contributionRate: ' ' }))).toBe(false);
+  });
+
+  test('validates career required fields without activity fields', () => {
+    expect(
+      isBasicInfoComplete(
+        createBasicInfo({
+          type: 'career',
+          teamNum: '',
+          role: '',
+          contributionRate: '',
+          company: '키움랩',
+          employmentStatus: '인턴',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test('validates education required fields', () => {
+    expect(
+      isBasicInfoComplete(
+        createBasicInfo({
+          type: 'education',
+          teamNum: '',
+          role: '',
+          contributionRate: '',
+          organizationName: '교육기관',
+          name: '프론트엔드 과정',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  test('validates etc required fields with only common fields', () => {
+    expect(
+      isBasicInfoComplete(
+        createBasicInfo({
+          type: 'etc',
+          teamNum: '',
+          role: '',
+          contributionRate: '',
+        }),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('isCoreInfoComplete', () => {
+  test('returns true when all core fields have text', () => {
+    expect(isCoreInfoComplete(createCoreInfo())).toBe(true);
+  });
+
+  test('returns false when a core field is blank', () => {
+    expect(isCoreInfoComplete(createCoreInfo({ task: ' ' }))).toBe(false);
+  });
+});
+
+describe('isResultStepComplete', () => {
+  test('returns true when basic info, core info, and both tag groups are complete', () => {
+    expect(
+      isResultStepComplete({
+        basicInfo: createBasicInfo(),
+        coreInfo: createCoreInfo(),
+        resultInfo: createResultInfo(),
+      }),
+    ).toBe(true);
+  });
+
+  test('returns false when a required tag group has no text', () => {
+    expect(
+      isResultStepComplete({
+        basicInfo: createBasicInfo(),
+        coreInfo: createCoreInfo(),
+        resultInfo: createResultInfo({
+          skillTags: [' '],
+        }),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('getExperienceAddNextStepDisabled', () => {
+  test('returns true while analyzing or saving', () => {
+    expect(
+      getExperienceAddNextStepDisabled(createNextStepDisabledParams({ isAnalyzing: true })),
+    ).toBe(true);
+    expect(getExperienceAddNextStepDisabled(createNextStepDisabledParams({ isSaving: true }))).toBe(
+      true,
+    );
+  });
+
+  test('validates basic info step state', () => {
+    expect(
+      getExperienceAddNextStepDisabled(
+        createNextStepDisabledParams({
+          isBasicInfoStep: true,
+          basicInfo: createBasicInfo({ title: '' }),
+        }),
+      ),
+    ).toBe(true);
+
+    expect(
+      getExperienceAddNextStepDisabled(
+        createNextStepDisabledParams({
+          isBasicInfoStep: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test('validates core info step state', () => {
+    expect(
+      getExperienceAddNextStepDisabled(
+        createNextStepDisabledParams({
+          isCoreInfoStep: true,
+          coreInfo: createCoreInfo({ act: '' }),
+        }),
+      ),
+    ).toBe(true);
+
+    expect(
+      getExperienceAddNextStepDisabled(
+        createNextStepDisabledParams({
+          isCoreInfoStep: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  test('validates result step state', () => {
+    expect(
+      getExperienceAddNextStepDisabled(
+        createNextStepDisabledParams({
+          isResultStep: true,
+          resultInfo: createResultInfo({ competencyTags: [] }),
+        }),
+      ),
+    ).toBe(true);
+
+    expect(
+      getExperienceAddNextStepDisabled(
+        createNextStepDisabledParams({
+          isResultStep: true,
+        }),
+      ),
+    ).toBe(false);
+  });
+});

--- a/src/app/(pages)/experience/add/_utils/mapAnalyzeResponseToBasicInfoForm.test.ts
+++ b/src/app/(pages)/experience/add/_utils/mapAnalyzeResponseToBasicInfoForm.test.ts
@@ -1,0 +1,151 @@
+import type { ExperienceAnalyzeResponse } from '@/app/api/experience/add/types';
+
+import {
+  mapAnalyzeResponseToBasicInfoForm,
+  mapAnalyzeResponseToCoreInfoForm,
+  mapAnalyzeResponseToResultInfoForm,
+} from './mapAnalyzeResponseToBasicInfoForm';
+
+function createAnalyzeResponse(
+  override: Partial<ExperienceAnalyzeResponse> = {},
+): ExperienceAnalyzeResponse {
+  return {
+    title: '분석된 제목',
+    oneLineIntro: '분석된 한 줄 소개',
+    activityInfo: null,
+    careerInfo: null,
+    educationInfo: null,
+    situation: '상황',
+    task: '과제',
+    act: '행동',
+    result: '결과',
+    taken: '배운 점',
+    tags: [],
+    ...override,
+  };
+}
+
+describe('mapAnalyzeResponseToBasicInfoForm', () => {
+  test('maps activity analyze info to basic info form', () => {
+    const response = createAnalyzeResponse({
+      activityInfo: {
+        name: '프로젝트',
+        teamNum: 4,
+        role: '프론트엔드',
+        contributionRate: 70,
+        startDate: '2024-01-01',
+        endDate: '2024-12-31',
+      },
+    });
+
+    expect(mapAnalyzeResponseToBasicInfoForm(response)).toEqual({
+      type: 'activity',
+      title: '분석된 제목',
+      oneLineIntro: '분석된 한 줄 소개',
+      teamNum: '4',
+      role: '프론트엔드',
+      contributionRate: '70',
+      company: '',
+      employmentStatus: '',
+      organizationName: '',
+      name: '',
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+    });
+  });
+
+  test('maps career analyze info to basic info form', () => {
+    const response = createAnalyzeResponse({
+      careerInfo: {
+        name: '인턴십',
+        company: '키움랩',
+        employmentStatus: '인턴',
+        startDate: '2023-01-01',
+        endDate: '2023-06-30',
+      },
+    });
+
+    expect(mapAnalyzeResponseToBasicInfoForm(response)).toMatchObject({
+      type: 'career',
+      company: '키움랩',
+      employmentStatus: '인턴',
+      startDate: '2023-01-01',
+      endDate: '2023-06-30',
+    });
+  });
+
+  test('maps education analyze info to basic info form', () => {
+    const response = createAnalyzeResponse({
+      educationInfo: {
+        organizationName: '교육기관',
+        name: '프론트엔드 과정',
+        startDate: '2024-03-01',
+        endDate: '2024-05-31',
+      },
+    });
+
+    expect(mapAnalyzeResponseToBasicInfoForm(response)).toMatchObject({
+      type: 'education',
+      organizationName: '교육기관',
+      name: '프론트엔드 과정',
+      startDate: '2024-03-01',
+      endDate: '2024-05-31',
+    });
+  });
+
+  test('uses etc type and empty strings when type-specific info is missing', () => {
+    const response = createAnalyzeResponse({
+      title: null,
+      oneLineIntro: null,
+    });
+
+    expect(mapAnalyzeResponseToBasicInfoForm(response)).toEqual({
+      type: 'etc',
+      title: '',
+      oneLineIntro: '',
+      teamNum: '',
+      role: '',
+      contributionRate: '',
+      company: '',
+      employmentStatus: '',
+      organizationName: '',
+      name: '',
+      startDate: '',
+      endDate: '',
+    });
+  });
+});
+
+describe('mapAnalyzeResponseToCoreInfoForm', () => {
+  test('maps core fields and converts null values to empty strings', () => {
+    const response = createAnalyzeResponse({
+      task: null,
+      result: null,
+    });
+
+    expect(mapAnalyzeResponseToCoreInfoForm(response)).toEqual({
+      situation: '상황',
+      task: '',
+      act: '행동',
+      result: '',
+      taken: '배운 점',
+    });
+  });
+});
+
+describe('mapAnalyzeResponseToResultInfoForm', () => {
+  test('splits tags by category', () => {
+    const response = createAnalyzeResponse({
+      tags: [
+        { category: 'TECH', field: 'React' },
+        { category: 'COMPETENCY', field: '협업' },
+        { category: 'TECH', field: 'TypeScript' },
+      ],
+    });
+
+    expect(mapAnalyzeResponseToResultInfoForm(response)).toEqual({
+      skillTags: ['React', 'TypeScript'],
+      competencyTags: ['협업'],
+    });
+  });
+});

--- a/src/app/(pages)/experience/add/_utils/mapExperienceAddFormToCreateRequest.test.ts
+++ b/src/app/(pages)/experience/add/_utils/mapExperienceAddFormToCreateRequest.test.ts
@@ -1,0 +1,169 @@
+import {
+  createEmptyBasicInfoForm,
+  createEmptyCoreInfoForm,
+  createEmptyResultInfoForm,
+  type ExperienceAddBasicInfoForm,
+  type ExperienceAddCoreInfoForm,
+  type ExperienceAddResultInfoForm,
+} from '@/app/(pages)/experience/add/_types/experienceAddForm';
+
+import { mapExperienceAddFormToCreateRequest } from './mapExperienceAddFormToCreateRequest';
+
+function createBasicInfo(
+  override: Partial<ExperienceAddBasicInfoForm> = {},
+): ExperienceAddBasicInfoForm {
+  return {
+    ...createEmptyBasicInfoForm(),
+    type: 'activity',
+    title: '경험 제목',
+    oneLineIntro: '한 줄 소개',
+    startDate: '2024-01-01',
+    endDate: '2024-12-31',
+    ...override,
+  };
+}
+
+function createCoreInfo(
+  override: Partial<ExperienceAddCoreInfoForm> = {},
+): ExperienceAddCoreInfoForm {
+  return {
+    ...createEmptyCoreInfoForm(),
+    situation: '상황',
+    task: '과제',
+    act: '행동',
+    result: '결과',
+    taken: '배운 점',
+    ...override,
+  };
+}
+
+function createResultInfo(
+  override: Partial<ExperienceAddResultInfoForm> = {},
+): ExperienceAddResultInfoForm {
+  return {
+    ...createEmptyResultInfoForm(),
+    skillTags: ['React', 'TypeScript'],
+    competencyTags: ['협업', '문제 해결'],
+    ...override,
+  };
+}
+
+describe('mapExperienceAddFormToCreateRequest', () => {
+  test('maps common fields, tags, and activity fields to create request', () => {
+    const request = mapExperienceAddFormToCreateRequest({
+      basicInfo: createBasicInfo({
+        name: '프로젝트',
+        teamNum: '5명',
+        role: ' 프론트엔드 ',
+        contributionRate: '70%',
+      }),
+      coreInfo: createCoreInfo(),
+      resultInfo: createResultInfo(),
+    });
+
+    expect(request).toEqual({
+      type: 'ACTIVITY',
+      title: '경험 제목',
+      oneLineIntro: '한 줄 소개',
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+      situation: '상황',
+      task: '과제',
+      act: '행동',
+      result: '결과',
+      taken: '배운 점',
+      tags: [
+        { category: 'TECH', field: 'React' },
+        { category: 'TECH', field: 'TypeScript' },
+        { category: 'COMPETENCY', field: '협업' },
+        { category: 'COMPETENCY', field: '문제 해결' },
+      ],
+      name: '프로젝트',
+      teamNum: 5,
+      role: '프론트엔드',
+      contributionRate: 70,
+    });
+  });
+
+  test('uses title as activity name fallback and omits invalid numeric fields', () => {
+    const request = mapExperienceAddFormToCreateRequest({
+      basicInfo: createBasicInfo({
+        name: ' ',
+        teamNum: 'abc',
+        contributionRate: '',
+      }),
+      coreInfo: createCoreInfo(),
+      resultInfo: createResultInfo(),
+    });
+
+    expect(request).toMatchObject({
+      type: 'ACTIVITY',
+      name: '경험 제목',
+      teamNum: undefined,
+      contributionRate: undefined,
+    });
+  });
+
+  test('maps career fields to create request', () => {
+    const request = mapExperienceAddFormToCreateRequest({
+      basicInfo: createBasicInfo({
+        type: 'career',
+        company: ' 키움랩 ',
+        employmentStatus: ' 인턴 ',
+      }),
+      coreInfo: createCoreInfo(),
+      resultInfo: createResultInfo(),
+    });
+
+    expect(request).toMatchObject({
+      type: 'CAREER',
+      company: '키움랩',
+      employmentStatus: '인턴',
+    });
+  });
+
+  test('maps education fields to create request', () => {
+    const request = mapExperienceAddFormToCreateRequest({
+      basicInfo: createBasicInfo({
+        type: 'education',
+        organizationName: ' 교육기관 ',
+        name: ' ',
+      }),
+      coreInfo: createCoreInfo(),
+      resultInfo: createResultInfo(),
+    });
+
+    expect(request).toMatchObject({
+      type: 'EDUCATION',
+      organizationName: '교육기관',
+      name: '경험 제목',
+    });
+  });
+
+  test('maps missing type to etc create request without type-specific fields', () => {
+    const request = mapExperienceAddFormToCreateRequest({
+      basicInfo: createBasicInfo({
+        type: null,
+      }),
+      coreInfo: createCoreInfo(),
+      resultInfo: createResultInfo({
+        skillTags: [],
+        competencyTags: [],
+      }),
+    });
+
+    expect(request).toEqual({
+      type: 'ETC',
+      title: '경험 제목',
+      oneLineIntro: '한 줄 소개',
+      startDate: '2024-01-01',
+      endDate: '2024-12-31',
+      situation: '상황',
+      task: '과제',
+      act: '행동',
+      result: '결과',
+      taken: '배운 점',
+      tags: [],
+    });
+  });
+});

--- a/src/app/(pages)/experience/add/_utils/mapExperienceAddFormToCreateRequest.test.ts
+++ b/src/app/(pages)/experience/add/_utils/mapExperienceAddFormToCreateRequest.test.ts
@@ -48,6 +48,20 @@ function createResultInfo(
   };
 }
 
+const etcCreateRequest = {
+  type: 'ETC',
+  title: '경험 제목',
+  oneLineIntro: '한 줄 소개',
+  startDate: '2024-01-01',
+  endDate: '2024-12-31',
+  situation: '상황',
+  task: '과제',
+  act: '행동',
+  result: '결과',
+  taken: '배운 점',
+  tags: [],
+} as const;
+
 describe('mapExperienceAddFormToCreateRequest', () => {
   test('maps common fields, tags, and activity fields to create request', () => {
     const request = mapExperienceAddFormToCreateRequest({
@@ -140,6 +154,21 @@ describe('mapExperienceAddFormToCreateRequest', () => {
     });
   });
 
+  test('maps etc type to etc create request without type-specific fields', () => {
+    const request = mapExperienceAddFormToCreateRequest({
+      basicInfo: createBasicInfo({
+        type: 'etc',
+      }),
+      coreInfo: createCoreInfo(),
+      resultInfo: createResultInfo({
+        skillTags: [],
+        competencyTags: [],
+      }),
+    });
+
+    expect(request).toEqual(etcCreateRequest);
+  });
+
   test('maps missing type to etc create request without type-specific fields', () => {
     const request = mapExperienceAddFormToCreateRequest({
       basicInfo: createBasicInfo({
@@ -152,18 +181,6 @@ describe('mapExperienceAddFormToCreateRequest', () => {
       }),
     });
 
-    expect(request).toEqual({
-      type: 'ETC',
-      title: '경험 제목',
-      oneLineIntro: '한 줄 소개',
-      startDate: '2024-01-01',
-      endDate: '2024-12-31',
-      situation: '상황',
-      task: '과제',
-      act: '행동',
-      result: '결과',
-      taken: '배운 점',
-      tags: [],
-    });
+    expect(request).toEqual(etcCreateRequest);
   });
 });


### PR DESCRIPTION
## #️⃣연관된 이슈

#154 

## 📝작업 내용

- 경험 관리 변환 유틸 테스트를 추가했습니다.
  - 경험 타입 정규화 및 카테고리 매핑 테스트
  - 경험 목록/상세 응답을 화면 모델로 변환하는 로직 테스트
  - 화면 모델을 경험 수정 API 요청으로 변환하는 로직 테스트

- 경험 추가 변환 유틸 테스트를 추가했습니다.
  - 분석 응답을 경험 추가 폼 상태로 변환하는 로직 테스트
  - 경험 추가 폼 상태를 생성 API 요청으로 변환하는 로직 테스트

- 경험 추가 유효성 검사 테스트를 추가했습니다.
  - 기본 정보, 핵심 경험, 결과 단계별 완료 여부 검증
  - 분석 중/저장 중 다음 버튼 비활성화 조건 검증
  - 타입별 필수 입력값 검증

- 검증
  - Jest: 6 suites / 39 tests 통과
  - ESLint 통과
  - Prettier 통과

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit test coverage for experience-related utility functions, including validation, form mapping, response transformation, and type normalization. Test suite covers multiple experience types (activity, career, education, etc.) and edge cases for data conversion and field validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->