### PR TITLE
[Perf] 경험 페이지 초기 번들 최적화 및 성능 측정

### DIFF
--- a/docs/performance/experience-initial-load.md
+++ b/docs/performance/experience-initial-load.md
@@ -1,0 +1,96 @@
+# Experience Initial Load Performance
+
+## Baseline
+
+Date: 2026-06-04
+
+Command:
+
+```bash
+pnpm build
+```
+
+Source:
+
+```txt
+.next/diagnostics/route-bundle-stats.json
+```
+
+| Route | First-load JS | Chunks |
+| --- | ---: | ---: |
+| `/experience` | 1,200,163 bytes (1,172.0 KiB / 1.14 MiB) | 19 |
+| `/experience/add` | 1,363,893 bytes (1,331.9 KiB / 1.30 MiB) | 18 |
+
+## Notes
+
+- This baseline is from a local production build.
+- Next.js emitted an existing static export warning for `headers` in `next.config.ts`.
+- Lighthouse and DevTools measurements should be recorded after serving the production build.
+
+## Lighthouse Baseline
+
+Date: 2026-06-04
+Target: deployed production domain
+Mode: Desktop
+
+| Route | FCP | LCP | TBT | CLS | Speed Index |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `/experience` | 1.5s | 4.9s | 10ms | 0 | 5.3s |
+| `/experience/add` | 1.5s | 5.0s | 10ms | 0 | 3.9s |
+
+### `/experience` Insights
+
+- Use efficient cache lifetimes: estimated savings 7,659 KiB.
+- Document request latency: server responded slowly, observed 646ms, no compression applied.
+- Render-blocking requests: CSS chunk, estimated savings 110ms.
+- LCP breakdown: TTFB 650ms, element render delay 4,310ms. LCP element is an experience card title.
+- Network dependency tree: maximum critical path latency 1,480ms.
+
+### `/experience/add` Insights
+
+- Use efficient cache lifetimes: estimated savings 6,091 KiB.
+- Document request latency: server responded slowly, observed 657ms, no compression applied.
+- Render-blocking requests: CSS chunk, estimated savings 50ms.
+- Legacy JavaScript: estimated savings 52 KiB.
+- LCP breakdown: TTFB 660ms, element render delay 4,360ms. LCP element is a text paragraph.
+- Network dependency tree: maximum critical path latency 1,609ms.
+
+## Optimization Candidates
+
+1. Fix cache lifetimes for static assets and generated chunks.
+2. Convert large local font files from TTF to WOFF2 where possible.
+3. Optimize oversized public SVG assets used in experience cards and shared UI.
+4. Split non-initial experience UI, such as detail panels, DnD-only code, material modal, and Notion views.
+5. Re-measure Lighthouse after each optimization group.
+
+## After Lazy Loading Non-Initial UI
+
+Date: 2026-06-04
+
+Command:
+
+```bash
+pnpm build
+```
+
+Source:
+
+```txt
+.next/diagnostics/route-bundle-stats.json
+```
+
+| Route | Before | After | Change | Chunks |
+| --- | ---: | ---: | ---: | ---: |
+| `/experience` | 1,200,163 bytes | 1,174,153 bytes | -26,010 bytes | 19 -> 18 |
+| `/experience/add` | 1,363,893 bytes | 998,965 bytes | -364,928 bytes | 18 -> 16 |
+
+Changes:
+
+- Lazily load the experience detail panel and detail page content.
+- Lazily load the experience add material modal.
+- Lazily load non-initial experience add steps after the upload step.
+
+Notes:
+
+- `pnpm build` passed.
+- Next.js still emitted the existing static export warning for `headers` in `next.config.ts`.

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import * as React from 'react';
 
 import { ExperienceCardGrid } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
 import type { ExperienceCategory } from '@/app/(pages)/experience/_components/ExperienceCategoryTab';
 import { ExperienceCategoryTabs } from '@/app/(pages)/experience/_components/ExperienceCategoryTabs';
-import { ExperienceDetailPanel } from '@/app/(pages)/experience/_components/ExperienceDetailPanel';
+import type { ExperienceDetailPanelProps } from '@/app/(pages)/experience/_components/ExperienceDetailPanel';
 import { useExperienceBoardActions } from '@/app/(pages)/experience/_hooks/useExperienceBoardActions';
 import { useExperienceBoardDetail } from '@/app/(pages)/experience/_hooks/useExperienceBoardDetail';
 import { useExperienceBoardInfiniteScroll } from '@/app/(pages)/experience/_hooks/useExperienceBoardInfiniteScroll';
@@ -35,6 +36,17 @@ const filterPieceTypeByCategory: Record<
   education: 'EDUCATION',
   etc: 'ETC',
 };
+
+const ExperienceDetailPanel = dynamic<ExperienceDetailPanelProps>(
+  () =>
+    import('@/app/(pages)/experience/_components/ExperienceDetailPanel').then(
+      (mod) => mod.ExperienceDetailPanel,
+    ),
+  {
+    ssr: false,
+    loading: ExperienceDetailPanelLoading,
+  },
+);
 
 export function ExperienceBoard({
   initialSelectedExperienceId,
@@ -209,5 +221,39 @@ export function ExperienceBoard({
         onOpenChange={handleErrorDialogOpenChange}
       />
     </section>
+  );
+}
+
+function ExperienceDetailPanelLoading() {
+  return (
+    <aside
+      role="dialog"
+      aria-modal="true"
+      aria-label="경험 상세 패널 로딩 중"
+      className="fixed top-0 right-0 z-40 flex h-dvh w-full max-w-[500px] flex-col gap-6 bg-background-default px-6 pt-8 pb-8 shadow-2xl"
+    >
+      <div className="grid h-8 grid-cols-[32px_1fr_32px] items-center">
+        <div className="size-8 animate-pulse rounded bg-gray-200" />
+        <div className="mx-auto h-6 w-24 animate-pulse rounded bg-gray-200" />
+        <div className="size-8 animate-pulse rounded bg-gray-200" />
+      </div>
+      <div className="flex animate-pulse flex-col gap-6">
+        <div className="flex flex-col gap-3">
+          <div className="h-8 w-3/4 rounded bg-gray-200" />
+          <div className="h-5 w-full rounded bg-gray-100" />
+          <div className="h-5 w-2/3 rounded bg-gray-100" />
+        </div>
+        <div className="grid grid-cols-2 gap-3">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="h-16 rounded-lg bg-gray-100" />
+          ))}
+        </div>
+        <div className="flex flex-col gap-3">
+          <div className="h-5 w-24 rounded bg-gray-200" />
+          <div className="h-28 rounded-lg bg-gray-100" />
+          <div className="h-28 rounded-lg bg-gray-100" />
+        </div>
+      </div>
+    </aside>
   );
 }

--- a/src/app/(pages)/experience/_components/ExperienceDetailPageContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailPageContent.tsx
@@ -14,7 +14,7 @@ import { ExpandIcon } from '@/components/common/icons/ExpandIcon';
 import { XIcon } from '@/components/common/icons/XIcon';
 import { useExperienceDetail, useUpdateExperience } from '@/hooks/experience/useExperiences';
 
-interface ExperienceDetailPageContentProps {
+export interface ExperienceDetailPageContentProps {
   experienceId: number;
 }
 

--- a/src/app/(pages)/experience/_components/ExperiencePageContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperiencePageContent.tsx
@@ -1,13 +1,25 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { notFound, useSearchParams } from 'next/navigation';
 import { Suspense } from 'react';
 import * as React from 'react';
 
 import { ExperienceBoard } from '@/app/(pages)/experience/_components/ExperienceBoard';
-import { ExperienceDetailPageContent } from '@/app/(pages)/experience/_components/ExperienceDetailPageContent';
+import type { ExperienceDetailPageContentProps } from '@/app/(pages)/experience/_components/ExperienceDetailPageContent';
 import { ExperiencePageHeader } from '@/app/(pages)/experience/_components/ExperiencePageHeader';
 import { useDebouncedValue } from '@/hooks/experience/useDebouncedValue';
+
+const ExperienceDetailPageContent = dynamic<ExperienceDetailPageContentProps>(
+  () =>
+    import('@/app/(pages)/experience/_components/ExperienceDetailPageContent').then(
+      (mod) => mod.ExperienceDetailPageContent,
+    ),
+  {
+    ssr: false,
+    loading: ExperienceDetailPageLoading,
+  },
+);
 
 export function ExperiencePageContent() {
   const [keyword, setKeyword] = React.useState('');
@@ -21,6 +33,35 @@ export function ExperiencePageContent() {
         onKeywordChange={setKeyword}
       />
     </Suspense>
+  );
+}
+
+function ExperienceDetailPageLoading() {
+  return (
+    <div className="flex min-h-[calc(100vh-32px)] flex-col gap-[22px]">
+      <header className="grid h-8 grid-cols-[32px_1fr_32px] items-center">
+        <div className="size-8 animate-pulse rounded bg-gray-200" />
+        <div className="mx-auto h-6 w-24 animate-pulse rounded bg-gray-200" />
+        <div className="size-8 animate-pulse rounded bg-gray-200" />
+      </header>
+      <div className="flex animate-pulse flex-col gap-7">
+        <div className="flex flex-col gap-3 rounded-xl border border-border-default bg-background-w px-[30px] py-5">
+          <div className="h-8 w-2/3 rounded bg-gray-200" />
+          <div className="h-5 w-full rounded bg-gray-100" />
+          <div className="h-5 w-3/4 rounded bg-gray-100" />
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="h-20 rounded-xl bg-gray-100" />
+          ))}
+        </div>
+        <div className="flex flex-col gap-4">
+          <div className="h-6 w-32 rounded bg-gray-200" />
+          <div className="h-36 rounded-xl bg-gray-100" />
+          <div className="h-36 rounded-xl bg-gray-100" />
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/app/(pages)/experience/add/_components/ExperienceAddBasicInfoStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddBasicInfoStep.tsx
@@ -25,7 +25,7 @@ import { type CalendarDateRange, RangeCalendar } from '@/components/common/Range
 import { TextField } from '@/components/common/TextField';
 import { cn } from '@/lib/utils';
 
-interface ExperienceAddBasicInfoStepProps {
+export interface ExperienceAddBasicInfoStepProps {
   value: ExperienceAddBasicInfoForm;
   onChange: (value: ExperienceAddBasicInfoForm) => void;
 }

--- a/src/app/(pages)/experience/add/_components/ExperienceAddCoreStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddCoreStep.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils';
 
 const CORE_FIELD_MAX_LENGTH = 1000;
 
-interface ExperienceAddCoreStepProps {
+export interface ExperienceAddCoreStepProps {
   value: ExperienceAddCoreInfoForm;
   onChange: (value: ExperienceAddCoreInfoForm) => void;
 }

--- a/src/app/(pages)/experience/add/_components/ExperienceAddMaterialModal.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddMaterialModal.tsx
@@ -31,7 +31,7 @@ export interface NotionMaterial {
 export type ExperienceMaterial = PdfMaterial | NotionMaterial;
 export type ExperienceAddMaterialModalView = 'material' | 'notion-connect' | 'notion-pages';
 
-interface ExperienceAddMaterialModalProps {
+export interface ExperienceAddMaterialModalProps {
   materials: ExperienceMaterial[];
   initialView?: ExperienceAddMaterialModalView;
   onSave: (materials: ExperienceMaterial[]) => void;

--- a/src/app/(pages)/experience/add/_components/ExperienceAddResultStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddResultStep.tsx
@@ -18,7 +18,7 @@ import { cn } from '@/lib/utils';
 
 type EditableTagGroupKey = 'skill' | 'competency';
 
-interface ExperienceAddResultStepProps {
+export interface ExperienceAddResultStepProps {
   basicInfo: ExperienceAddBasicInfoForm;
   coreInfo: ExperienceAddCoreInfoForm;
   resultInfo: ExperienceAddResultInfoForm;

--- a/src/app/(pages)/experience/add/_components/ExperienceAddStepContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddStepContent.tsx
@@ -1,12 +1,14 @@
-import { ExperienceAddBasicInfoStep } from '@/app/(pages)/experience/add/_components/ExperienceAddBasicInfoStep';
-import { ExperienceAddAnalyzingStep } from '@/app/(pages)/experience/add/_components/ExperienceAddAnalyzingStep';
-import { ExperienceAddCompleteStep } from '@/app/(pages)/experience/add/_components/ExperienceAddCompleteStep';
-import { ExperienceAddCoreStep } from '@/app/(pages)/experience/add/_components/ExperienceAddCoreStep';
+'use client';
+
+import dynamic from 'next/dynamic';
+
+import type { ExperienceAddBasicInfoStepProps } from '@/app/(pages)/experience/add/_components/ExperienceAddBasicInfoStep';
+import type { ExperienceAddCoreStepProps } from '@/app/(pages)/experience/add/_components/ExperienceAddCoreStep';
 import type {
   ExperienceAddMaterialModalView,
   ExperienceMaterial,
 } from '@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal';
-import { ExperienceAddResultStep } from '@/app/(pages)/experience/add/_components/ExperienceAddResultStep';
+import type { ExperienceAddResultStepProps } from '@/app/(pages)/experience/add/_components/ExperienceAddResultStep';
 import { ExperienceAddUploadStep } from '@/app/(pages)/experience/add/_components/ExperienceAddUploadStep';
 import { EXPERIENCE_ADD_STEPS } from '@/app/(pages)/experience/add/_constants/experienceAddSteps';
 import type {
@@ -14,6 +16,61 @@ import type {
   ExperienceAddCoreInfoForm,
   ExperienceAddResultInfoForm,
 } from '@/app/(pages)/experience/add/_types/experienceAddForm';
+
+const ExperienceAddAnalyzingStep = dynamic(
+  () =>
+    import('@/app/(pages)/experience/add/_components/ExperienceAddAnalyzingStep').then(
+      (mod) => mod.ExperienceAddAnalyzingStep,
+    ),
+  {
+    ssr: false,
+    loading: ExperienceAddStepLoading,
+  },
+);
+
+const ExperienceAddBasicInfoStep = dynamic<ExperienceAddBasicInfoStepProps>(
+  () =>
+    import('@/app/(pages)/experience/add/_components/ExperienceAddBasicInfoStep').then(
+      (mod) => mod.ExperienceAddBasicInfoStep,
+    ),
+  {
+    ssr: false,
+    loading: ExperienceAddStepLoading,
+  },
+);
+
+const ExperienceAddCoreStep = dynamic<ExperienceAddCoreStepProps>(
+  () =>
+    import('@/app/(pages)/experience/add/_components/ExperienceAddCoreStep').then(
+      (mod) => mod.ExperienceAddCoreStep,
+    ),
+  {
+    ssr: false,
+    loading: ExperienceAddStepLoading,
+  },
+);
+
+const ExperienceAddResultStep = dynamic<ExperienceAddResultStepProps>(
+  () =>
+    import('@/app/(pages)/experience/add/_components/ExperienceAddResultStep').then(
+      (mod) => mod.ExperienceAddResultStep,
+    ),
+  {
+    ssr: false,
+    loading: ExperienceAddStepLoading,
+  },
+);
+
+const ExperienceAddCompleteStep = dynamic(
+  () =>
+    import('@/app/(pages)/experience/add/_components/ExperienceAddCompleteStep').then(
+      (mod) => mod.ExperienceAddCompleteStep,
+    ),
+  {
+    ssr: false,
+    loading: ExperienceAddStepLoading,
+  },
+);
 
 interface ExperienceAddStepContentProps {
   currentStepIndex: number;
@@ -98,6 +155,28 @@ export function ExperienceAddStepContent({
       className="rounded-xl border border-border-default bg-background-w px-[30px] py-5"
     >
       <p className="body-1-bold text-strong">{currentStep}</p>
+    </section>
+  );
+}
+
+function ExperienceAddStepLoading() {
+  return (
+    <section className="flex w-full flex-col gap-6 rounded-xl border border-border-default bg-background-w px-[30px] py-5">
+      <div className="flex animate-pulse flex-col gap-1">
+        <div className="h-6 w-16 rounded bg-mint-100" />
+        <div className="h-7 w-40 rounded bg-gray-200" />
+        <div className="h-5 w-80 max-w-full rounded bg-gray-100" />
+      </div>
+      <div className="grid animate-pulse grid-cols-2 gap-4">
+        {Array.from({ length: 4 }).map((_, index) => (
+          <div key={index} className="h-14 rounded-lg bg-gray-100" />
+        ))}
+      </div>
+      <div className="flex animate-pulse flex-col gap-4">
+        <div className="h-6 w-28 rounded bg-gray-200" />
+        <div className="h-24 rounded-lg bg-gray-100" />
+        <div className="h-24 rounded-lg bg-gray-100" />
+      </div>
     </section>
   );
 }

--- a/src/app/(pages)/experience/add/_components/ExperienceAddStepContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddStepContent.tsx
@@ -67,7 +67,6 @@ const ExperienceAddCompleteStep = dynamic(
     ),
   {
     ssr: false,
-    loading: ExperienceAddStepLoading,
   },
 );
 

--- a/src/app/(pages)/experience/add/_components/ExperienceAddStepContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddStepContent.tsx
@@ -24,7 +24,6 @@ const ExperienceAddAnalyzingStep = dynamic(
     ),
   {
     ssr: false,
-    loading: ExperienceAddStepLoading,
   },
 );
 

--- a/src/app/(pages)/experience/add/_components/ExperienceAddUploadStep.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddUploadStep.tsx
@@ -1,13 +1,14 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import type { ReactNode } from 'react';
 
-import {
-  ExperienceAddMaterialModal,
-  type PdfMaterial,
-  type ExperienceAddMaterialModalView,
-  type ExperienceMaterial,
+import type {
+  ExperienceAddMaterialModalProps,
+  ExperienceAddMaterialModalView,
+  ExperienceMaterial,
+  PdfMaterial,
 } from '@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal';
 import {
   clearExperienceAddPdfDraft,
@@ -25,6 +26,17 @@ import { Tag } from '@/components/common/Tag';
 import { PlusIcon } from '@/components/common/icons/PlusIcon';
 import { XIcon } from '@/components/common/icons/XIcon';
 import { Button } from '@/components/ui/button';
+
+const ExperienceAddMaterialModal = dynamic<ExperienceAddMaterialModalProps>(
+  () =>
+    import('@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal').then(
+      (mod) => mod.ExperienceAddMaterialModal,
+    ),
+  {
+    ssr: false,
+    loading: ExperienceAddMaterialModalLoading,
+  },
+);
 
 interface ExperienceAddUploadStepProps {
   materials: ExperienceMaterial[];
@@ -156,6 +168,22 @@ export function ExperienceAddUploadStep({
         </div>
       )}
     </section>
+  );
+}
+
+function ExperienceAddMaterialModalLoading() {
+  return (
+    <div className="flex min-h-[360px] w-full animate-pulse flex-col gap-6">
+      <div className="flex flex-col gap-2">
+        <div className="h-7 w-32 rounded bg-gray-200" />
+        <div className="h-5 w-56 rounded bg-gray-100" />
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        <div className="h-[180px] rounded-xl bg-gray-100" />
+        <div className="h-[180px] rounded-xl bg-gray-100" />
+      </div>
+      <div className="ml-auto h-10 w-24 rounded bg-gray-200" />
+    </div>
   );
 }
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#174 

## 📝작업 내용

- `/experience`, `/experience/add` Lighthouse Desktop 기준선을 문서화했습니다.
- 경험 상세 패널과 상세 페이지를 dynamic import로 분리했습니다.
- 경험 추가 페이지의 자료 추가 모달과 비초기 단계 화면을 dynamic import로 분리했습니다.
- lazy loading fallback을 Lottie 대신 CSS skeleton UI로 구성했습니다.
- 빌드 기준 first-load JS 변화를 기록했습니다.
  - `/experience`: 1,200,163 bytes → 1,174,153 bytes
  - `/experience/add`: 1,363,893 bytes → 998,965 bytes

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized initial page load performance for experience pages by lazy loading non-critical UI components, reducing initial bundle size and improving time-to-interactive metrics.

* **Documentation**
  * Added detailed performance baseline documentation capturing bundle metrics, Lighthouse scores, and actionable optimization recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->