### PR TITLE
ci: Playwright E2E 워크플로우 추가

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,44 @@
+name: Playwright E2E
+
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - run: pnpm exec playwright install --with-deps chromium
+
+      - run: pnpm test:e2e
+
+      - name: Upload Playwright report
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          if-no-files-found: ignore
+          retention-days: 7


### PR DESCRIPTION
## #️⃣연관된 이슈

#201 

## 📝작업 내용

- PR 검증 시 Playwright E2E 테스트가 실행되도록 GitHub Actions 워크플로우를 추가했습니다.
- `main`, `dev` 대상 PR에서 E2E workflow가 실행되도록 설정했습니다.
- CI에서 pnpm 의존성 설치 후 Playwright Chromium을 설치하고 `pnpm test:e2e`를 실행하도록 구성했습니다.
- E2E 실패 시 디버깅할 수 있도록 `playwright-report`, `test-results`를 artifact로 업로드하도록 설정했습니다.
- 수동 실행을 위해 `workflow_dispatch`를 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
