### PR TITLE
[Perf] 경험 페이지 LCP 렌더 지연 개선

### DIFF
--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -25,6 +25,7 @@ import { cn } from '@/lib/utils';
 export interface ExperienceBoardProps extends React.ComponentProps<'section'> {
   initialSelectedExperienceId?: string;
   keyword?: string;
+  onDetailViewRequest?: (experienceId: string) => void;
 }
 
 const filterPieceTypeByCategory: Record<
@@ -51,6 +52,7 @@ const ExperienceDetailPanel = dynamic<ExperienceDetailPanelProps>(
 export function ExperienceBoard({
   initialSelectedExperienceId,
   keyword,
+  onDetailViewRequest,
   className,
   ...props
 }: ExperienceBoardProps) {
@@ -67,6 +69,7 @@ export function ExperienceBoard({
   } = useExperienceBoardSelection({
     initialSelectedExperienceId,
     keyword,
+    onDetailViewRequest,
   });
   const selectedPieceType =
     selectedCategory === 'all' ? undefined : filterPieceTypeByCategory[selectedCategory];

--- a/src/app/(pages)/experience/_components/ExperienceDetailPageContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceDetailPageContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import * as React from 'react';
 
 import {
@@ -16,10 +16,13 @@ import { useExperienceDetail, useUpdateExperience } from '@/hooks/experience/use
 
 export interface ExperienceDetailPageContentProps {
   experienceId: number;
+  onRouteExit?: () => void;
 }
 
-export function ExperienceDetailPageContent({ experienceId }: ExperienceDetailPageContentProps) {
-  const router = useRouter();
+export function ExperienceDetailPageContent({
+  experienceId,
+  onRouteExit,
+}: ExperienceDetailPageContentProps) {
   const searchParams = useSearchParams();
   const category = searchParams.get('category');
   const { data, isError, isPending } = useExperienceDetail(experienceId);
@@ -33,11 +36,13 @@ export function ExperienceDetailPageContent({ experienceId }: ExperienceDetailPa
       params.set('category', category);
     }
 
-    router.push(`/experience?${params.toString()}`);
+    window.history.pushState(null, '', `/experience?${params.toString()}`);
+    onRouteExit?.();
   };
 
   const handleBackToExperience = () => {
-    router.push('/experience');
+    window.history.pushState(null, '', '/experience');
+    onRouteExit?.();
   };
 
   const handleExperienceSave = async (nextExperience: ExperienceDetailSaveValue) => {

--- a/src/app/(pages)/experience/_components/ExperiencePageContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperiencePageContent.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { notFound, useSearchParams } from 'next/navigation';
-import { Suspense } from 'react';
+import { notFound } from 'next/navigation';
 import * as React from 'react';
 
 import { ExperienceBoard } from '@/app/(pages)/experience/_components/ExperienceBoard';
@@ -26,13 +25,11 @@ export function ExperiencePageContent() {
   const debouncedKeyword = useDebouncedValue(keyword.trim(), 500);
 
   return (
-    <Suspense>
-      <ExperiencePageRouteContent
-        keyword={keyword}
-        debouncedKeyword={debouncedKeyword}
-        onKeywordChange={setKeyword}
-      />
-    </Suspense>
+    <ExperiencePageRouteContent
+      keyword={keyword}
+      debouncedKeyword={debouncedKeyword}
+      onKeywordChange={setKeyword}
+    />
   );
 }
 
@@ -76,11 +73,19 @@ function ExperiencePageRouteContent({
   debouncedKeyword,
   onKeywordChange,
 }: ExperiencePageRouteContentProps) {
-  const searchParams = useSearchParams();
-  const selectedExperienceId = searchParams.get('selected');
-  const isDetailView = searchParams.get('view') === 'detail';
+  const [detailExperienceId, setDetailExperienceId] = React.useState<number | null>(null);
+  const [hasInvalidDetailParam, setHasInvalidDetailParam] = React.useState(false);
 
-  if (isDetailView) {
+  React.useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const selectedExperienceId = searchParams.get('selected');
+
+    if (searchParams.get('view') !== 'detail') {
+      setDetailExperienceId(null);
+      setHasInvalidDetailParam(false);
+      return;
+    }
+
     const numericExperienceId = selectedExperienceId ? Number(selectedExperienceId) : null;
 
     if (
@@ -88,10 +93,21 @@ function ExperiencePageRouteContent({
       !Number.isInteger(numericExperienceId) ||
       numericExperienceId <= 0
     ) {
-      notFound();
+      setDetailExperienceId(null);
+      setHasInvalidDetailParam(true);
+      return;
     }
 
-    return <ExperienceDetailPageContent experienceId={numericExperienceId} />;
+    setDetailExperienceId(numericExperienceId);
+    setHasInvalidDetailParam(false);
+  }, []);
+
+  if (hasInvalidDetailParam) {
+    notFound();
+  }
+
+  if (detailExperienceId) {
+    return <ExperienceDetailPageContent experienceId={detailExperienceId} />;
   }
 
   return (

--- a/src/app/(pages)/experience/_components/ExperiencePageContent.tsx
+++ b/src/app/(pages)/experience/_components/ExperiencePageContent.tsx
@@ -68,6 +68,27 @@ interface ExperiencePageRouteContentProps {
   onKeywordChange: (keyword: string) => void;
 }
 
+function getDetailExperienceIdFromSearch() {
+  const searchParams = new URLSearchParams(window.location.search);
+  const selectedExperienceId = searchParams.get('selected');
+
+  if (searchParams.get('view') !== 'detail') {
+    return { experienceId: null, invalid: false };
+  }
+
+  const numericExperienceId = selectedExperienceId ? Number(selectedExperienceId) : null;
+
+  if (
+    numericExperienceId === null ||
+    !Number.isInteger(numericExperienceId) ||
+    numericExperienceId <= 0
+  ) {
+    return { experienceId: null, invalid: true };
+  }
+
+  return { experienceId: numericExperienceId, invalid: false };
+}
+
 function ExperiencePageRouteContent({
   keyword,
   debouncedKeyword,
@@ -76,23 +97,24 @@ function ExperiencePageRouteContent({
   const [detailExperienceId, setDetailExperienceId] = React.useState<number | null>(null);
   const [hasInvalidDetailParam, setHasInvalidDetailParam] = React.useState(false);
 
+  const syncDetailRoute = React.useCallback(() => {
+    const { experienceId, invalid } = getDetailExperienceIdFromSearch();
+
+    setDetailExperienceId(experienceId);
+    setHasInvalidDetailParam(invalid);
+  }, []);
+
   React.useEffect(() => {
-    const searchParams = new URLSearchParams(window.location.search);
-    const selectedExperienceId = searchParams.get('selected');
+    syncDetailRoute();
+    window.addEventListener('popstate', syncDetailRoute);
 
-    if (searchParams.get('view') !== 'detail') {
-      setDetailExperienceId(null);
-      setHasInvalidDetailParam(false);
-      return;
-    }
+    return () => window.removeEventListener('popstate', syncDetailRoute);
+  }, [syncDetailRoute]);
 
-    const numericExperienceId = selectedExperienceId ? Number(selectedExperienceId) : null;
+  const handleDetailViewRequest = React.useCallback((experienceId: string) => {
+    const numericExperienceId = Number(experienceId);
 
-    if (
-      numericExperienceId === null ||
-      !Number.isInteger(numericExperienceId) ||
-      numericExperienceId <= 0
-    ) {
+    if (!Number.isInteger(numericExperienceId) || numericExperienceId <= 0) {
       setDetailExperienceId(null);
       setHasInvalidDetailParam(true);
       return;
@@ -102,19 +124,32 @@ function ExperiencePageRouteContent({
     setHasInvalidDetailParam(false);
   }, []);
 
+  const handleDetailRouteExit = React.useCallback(() => {
+    setDetailExperienceId(null);
+    setHasInvalidDetailParam(false);
+  }, []);
+
   if (hasInvalidDetailParam) {
     notFound();
   }
 
   if (detailExperienceId) {
-    return <ExperienceDetailPageContent experienceId={detailExperienceId} />;
+    return (
+      <ExperienceDetailPageContent
+        experienceId={detailExperienceId}
+        onRouteExit={handleDetailRouteExit}
+      />
+    );
   }
 
   return (
     <div className="flex min-h-[calc(100vh-32px)] flex-col">
       <div className="flex flex-1 flex-col gap-5">
         <ExperiencePageHeader keyword={keyword} onKeywordChange={onKeywordChange} />
-        <ExperienceBoard keyword={debouncedKeyword || undefined} />
+        <ExperienceBoard
+          keyword={debouncedKeyword || undefined}
+          onDetailViewRequest={handleDetailViewRequest}
+        />
       </div>
     </div>
   );

--- a/src/app/(pages)/experience/_hooks/useExperienceBoardSelection.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceBoardSelection.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import * as React from 'react';
 
 import type { ExperienceCategory } from '@/app/(pages)/experience/_utils/ExperienceCategory';
@@ -19,23 +19,29 @@ function isExperienceCategory(category: string | null): category is ExperienceCa
   return EXPERIENCE_ORDER_CATEGORIES.includes(category as ExperienceCategory);
 }
 
+function getCurrentSearchParams() {
+  if (typeof window === 'undefined') {
+    return new URLSearchParams();
+  }
+
+  return new URLSearchParams(window.location.search);
+}
+
 export function useExperienceBoardSelection({
   initialSelectedExperienceId,
   keyword,
 }: UseExperienceBoardSelectionParams) {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const selectedExperienceIdFromQuery = searchParams.get('selected') ?? initialSelectedExperienceId;
-  const selectedCategoryFromQuery = searchParams.get('category');
-  const initialSelectedCategory = isExperienceCategory(selectedCategoryFromQuery)
-    ? selectedCategoryFromQuery
-    : 'all';
-  const [selectedCategory, setSelectedCategory] =
-    React.useState<ExperienceCategory>(initialSelectedCategory);
+  const [selectedCategory, setSelectedCategory] = React.useState<ExperienceCategory>('all');
   const [selectedExperienceId, setSelectedExperienceId] = React.useState<string | undefined>(
-    selectedExperienceIdFromQuery,
+    initialSelectedExperienceId,
   );
-  const [panelOpen, setPanelOpen] = React.useState(Boolean(selectedExperienceIdFromQuery));
+  const [panelOpen, setPanelOpen] = React.useState(Boolean(initialSelectedExperienceId));
+  const [initialSelectedCategory, setInitialSelectedCategory] =
+    React.useState<ExperienceCategory>('all');
+  const [selectedExperienceIdFromQuery, setSelectedExperienceIdFromQuery] = React.useState<
+    string | undefined
+  >(initialSelectedExperienceId);
   const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   const hasAppliedInitialSelectionRef = React.useRef(false);
   const previousKeywordRef = React.useRef(keyword);
@@ -46,6 +52,24 @@ export function useExperienceBoardSelection({
       closeTimerRef.current = null;
     }
   }, []);
+
+  React.useEffect(() => {
+    const searchParams = getCurrentSearchParams();
+    const nextSelectedExperienceId = searchParams.get('selected') ?? initialSelectedExperienceId;
+    const selectedCategoryFromQuery = searchParams.get('category');
+    const nextSelectedCategory = isExperienceCategory(selectedCategoryFromQuery)
+      ? selectedCategoryFromQuery
+      : 'all';
+
+    setInitialSelectedCategory(nextSelectedCategory);
+    setSelectedCategory(nextSelectedCategory);
+    setSelectedExperienceIdFromQuery(nextSelectedExperienceId);
+
+    if (!nextSelectedExperienceId) {
+      setSelectedExperienceId(undefined);
+      setPanelOpen(false);
+    }
+  }, [initialSelectedExperienceId]);
 
   const applyInitialSelectedExperience = React.useCallback(
     (experiences: readonly ExperienceSelectionItem[]) => {
@@ -80,7 +104,7 @@ export function useExperienceBoardSelection({
     setSelectedExperienceId(undefined);
     setPanelOpen(false);
 
-    const params = new URLSearchParams(searchParams.toString());
+    const params = getCurrentSearchParams();
 
     params.delete('selected');
 
@@ -93,7 +117,7 @@ export function useExperienceBoardSelection({
     router.replace(params.size > 0 ? `/experience?${params.toString()}` : '/experience', {
       scroll: false,
     });
-  }, [clearCloseTimer, keyword, router, searchParams, selectedCategory]);
+  }, [clearCloseTimer, keyword, router, selectedCategory]);
 
   React.useEffect(() => clearCloseTimer, [clearCloseTimer]);
 
@@ -145,7 +169,7 @@ export function useExperienceBoardSelection({
         return;
       }
 
-      const params = new URLSearchParams(searchParams.toString());
+      const params = getCurrentSearchParams();
 
       params.set('selected', experienceId);
       params.set('category', selectedCategory);
@@ -153,7 +177,7 @@ export function useExperienceBoardSelection({
 
       router.push(`/experience?${params.toString()}`);
     },
-    [router, searchParams, selectedCategory],
+    [router, selectedCategory],
   );
 
   return {

--- a/src/app/(pages)/experience/_hooks/useExperienceBoardSelection.ts
+++ b/src/app/(pages)/experience/_hooks/useExperienceBoardSelection.ts
@@ -13,6 +13,7 @@ interface ExperienceSelectionItem {
 interface UseExperienceBoardSelectionParams {
   initialSelectedExperienceId?: string;
   keyword?: string;
+  onDetailViewRequest?: (experienceId: string) => void;
 }
 
 function isExperienceCategory(category: string | null): category is ExperienceCategory {
@@ -30,6 +31,7 @@ function getCurrentSearchParams() {
 export function useExperienceBoardSelection({
   initialSelectedExperienceId,
   keyword,
+  onDetailViewRequest,
 }: UseExperienceBoardSelectionParams) {
   const router = useRouter();
   const [selectedCategory, setSelectedCategory] = React.useState<ExperienceCategory>('all');
@@ -53,7 +55,8 @@ export function useExperienceBoardSelection({
     }
   }, []);
 
-  React.useEffect(() => {
+  const syncRouteSelection = React.useCallback(() => {
+    clearCloseTimer();
     const searchParams = getCurrentSearchParams();
     const nextSelectedExperienceId = searchParams.get('selected') ?? initialSelectedExperienceId;
     const selectedCategoryFromQuery = searchParams.get('category');
@@ -61,15 +64,26 @@ export function useExperienceBoardSelection({
       ? selectedCategoryFromQuery
       : 'all';
 
+    hasAppliedInitialSelectionRef.current = false;
     setInitialSelectedCategory(nextSelectedCategory);
     setSelectedCategory(nextSelectedCategory);
     setSelectedExperienceIdFromQuery(nextSelectedExperienceId);
 
-    if (!nextSelectedExperienceId) {
+    if (nextSelectedExperienceId) {
+      setSelectedExperienceId(nextSelectedExperienceId);
+      setPanelOpen(true);
+    } else {
       setSelectedExperienceId(undefined);
       setPanelOpen(false);
     }
-  }, [initialSelectedExperienceId]);
+  }, [clearCloseTimer, initialSelectedExperienceId]);
+
+  React.useEffect(() => {
+    syncRouteSelection();
+    window.addEventListener('popstate', syncRouteSelection);
+
+    return () => window.removeEventListener('popstate', syncRouteSelection);
+  }, [syncRouteSelection]);
 
   const applyInitialSelectedExperience = React.useCallback(
     (experiences: readonly ExperienceSelectionItem[]) => {
@@ -176,8 +190,9 @@ export function useExperienceBoardSelection({
       params.set('view', 'detail');
 
       router.push(`/experience?${params.toString()}`);
+      onDetailViewRequest?.(experienceId);
     },
-    [router, selectedCategory],
+    [onDetailViewRequest, router, selectedCategory],
   );
 
   return {

--- a/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
+++ b/src/app/(pages)/experience/add/_components/ExperienceAddPageContent.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import type { ExperienceAddMaterialModalView } from '@/app/(pages)/experience/add/_components/ExperienceAddMaterialModal';
@@ -17,9 +17,6 @@ import { Button } from '@/components/ui/button';
 
 export function ExperienceAddPageContent() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const isNotionConnected =
-    searchParams.get('notion') === 'connected' || searchParams.get('success') === 'true';
   const {
     currentStepIndex,
     isFirstStep,
@@ -31,9 +28,9 @@ export function ExperienceAddPageContent() {
     goNextStep: goToNextStep,
   } = useExperienceAddStep();
   const { materials, setMaterials } = useExperienceAddMaterials();
-  const [isMaterialModalOpen, setIsMaterialModalOpen] = useState(isNotionConnected);
+  const [isMaterialModalOpen, setIsMaterialModalOpen] = useState(false);
   const [materialModalInitialView, setMaterialModalInitialView] =
-    useState<ExperienceAddMaterialModalView>(isNotionConnected ? 'notion-pages' : 'material');
+    useState<ExperienceAddMaterialModalView>('material');
   const {
     basicInfo,
     coreInfo,
@@ -68,10 +65,21 @@ export function ExperienceAddPageContent() {
   });
 
   useEffect(() => {
+    const searchParams = new URLSearchParams(window.location.search);
+    const isNotionConnected =
+      searchParams.get('notion') === 'connected' || searchParams.get('success') === 'true';
+
     if (!isNotionConnected) return;
 
+    const frameId = window.requestAnimationFrame(() => {
+      setMaterialModalInitialView('notion-pages');
+      setIsMaterialModalOpen(true);
+    });
+
     router.replace('/experience/add', { scroll: false });
-  }, [isNotionConnected, router]);
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [router]);
 
   return (
     <div className="flex min-h-dvh flex-col py-5">

--- a/src/app/(pages)/experience/add/page.tsx
+++ b/src/app/(pages)/experience/add/page.tsx
@@ -1,11 +1,5 @@
-import { Suspense } from 'react';
-
 import { ExperienceAddPageContent } from '@/app/(pages)/experience/add/_components/ExperienceAddPageContent';
 
 export default function ExperienceAddPage() {
-  return (
-    <Suspense fallback={null}>
-      <ExperienceAddPageContent />
-    </Suspense>
-  );
+  return <ExperienceAddPageContent />;
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#185 

## 📝작업 내용

- `/experience`, `/experience/add` 페이지에서 `useSearchParams`로 인해 정적 HTML 본문이 빠지고 CSR bailout이 발생하던 문제를 개선했습니다.
- `/experience`의 상세 보기 query 처리 로직을 초기 렌더 이후 `window.location.search` 기반으로 처리하도록 변경했습니다.
- 경험 목록의 category/selected query 처리를 mount 이후로 옮겨 기본 화면이 정적 HTML에 포함되도록 수정했습니다.
- `/experience/add`의 Notion 연결 callback query 처리를 초기 렌더 이후로 옮기고, `Suspense fallback={null}`을 제거했습니다.
- 빌드 산출물에서 `/experience`, `/experience/add`의 `BAILOUT_TO_CLIENT_SIDE_RENDERING`이 제거되고 초기 화면 텍스트가 포함되는 것을 확인했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized URL parameter handling on the experience pages for improved client-side routing and state management.
  * Simplified component architecture by removing unnecessary async boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->