### PR TITLE
[Perf] 정적 리소스 캐시 및 압축 설정 개선

### DIFF
--- a/docs/performance/static-cache-compression.md
+++ b/docs/performance/static-cache-compression.md
@@ -1,0 +1,172 @@
+# Static Resource Cache and Compression
+
+## Header Audit
+
+Date: 2026-06-04
+Target: deployed production domain
+
+### `/experience/`
+
+Command:
+
+```bash
+curl -I -L https://www.kkium.com/experience/
+```
+
+Findings:
+
+- Status: `200`
+- Origin/server: `AmazonS3` via `CloudFront`
+- `Cache-Control`: missing
+- `Content-Encoding`: missing
+- `Content-Length`: `18765`
+- `x-cache`: `Miss from cloudfront`
+
+### `/experience/add/`
+
+Command:
+
+```bash
+curl -I -L https://www.kkium.com/experience/add/
+```
+
+Findings:
+
+- Status: `200`
+- Origin/server: `AmazonS3` via `CloudFront`
+- `Cache-Control`: missing
+- `Content-Encoding`: missing
+- `Content-Length`: `19054`
+- `x-cache`: `Miss from cloudfront`
+
+### JS Chunk
+
+Command:
+
+```bash
+curl -I -H 'Accept-Encoding: gzip, br' https://www.kkium.com/_next/static/chunks/0qfvstqmkg-o..js
+```
+
+Findings:
+
+- Status: `200`
+- `Content-Type`: `application/x-javascript`
+- `Cache-Control`: missing
+- `Content-Encoding`: missing
+- `Content-Length`: `226352`
+
+### CSS Chunk
+
+Command:
+
+```bash
+curl -I -H 'Accept-Encoding: gzip, br' https://www.kkium.com/_next/static/chunks/07yk.tnyd8~cx.css
+```
+
+Findings:
+
+- Status: `200`
+- `Content-Type`: `text/css`
+- `Cache-Control`: missing
+- `Content-Encoding`: missing
+- `Content-Length`: `71121`
+
+### Font
+
+Command:
+
+```bash
+curl -I -H 'Accept-Encoding: gzip, br' https://www.kkium.com/_next/static/media/NanumSquareR-s.p.0zryv4ll6ot5o.ttf
+```
+
+Findings:
+
+- Status: `200`
+- `Content-Type`: `application/octet-stream`
+- `Cache-Control`: missing
+- `Content-Encoding`: missing
+- `Content-Length`: `723640`
+
+### SVG
+
+Command:
+
+```bash
+curl -I -H 'Accept-Encoding: gzip, br' https://www.kkium.com/education-default.svg
+```
+
+Findings:
+
+- Status: `200`
+- `Content-Type`: `image/svg+xml`
+- `Cache-Control`: missing
+- `Content-Encoding`: missing
+- `Content-Length`: `557210`
+
+## Summary
+
+- HTML, JS, CSS, font, and SVG responses do not expose browser cache lifetimes.
+- JS, CSS, font, and SVG responses were not compressed even when `Accept-Encoding: gzip, br` was sent.
+- Font files are served as `application/octet-stream`, not a font-specific MIME type.
+- The response headers match Lighthouse findings for cache lifetime and document request compression issues.
+
+## Next Checks
+
+- Inspect deployment scripts for S3 upload metadata and CloudFront invalidation.
+- Confirm whether CloudFront compression is enabled.
+- Confirm CloudFront cache policies for HTML and static assets.
+- Remove or document `next.config.ts` `headers()` because Next.js warns that it is not applied with `output: 'export'`.
+
+## Repository Deployment Config
+
+`buildspec.yml` currently runs tests and builds the static export:
+
+```yaml
+phases:
+  build:
+    commands:
+      - pnpm test:unit
+      - pnpm build
+
+artifacts:
+  base-directory: out
+  files:
+    - '**/*'
+```
+
+Findings:
+
+- The repository only produces the `out` artifact.
+- The repository does not run `aws s3 sync`, set S3 object metadata, or invalidate CloudFront.
+- Static resource cache and compression policies are likely controlled by the CodePipeline deploy action, S3 bucket metadata, and CloudFront behavior settings.
+
+## Applied Repository Cleanup
+
+- Removed `next.config.ts` `headers()` because Next.js warns that custom headers are not applied with `output: 'export'`.
+- This cleanup removes a misleading config and the static export warning, but does not by itself set deployed cache or compression headers.
+
+## Recommended AWS Settings
+
+Static hashed assets:
+
+- Path pattern: `/_next/static/*`
+- Cache-Control: `public, max-age=31536000, immutable`
+- Compression: enabled in CloudFront
+
+Public static assets:
+
+- Path patterns: `/*.svg`, `/*.png`, `/*.jpg`, `/*.webp`, `/*.ico`
+- Cache-Control: `public, max-age=31536000`
+- Compression: enabled for SVG and other compressible text assets
+
+HTML documents:
+
+- Path patterns: `/*.html`, `/`, `/experience/`, `/experience/add/`
+- Cache-Control: short-lived or no-cache, for example `public, max-age=0, must-revalidate`
+- Invalidate HTML paths on deployment.
+
+Font files:
+
+- Path pattern: `/_next/static/media/*`
+- Cache-Control: `public, max-age=31536000, immutable`
+- MIME type should be font-specific where possible, for example `font/ttf` for TTF files.

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,19 +7,6 @@ const nextConfig: NextConfig = {
     unoptimized: true,
   },
   serverExternalPackages: ['@lottiefiles/dotlottie-react', '@lottiefiles/dotlottie-web'],
-  async headers() {
-    return [
-      {
-        source: '/:path*',
-        headers: [
-          {
-            key: 'Cache-Control',
-            value: 'no-store, must-revalidate',
-          },
-        ],
-      },
-    ];
-  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## #️⃣연관된 이슈

#177 

## 📝작업 내용

- 배포 서버의 HTML, JS, CSS, 폰트, SVG 응답 헤더를 점검했습니다.
- `Cache-Control`, `Content-Encoding`이 누락되어 Lighthouse의 cache/compression 지적과 일치함을 문서화했습니다.
- `output: 'export'` 환경에서 적용되지 않는 `next.config.ts`의 `headers()` 설정을 제거했습니다.
- 해당 설정 제거 후 Next static export 관련 headers 경고가 사라지는 것을 확인했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)