### PR TITLE
[Perf] 경험 목록 초기 데이터 로딩 시점 개선

### DIFF
--- a/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
@@ -1,14 +1,9 @@
+import dynamic from 'next/dynamic';
 import * as React from 'react';
 
 import { ExperienceCard } from '@/app/(pages)/experience/_components/ExperienceCard';
 import type { ExperienceCategory } from '@/app/(pages)/experience/_components/ExperienceCategoryTab';
 import { cn } from '@/lib/utils';
-
-const ExperienceSortableCardGrid = React.lazy(() =>
-  import('@/app/(pages)/experience/_components/ExperienceSortableCardGrid').then((mod) => ({
-    default: mod.ExperienceSortableCardGrid,
-  })),
-);
 
 export const EXPERIENCE_CARD_GRID_CLASS_NAME =
   'grid w-full grid-cols-2 gap-x-4 gap-y-5 min-[1720px]:grid-cols-3';
@@ -55,6 +50,15 @@ export interface ExperienceCardGridProps extends React.ComponentProps<'div'> {
   onExperienceTitleSave?: (experience: ExperienceItem, nextTitle: string) => Promise<void> | void;
 }
 
+export type ExperienceSortableCardGridProps = Omit<ExperienceCardGridProps, 'sortable'> & {
+  onReady?: () => void;
+};
+
+const ExperienceSortableCardGrid = dynamic<ExperienceSortableCardGridProps>(
+  () => import('@/app/(pages)/experience/_components/ExperienceSortableCardGrid'),
+  { ssr: false },
+);
+
 export function ExperienceCardGrid({
   experiences,
   selectedExperienceId,
@@ -66,6 +70,18 @@ export function ExperienceCardGrid({
   className,
   ...props
 }: ExperienceCardGridProps) {
+  const [sortableGridReady, setSortableGridReady] = React.useState(false);
+
+  React.useEffect(() => {
+    if (!sortable) {
+      setSortableGridReady(false);
+    }
+  }, [sortable]);
+
+  const handleSortableGridReady = React.useCallback(() => {
+    setSortableGridReady(true);
+  }, []);
+
   const grid = (
     <div
       data-slot="experience-card-grid"
@@ -95,7 +111,8 @@ export function ExperienceCardGrid({
   }
 
   return (
-    <React.Suspense fallback={grid}>
+    <>
+      {!sortableGridReady && grid}
       <ExperienceSortableCardGrid
         experiences={experiences}
         selectedExperienceId={selectedExperienceId}
@@ -103,9 +120,10 @@ export function ExperienceCardGrid({
         onExperienceDelete={onExperienceDelete}
         onExperienceReorder={onExperienceReorder}
         onExperienceTitleSave={onExperienceTitleSave}
-        className={className}
+        onReady={handleSortableGridReady}
+        className={cn(className, !sortableGridReady && 'hidden')}
         {...props}
       />
-    </React.Suspense>
+    </>
   );
 }

--- a/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
@@ -2,57 +2,14 @@ import dynamic from 'next/dynamic';
 import * as React from 'react';
 
 import { ExperienceCard } from '@/app/(pages)/experience/_components/ExperienceCard';
-import type { ExperienceCategory } from '@/app/(pages)/experience/_components/ExperienceCategoryTab';
+import {
+  EXPERIENCE_CARD_GRID_CLASS_NAME,
+  type ExperienceCardGridProps,
+  type ExperienceSortableCardGridProps,
+} from '@/app/(pages)/experience/_components/experienceCardGridTypes';
 import { cn } from '@/lib/utils';
 
-export const EXPERIENCE_CARD_GRID_CLASS_NAME =
-  'grid w-full grid-cols-2 gap-x-4 gap-y-5 min-[1720px]:grid-cols-3';
-
-export interface ExperienceItem {
-  id: string;
-  type: Exclude<ExperienceCategory, 'all'>;
-  title: string;
-  description: string;
-  startDate: string;
-  endDate: string;
-  period: string;
-  detailInfo: {
-    label: string;
-    value: string;
-  }[];
-  basicDetail: {
-    name?: string;
-    teamNum?: string;
-    role?: string;
-    contributionRate?: string;
-    company?: string;
-    employmentStatus?: string;
-    organizationName?: string;
-  };
-  skillTags: string[];
-  competencyTags: string[];
-  detail: {
-    situation: string;
-    task: string;
-    action: string;
-    result: string;
-    taken: string;
-  };
-}
-
-export interface ExperienceCardGridProps extends React.ComponentProps<'div'> {
-  experiences: ExperienceItem[];
-  selectedExperienceId?: string;
-  sortable?: boolean;
-  onExperienceClick?: (experience: ExperienceItem) => void;
-  onExperienceDelete?: (experience: ExperienceItem) => Promise<void> | void;
-  onExperienceReorder?: (experienceIds: string[]) => void;
-  onExperienceTitleSave?: (experience: ExperienceItem, nextTitle: string) => Promise<void> | void;
-}
-
-export type ExperienceSortableCardGridProps = Omit<ExperienceCardGridProps, 'sortable'> & {
-  onReady?: () => void;
-};
+export type { ExperienceCardGridProps, ExperienceItem } from './experienceCardGridTypes';
 
 const ExperienceSortableCardGrid = dynamic<ExperienceSortableCardGridProps>(
   () => import('@/app/(pages)/experience/_components/ExperienceSortableCardGrid'),

--- a/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
@@ -39,11 +39,11 @@ export function ExperienceCardGrid({
     setSortableGridReady(true);
   }, []);
 
-  const grid = (
+  const renderGrid = (gridProps?: React.ComponentProps<'div'>) => (
     <div
       data-slot="experience-card-grid"
       className={cn(EXPERIENCE_CARD_GRID_CLASS_NAME, className)}
-      {...props}
+      {...gridProps}
     >
       {experiences.map((experience) => (
         <ExperienceCard
@@ -63,13 +63,16 @@ export function ExperienceCardGrid({
     </div>
   );
 
+  const grid = renderGrid(props);
+  const fallbackGrid = renderGrid();
+
   if (!sortable) {
     return grid;
   }
 
   return (
     <>
-      {!sortableGridReady && grid}
+      {!sortableGridReady && fallbackGrid}
       <ExperienceSortableCardGrid
         experiences={experiences}
         selectedExperienceId={selectedExperienceId}

--- a/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCardGrid.tsx
@@ -1,12 +1,17 @@
 import * as React from 'react';
-import { arrayMove } from '@dnd-kit/helpers';
-import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react';
-import { isSortable } from '@dnd-kit/react/sortable';
 
 import { ExperienceCard } from '@/app/(pages)/experience/_components/ExperienceCard';
-import { SortableExperienceCard } from '@/app/(pages)/experience/_components/SortableExperienceCard';
 import type { ExperienceCategory } from '@/app/(pages)/experience/_components/ExperienceCategoryTab';
 import { cn } from '@/lib/utils';
+
+const ExperienceSortableCardGrid = React.lazy(() =>
+  import('@/app/(pages)/experience/_components/ExperienceSortableCardGrid').then((mod) => ({
+    default: mod.ExperienceSortableCardGrid,
+  })),
+);
+
+export const EXPERIENCE_CARD_GRID_CLASS_NAME =
+  'grid w-full grid-cols-2 gap-x-4 gap-y-5 min-[1720px]:grid-cols-3';
 
 export interface ExperienceItem {
   id: string;
@@ -61,64 +66,27 @@ export function ExperienceCardGrid({
   className,
   ...props
 }: ExperienceCardGridProps) {
-  const handleDragEnd = React.useCallback(
-    (event: DragEndEvent) => {
-      if (event.canceled) {
-        return;
-      }
-
-      const { source } = event.operation;
-
-      if (!isSortable(source)) {
-        return;
-      }
-
-      const { initialIndex, index } = source;
-
-      if (initialIndex === index) {
-        return;
-      }
-
-      const nextExperiences = arrayMove(experiences, initialIndex, index);
-
-      onExperienceReorder?.(nextExperiences.map((experience) => experience.id));
-    },
-    [experiences, onExperienceReorder],
-  );
-
   const grid = (
     <div
       data-slot="experience-card-grid"
-      className={cn('grid w-full grid-cols-2 gap-x-4 gap-y-5 min-[1720px]:grid-cols-3', className)}
+      className={cn(EXPERIENCE_CARD_GRID_CLASS_NAME, className)}
       {...props}
     >
-      {experiences.map((experience, index) =>
-        sortable ? (
-          <SortableExperienceCard
-            key={experience.id}
-            experience={experience}
-            index={index}
-            selected={selectedExperienceId === experience.id}
-            onClick={onExperienceClick}
-            onDelete={onExperienceDelete}
-            onTitleSave={onExperienceTitleSave}
-          />
-        ) : (
-          <ExperienceCard
-            key={experience.id}
-            type={experience.type}
-            title={experience.title}
-            period={experience.period}
-            skillTags={experience.skillTags}
-            competencyTags={experience.competencyTags}
-            selected={selectedExperienceId === experience.id}
-            className="max-w-none"
-            onClick={() => onExperienceClick?.(experience)}
-            onDelete={() => onExperienceDelete?.(experience)}
-            onTitleSave={(nextTitle) => onExperienceTitleSave?.(experience, nextTitle)}
-          />
-        ),
-      )}
+      {experiences.map((experience) => (
+        <ExperienceCard
+          key={experience.id}
+          type={experience.type}
+          title={experience.title}
+          period={experience.period}
+          skillTags={experience.skillTags}
+          competencyTags={experience.competencyTags}
+          selected={selectedExperienceId === experience.id}
+          className="max-w-none"
+          onClick={() => onExperienceClick?.(experience)}
+          onDelete={() => onExperienceDelete?.(experience)}
+          onTitleSave={(nextTitle) => onExperienceTitleSave?.(experience, nextTitle)}
+        />
+      ))}
     </div>
   );
 
@@ -126,5 +94,18 @@ export function ExperienceCardGrid({
     return grid;
   }
 
-  return <DragDropProvider onDragEnd={handleDragEnd}>{grid}</DragDropProvider>;
+  return (
+    <React.Suspense fallback={grid}>
+      <ExperienceSortableCardGrid
+        experiences={experiences}
+        selectedExperienceId={selectedExperienceId}
+        onExperienceClick={onExperienceClick}
+        onExperienceDelete={onExperienceDelete}
+        onExperienceReorder={onExperienceReorder}
+        onExperienceTitleSave={onExperienceTitleSave}
+        className={className}
+        {...props}
+      />
+    </React.Suspense>
+  );
 }

--- a/src/app/(pages)/experience/_components/ExperienceSortableCardGrid.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceSortableCardGrid.tsx
@@ -8,11 +8,11 @@ import * as React from 'react';
 import {
   EXPERIENCE_CARD_GRID_CLASS_NAME,
   type ExperienceSortableCardGridProps,
-} from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+} from '@/app/(pages)/experience/_components/experienceCardGridTypes';
 import { SortableExperienceCard } from '@/app/(pages)/experience/_components/SortableExperienceCard';
 import { cn } from '@/lib/utils';
 
-export function ExperienceSortableCardGrid({
+export default function ExperienceSortableCardGrid({
   experiences,
   selectedExperienceId,
   onExperienceClick,
@@ -74,5 +74,3 @@ export function ExperienceSortableCardGrid({
     </DragDropProvider>
   );
 }
-
-export default ExperienceSortableCardGrid;

--- a/src/app/(pages)/experience/_components/ExperienceSortableCardGrid.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceSortableCardGrid.tsx
@@ -1,0 +1,73 @@
+'use client';
+
+import { arrayMove } from '@dnd-kit/helpers';
+import { DragDropProvider, type DragEndEvent } from '@dnd-kit/react';
+import { isSortable } from '@dnd-kit/react/sortable';
+import * as React from 'react';
+
+import {
+  EXPERIENCE_CARD_GRID_CLASS_NAME,
+  type ExperienceCardGridProps,
+} from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+import { SortableExperienceCard } from '@/app/(pages)/experience/_components/SortableExperienceCard';
+import { cn } from '@/lib/utils';
+
+type ExperienceSortableCardGridProps = Omit<ExperienceCardGridProps, 'sortable'>;
+
+export function ExperienceSortableCardGrid({
+  experiences,
+  selectedExperienceId,
+  onExperienceClick,
+  onExperienceDelete,
+  onExperienceReorder,
+  onExperienceTitleSave,
+  className,
+  ...props
+}: ExperienceSortableCardGridProps) {
+  const handleDragEnd = React.useCallback(
+    (event: DragEndEvent) => {
+      if (event.canceled) {
+        return;
+      }
+
+      const { source } = event.operation;
+
+      if (!isSortable(source)) {
+        return;
+      }
+
+      const { initialIndex, index } = source;
+
+      if (initialIndex === index) {
+        return;
+      }
+
+      const nextExperiences = arrayMove(experiences, initialIndex, index);
+
+      onExperienceReorder?.(nextExperiences.map((experience) => experience.id));
+    },
+    [experiences, onExperienceReorder],
+  );
+
+  return (
+    <DragDropProvider onDragEnd={handleDragEnd}>
+      <div
+        data-slot="experience-card-grid"
+        className={cn(EXPERIENCE_CARD_GRID_CLASS_NAME, className)}
+        {...props}
+      >
+        {experiences.map((experience, index) => (
+          <SortableExperienceCard
+            key={experience.id}
+            experience={experience}
+            index={index}
+            selected={selectedExperienceId === experience.id}
+            onClick={onExperienceClick}
+            onDelete={onExperienceDelete}
+            onTitleSave={onExperienceTitleSave}
+          />
+        ))}
+      </div>
+    </DragDropProvider>
+  );
+}

--- a/src/app/(pages)/experience/_components/ExperienceSortableCardGrid.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceSortableCardGrid.tsx
@@ -7,12 +7,10 @@ import * as React from 'react';
 
 import {
   EXPERIENCE_CARD_GRID_CLASS_NAME,
-  type ExperienceCardGridProps,
+  type ExperienceSortableCardGridProps,
 } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
 import { SortableExperienceCard } from '@/app/(pages)/experience/_components/SortableExperienceCard';
 import { cn } from '@/lib/utils';
-
-type ExperienceSortableCardGridProps = Omit<ExperienceCardGridProps, 'sortable'>;
 
 export function ExperienceSortableCardGrid({
   experiences,
@@ -21,9 +19,14 @@ export function ExperienceSortableCardGrid({
   onExperienceDelete,
   onExperienceReorder,
   onExperienceTitleSave,
+  onReady,
   className,
   ...props
 }: ExperienceSortableCardGridProps) {
+  React.useEffect(() => {
+    onReady?.();
+  }, [onReady]);
+
   const handleDragEnd = React.useCallback(
     (event: DragEndEvent) => {
       if (event.canceled) {
@@ -71,3 +74,5 @@ export function ExperienceSortableCardGrid({
     </DragDropProvider>
   );
 }
+
+export default ExperienceSortableCardGrid;

--- a/src/app/(pages)/experience/_components/SortableExperienceCard.tsx
+++ b/src/app/(pages)/experience/_components/SortableExperienceCard.tsx
@@ -1,7 +1,7 @@
 import { useSortable } from '@dnd-kit/react/sortable';
 
 import { ExperienceCard } from '@/app/(pages)/experience/_components/ExperienceCard';
-import type { ExperienceItem } from '@/app/(pages)/experience/_components/ExperienceCardGrid';
+import type { ExperienceItem } from '@/app/(pages)/experience/_components/experienceCardGridTypes';
 import { cn } from '@/lib/utils';
 
 export interface SortableExperienceCardProps {

--- a/src/app/(pages)/experience/_components/experienceCardGridTypes.ts
+++ b/src/app/(pages)/experience/_components/experienceCardGridTypes.ts
@@ -1,0 +1,52 @@
+import type * as React from 'react';
+
+import type { ExperienceCategory } from '@/app/(pages)/experience/_components/ExperienceCategoryTab';
+
+export const EXPERIENCE_CARD_GRID_CLASS_NAME =
+  'grid w-full grid-cols-2 gap-x-4 gap-y-5 min-[1720px]:grid-cols-3';
+
+export interface ExperienceItem {
+  id: string;
+  type: Exclude<ExperienceCategory, 'all'>;
+  title: string;
+  description: string;
+  startDate: string;
+  endDate: string;
+  period: string;
+  detailInfo: {
+    label: string;
+    value: string;
+  }[];
+  basicDetail: {
+    name?: string;
+    teamNum?: string;
+    role?: string;
+    contributionRate?: string;
+    company?: string;
+    employmentStatus?: string;
+    organizationName?: string;
+  };
+  skillTags: string[];
+  competencyTags: string[];
+  detail: {
+    situation: string;
+    task: string;
+    action: string;
+    result: string;
+    taken: string;
+  };
+}
+
+export interface ExperienceCardGridProps extends React.ComponentProps<'div'> {
+  experiences: ExperienceItem[];
+  selectedExperienceId?: string;
+  sortable?: boolean;
+  onExperienceClick?: (experience: ExperienceItem) => void;
+  onExperienceDelete?: (experience: ExperienceItem) => Promise<void> | void;
+  onExperienceReorder?: (experienceIds: string[]) => void;
+  onExperienceTitleSave?: (experience: ExperienceItem, nextTitle: string) => Promise<void> | void;
+}
+
+export type ExperienceSortableCardGridProps = Omit<ExperienceCardGridProps, 'sortable'> & {
+  onReady?: () => void;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

#188 

## 📝작업 내용

경험 목록 초기 렌더링 시 불필요하게 함께 로드되던 드래그앤드롭 관련 코드를 별도 청크로 분리했습니다.

- `ExperienceCardGrid`에서 `@dnd-kit` 관련 동기 import 제거
- `ExperienceSortableCardGrid` 컴포넌트 분리
- 일반 카드 그리드를 먼저 렌더링하고, sortable 기능은 `React.lazy`로 지연 로드
- 초기 경험 카드 렌더 전에 DnD 라이브러리 로드 부담을 줄이도록 개선

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized experience card grid by extracting sortable behavior into its own component module.
  * Consolidated shared type definitions and grid styling constants to a dedicated types module.
  * Updated component imports to reference the new types module for better code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->