### PR TITLE
[Test] 주요 사용자 플로우 E2E 테스트 확장

### DIFF
--- a/e2e/apply.spec.ts
+++ b/e2e/apply.spec.ts
@@ -1,16 +1,46 @@
 import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
-import { mockApplyListApi, mockUserProfileApi } from './fixtures/api';
+import {
+  mockApplyDetailApi,
+  mockApplyListApi,
+  mockUserProfileApi,
+} from './fixtures/api';
 import { mockAuthenticatedSession } from './fixtures/auth';
 
-test('인증 상태에서 지원 목록을 보여준다', async ({ page }) => {
+async function setupAuthenticatedApplyPage(page: Page) {
   await mockAuthenticatedSession(page);
   await mockUserProfileApi(page);
   await mockApplyListApi(page);
+}
+
+test('인증 상태에서 지원 목록을 보여준다', async ({ page }) => {
+  await setupAuthenticatedApplyPage(page);
 
   await page.goto('/apply/list');
 
   await expect(page.getByRole('heading', { name: '지원 관리' })).toBeVisible();
   await expect(page.getByText('E2E 지원 공고')).toBeVisible();
   await expect(page.getByText('끼움테스트')).toBeVisible();
+});
+
+test('지원 공고에서 자기소개서 작성 화면으로 이동한다', async ({ page }) => {
+  await setupAuthenticatedApplyPage(page);
+  await mockApplyDetailApi(page);
+
+  await page.goto('/apply/list');
+  await page.getByRole('link', { name: '자기소개서 작성하기' }).click();
+
+  await expect(page).toHaveURL(/\/apply\/?\?jdId=1/);
+  await expect(page.getByRole('heading', { name: 'E2E 지원 공고' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: '공고 분석' })).toBeVisible();
+  await expect(page.getByRole('heading', { name: '내 경험' })).toBeVisible();
+  await expect(page.getByText('사용자 경험 개선')).toBeVisible();
+
+  await page.getByRole('button', { name: '자기소개서 작성' }).click();
+
+  await expect(page.getByRole('heading', { name: '경험 선택 및 자기소개서 작성' })).toBeVisible();
+  await expect(page.getByText('지원 동기를 작성해주세요.')).toBeVisible();
+  await expect(page.getByPlaceholder('여기에 자기소개서를 작성해보세요.')).toBeVisible();
+  await expect(page.getByText('선택된 경험이 여기에 표시됩니다')).toBeVisible();
 });

--- a/e2e/experience-add.spec.ts
+++ b/e2e/experience-add.spec.ts
@@ -1,11 +1,64 @@
 import { expect, test } from '@playwright/test';
+import type { Page } from '@playwright/test';
 
-import { mockUserProfileApi } from './fixtures/api';
+import { mockExperienceCreateApi, mockUserProfileApi } from './fixtures/api';
 import { mockAuthenticatedSession } from './fixtures/auth';
 
-test('인증 상태에서 경험 추가 첫 단계에서 기본 정보 단계로 이동한다', async ({ page }) => {
+async function setupAuthenticatedExperienceAddPage(page: Page) {
   await mockAuthenticatedSession(page);
   await mockUserProfileApi(page);
+}
+
+async function selectCurrentMonthDateRange(page: Page) {
+  await page.getByRole('button', { name: '0000년 00월 00일 ~ 0000년 00월 00일' }).click();
+
+  const datePicker = page.getByRole('dialog', { name: '날짜 선택' });
+  await datePicker.getByRole('button', { name: '1', exact: true }).first().click();
+  await datePicker.getByRole('button', { name: '2', exact: true }).first().click();
+}
+
+async function fillEtcBasicInfo(page: Page) {
+  await page.getByRole('button', { name: '기타' }).click();
+  await page.getByPlaceholder('제목을 작성해주세요.').fill('E2E 직접 입력 경험');
+  await page
+    .getByPlaceholder('이 경험을 간단히 설명해주세요.')
+    .fill('직접 입력으로 저장되는 경험입니다.');
+  await selectCurrentMonthDateRange(page);
+}
+
+async function fillCoreInfo(page: Page) {
+  await page
+    .getByPlaceholder('이 경험을 통해 달성하고자 했던 목표를 구체적으로 작성해주세요.')
+    .fill('사용자가 경험을 직접 입력해 저장할 수 있도록 검증했습니다.');
+  await page
+    .getByPlaceholder('직면했던 문제나 해결해야 했던 과제를 작성해주세요.')
+    .fill('필수 입력값과 단계 이동을 함께 확인해야 했습니다.');
+  await page
+    .getByPlaceholder('문제 해결을 위해 구체적으로 어떤 행동을 했는지 작성해주세요.')
+    .fill('기본 정보, 핵심 경험, 결과 확인 단계를 순서대로 입력했습니다.');
+  await page
+    .getByPlaceholder(
+      '수치화된 성과(KPI)를 포함하여 결과를 작성해주세요. 예: 전환율 20% 상승, 참여자 100명 증가',
+    )
+    .fill('E2E 테스트에서 저장 완료 화면까지 도달했습니다.');
+  await page
+    .getByPlaceholder('이 경험을 통해 배운 점이나 성장한 부분을 작성해주세요.')
+    .fill('직접 입력 플로우의 회귀를 빠르게 확인할 수 있습니다.');
+}
+
+async function addResultTags(page: Page) {
+  await page.getByRole('button', { name: '기술 태그 수정' }).click();
+  await page.getByLabel('기술 태그 입력').fill('Playwright');
+  await page.getByRole('button', { name: 'Playwright 태그 추가' }).click();
+  await page.getByRole('heading', { name: '결과 확인' }).click();
+
+  await page.getByRole('button', { name: '역량 태그 수정' }).click();
+  await page.getByLabel('역량 태그 입력').fill('꼼꼼함');
+  await page.getByRole('button', { name: '꼼꼼함 태그 추가' }).click();
+}
+
+test('인증 상태에서 경험 추가 첫 단계에서 기본 정보 단계로 이동한다', async ({ page }) => {
+  await setupAuthenticatedExperienceAddPage(page);
 
   await page.goto('/experience/add');
 
@@ -16,4 +69,37 @@ test('인증 상태에서 경험 추가 첫 단계에서 기본 정보 단계로
   await page.getByRole('button', { name: '다음' }).click();
 
   await expect(page.getByRole('heading', { name: '기본 정보 입력' })).toBeVisible();
+});
+
+test('자료 없이 직접 입력한 경험을 저장한다', async ({ page }) => {
+  let createRequestBody: Record<string, unknown> | null = null;
+
+  await setupAuthenticatedExperienceAddPage(page);
+  await mockExperienceCreateApi(page, (requestBody) => {
+    createRequestBody = requestBody;
+  });
+
+  await page.goto('/experience/add');
+  await page.getByRole('button', { name: '다음' }).click();
+  await fillEtcBasicInfo(page);
+  await page.getByRole('button', { name: '다음' }).click();
+
+  await expect(page.getByRole('heading', { name: '핵심 경험 입력' })).toBeVisible();
+  await fillCoreInfo(page);
+  await page.getByRole('button', { name: '다음' }).click();
+
+  await expect(page.getByRole('heading', { name: '결과 확인' })).toBeVisible();
+  await addResultTags(page);
+  await page.getByRole('button', { name: '저장하기' }).click();
+
+  await expect(page.getByRole('heading', { name: '경험 추가가 완료되었습니다!' })).toBeVisible();
+  expect(createRequestBody).toMatchObject({
+    type: 'ETC',
+    title: 'E2E 직접 입력 경험',
+    oneLineIntro: '직접 입력으로 저장되는 경험입니다.',
+    tags: [
+      { category: 'TECH', field: 'Playwright' },
+      { category: 'COMPETENCY', field: '꼼꼼함' },
+    ],
+  });
 });

--- a/e2e/experience-add.spec.ts
+++ b/e2e/experience-add.spec.ts
@@ -5,6 +5,7 @@ import { mockExperienceCreateApi, mockUserProfileApi } from './fixtures/api';
 import { mockAuthenticatedSession } from './fixtures/auth';
 
 async function setupAuthenticatedExperienceAddPage(page: Page) {
+  await page.clock.setFixedTime(new Date('2026-03-15'));
   await mockAuthenticatedSession(page);
   await mockUserProfileApi(page);
 }

--- a/e2e/experience-add.spec.ts
+++ b/e2e/experience-add.spec.ts
@@ -73,12 +73,8 @@ test('인증 상태에서 경험 추가 첫 단계에서 기본 정보 단계로
 });
 
 test('자료 없이 직접 입력한 경험을 저장한다', async ({ page }) => {
-  let createRequestBody: Record<string, unknown> | null = null;
-
   await setupAuthenticatedExperienceAddPage(page);
-  await mockExperienceCreateApi(page, (requestBody) => {
-    createRequestBody = requestBody;
-  });
+  await mockExperienceCreateApi(page);
 
   await page.goto('/experience/add');
   await page.getByRole('button', { name: '다음' }).click();
@@ -91,7 +87,15 @@ test('자료 없이 직접 입력한 경험을 저장한다', async ({ page }) =
 
   await expect(page.getByRole('heading', { name: '결과 확인' })).toBeVisible();
   await addResultTags(page);
+
+  const createRequestPromise = page.waitForRequest(
+    (request) => request.url().includes('/api/v1/experiences') && request.method() === 'POST',
+  );
+
   await page.getByRole('button', { name: '저장하기' }).click();
+
+  const createRequest = await createRequestPromise;
+  const createRequestBody = createRequest.postDataJSON();
 
   await expect(page.getByRole('heading', { name: '경험 추가가 완료되었습니다!' })).toBeVisible();
   expect(createRequestBody).toMatchObject({

--- a/e2e/experience.spec.ts
+++ b/e2e/experience.spec.ts
@@ -1,12 +1,16 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page } from '@playwright/test';
 
 import { mockExperienceApi, mockUserProfileApi } from './fixtures/api';
 import { mockAuthenticatedSession } from './fixtures/auth';
 
-test('인증 상태에서 경험 목록을 보고 상세 패널을 열고 닫는다', async ({ page }) => {
+async function setupAuthenticatedExperiencePage(page: Page) {
   await mockAuthenticatedSession(page);
   await mockUserProfileApi(page);
   await mockExperienceApi(page);
+}
+
+test('인증 상태에서 경험 목록을 보고 상세 패널을 열고 닫는다', async ({ page }) => {
+  await setupAuthenticatedExperiencePage(page);
 
   await page.goto('/experience');
 
@@ -23,4 +27,56 @@ test('인증 상태에서 경험 목록을 보고 상세 패널을 열고 닫는
 
   await page.getByRole('button', { name: '경험 상세 패널 닫기' }).click();
   await expect(detailPanel).toHaveCount(0);
+});
+
+test('경험 카테고리 필터로 목록을 좁힌다', async ({ page }) => {
+  await setupAuthenticatedExperiencePage(page);
+
+  await page.goto('/experience');
+  await page.getByRole('tab', { name: '인턴/직무경력' }).click();
+
+  await expect(page).toHaveURL(/category=career/);
+  await expect(page.getByRole('button', { name: /E2E 커리어 경험/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /E2E 경험 카드/ })).toHaveCount(0);
+});
+
+test('검색어로 경험 목록을 필터링한다', async ({ page }) => {
+  await setupAuthenticatedExperiencePage(page);
+
+  await page.goto('/experience');
+  await page
+    .getByPlaceholder('경험 제목, 기술 태그, 역량 태그를 검색해주세요')
+    .fill('검색 대상');
+
+  await expect(page.getByRole('button', { name: /E2E 검색 대상 경험/ })).toBeVisible();
+  await expect(page.getByRole('button', { name: /E2E 경험 카드/ })).toHaveCount(0);
+});
+
+test('상세 패널에서 상세 페이지로 확장하고 다시 패널로 돌아온다', async ({ page }) => {
+  await setupAuthenticatedExperiencePage(page);
+
+  await page.goto('/experience');
+
+  const experienceCard = page.getByRole('button', { name: /E2E 경험 카드/ }).first();
+  await experienceCard.click();
+
+  await expect(page.getByRole('dialog', { name: '상세 경험' })).toBeVisible();
+  await page.getByRole('button', { name: '경험 상세 확장 보기' }).click();
+
+  await expect(page).toHaveURL(/view=detail/);
+  await expect(page.getByRole('heading', { name: '상세 경험' })).toBeVisible();
+  await expect(page.getByText('E2E 상세 한 줄 소개')).toBeVisible();
+
+  await page.getByRole('button', { name: '경험 상세 패널로 돌아가기' }).click();
+
+  await expect(page).toHaveURL(/selected=1/);
+  await expect(page.getByRole('dialog', { name: '상세 경험' })).toBeVisible();
+});
+
+test('잘못된 상세 URL은 404 화면을 보여준다', async ({ page }) => {
+  await setupAuthenticatedExperiencePage(page);
+
+  await page.goto('/experience?view=detail&selected=abc');
+
+  await expect(page.getByRole('heading', { name: 'Page Not Found' })).toBeVisible();
 });

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -43,6 +43,113 @@ function throwUnexpectedApiMethod(route: Route): never {
   throw new Error(`Unexpected E2E API method: ${request.method()} ${request.url()}`);
 }
 
+const experienceCards = [
+  {
+    pieceId: 101,
+    experienceId: 1,
+    type: 'ACTIVITY',
+    title: 'E2E 경험 카드',
+    oneLineIntro: 'E2E 한 줄 소개',
+    startDate: '2026-01-01',
+    endDate: '2026-02-01',
+    tags: [
+      { category: 'TECH', field: 'Playwright' },
+      { category: 'COMPETENCY', field: '문제해결' },
+    ],
+  },
+  {
+    pieceId: 102,
+    experienceId: 2,
+    type: 'CAREER',
+    title: 'E2E 커리어 경험',
+    oneLineIntro: 'E2E 커리어 한 줄 소개',
+    startDate: '2026-02-01',
+    endDate: '2026-03-01',
+    tags: [
+      { category: 'TECH', field: 'React' },
+      { category: 'COMPETENCY', field: '협업' },
+    ],
+  },
+  {
+    pieceId: 103,
+    experienceId: 3,
+    type: 'ETC',
+    title: 'E2E 검색 대상 경험',
+    oneLineIntro: '검색 대상 한 줄 소개',
+    startDate: '2026-03-01',
+    endDate: '2026-04-01',
+    tags: [
+      { category: 'TECH', field: '검색태그' },
+      { category: 'COMPETENCY', field: '집중력' },
+    ],
+  },
+];
+
+type ExperienceDetailMock = Record<string, unknown>;
+
+const experienceDetails: Record<string, ExperienceDetailMock> = {
+  1: {
+    ...experienceCards[0],
+    oneLineIntro: 'E2E 상세 한 줄 소개',
+    situation: 'E2E 상황',
+    task: 'E2E 과제',
+    act: 'E2E 행동',
+    result: 'E2E 결과',
+    taken: 'E2E 배운 점',
+    detail: {
+      name: 'E2E 활동',
+      teamNum: 4,
+      role: '프론트엔드',
+      contributionRate: 80,
+      startDate: '2026-01-01',
+      endDate: '2026-02-01',
+    },
+  },
+  2: {
+    ...experienceCards[1],
+    situation: 'E2E 커리어 상황',
+    task: 'E2E 커리어 과제',
+    act: 'E2E 커리어 행동',
+    result: 'E2E 커리어 결과',
+    taken: 'E2E 커리어 배운 점',
+    detail: {
+      name: 'E2E 커리어',
+      company: '끼움컴퍼니',
+      employmentStatus: '인턴',
+      startDate: '2026-02-01',
+      endDate: '2026-03-01',
+    },
+  },
+  3: {
+    ...experienceCards[2],
+    situation: 'E2E 검색 상황',
+    task: 'E2E 검색 과제',
+    act: 'E2E 검색 행동',
+    result: 'E2E 검색 결과',
+    taken: 'E2E 검색 배운 점',
+    detail: {
+      startDate: '2026-03-01',
+      endDate: '2026-04-01',
+    },
+  },
+};
+
+function getMockExperienceCards(url: URL) {
+  const type = url.searchParams.get('type');
+  const keyword = url.searchParams.get('keyword')?.trim().toLowerCase() ?? '';
+
+  return experienceCards.filter((experience) => {
+    const matchesType = !type || experience.type === type;
+    const matchesKeyword =
+      keyword.length === 0 ||
+      [experience.title, experience.oneLineIntro, ...experience.tags.map((tag) => tag.field)].some(
+        (value) => value.toLowerCase().includes(keyword),
+      );
+
+    return matchesType && matchesKeyword;
+  });
+}
+
 export async function mockUserProfileApi(page: Page) {
   await page.route('**/api/v1/users/me/profile', async (route) => {
     await fulfillApiSuccess(route, {
@@ -66,50 +173,16 @@ export async function mockExperienceApi(page: Page) {
       await fulfillApiSuccess(route, {
         hasNext: false,
         nextCursor: null,
-        experiences: [
-          {
-            pieceId: 101,
-            experienceId: 1,
-            type: 'ACTIVITY',
-            title: 'E2E 경험 카드',
-            oneLineIntro: 'E2E 한 줄 소개',
-            startDate: '2026-01-01',
-            endDate: '2026-02-01',
-            tags: [
-              { category: 'TECH', field: 'Playwright' },
-              { category: 'COMPETENCY', field: '문제해결' },
-            ],
-          },
-        ],
+        experiences: getMockExperienceCards(url),
       });
       return;
     }
 
-    if (url.pathname === '/api/v1/experiences/1') {
-      await fulfillApiSuccess(route, {
-        pieceId: 101,
-        experienceId: 1,
-        type: 'ACTIVITY',
-        title: 'E2E 경험 카드',
-        oneLineIntro: 'E2E 상세 한 줄 소개',
-        situation: 'E2E 상황',
-        task: 'E2E 과제',
-        act: 'E2E 행동',
-        result: 'E2E 결과',
-        taken: 'E2E 배운 점',
-        tags: [
-          { category: 'TECH', field: 'Playwright' },
-          { category: 'COMPETENCY', field: '문제해결' },
-        ],
-        detail: {
-          name: 'E2E 활동',
-          teamNum: 4,
-          role: '프론트엔드',
-          contributionRate: 80,
-          startDate: '2026-01-01',
-          endDate: '2026-02-01',
-        },
-      });
+    const experienceId = url.pathname.match(/^\/api\/v1\/experiences\/(\d+)$/)?.[1];
+    const experienceDetail = experienceId ? experienceDetails[experienceId] : undefined;
+
+    if (experienceDetail) {
+      await fulfillApiSuccess(route, experienceDetail);
       return;
     }
 

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -255,3 +255,101 @@ export async function mockApplyListApi(page: Page) {
     await fulfillUnmockedApi(route);
   });
 }
+
+export async function mockApplyDetailApi(page: Page) {
+  await page.route('**/api/v1/jd/**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+
+    if (request.method() !== 'GET') {
+      throwUnexpectedApiMethod(route);
+    }
+
+    if (url.pathname === '/api/v1/jd/1/resume') {
+      await fulfillApiSuccess(route, {
+        id: 1,
+        postingTitle: 'E2E 지원 공고',
+        companyName: '끼움테스트',
+        recruitmentField: '프론트엔드',
+        startDate: '2026-03-01',
+        endDate: '2026-03-31',
+        questions: [
+          {
+            questionId: 1,
+            orderNum: 1,
+            content: '지원 동기를 작성해주세요.',
+            answer: '',
+            aiDraft: '',
+            hasAiDraft: false,
+          },
+        ],
+      });
+      return;
+    }
+
+    if (url.pathname === '/api/v1/jd/1/analysis') {
+      await fulfillApiSuccess(route, {
+        analysisStatus: 'COMPLETED',
+        jdInfo: {
+          postingTitle: 'E2E 지원 공고',
+          companyName: '끼움테스트',
+          recruitmentField: '프론트엔드',
+          startDate: '2026-03-01',
+          endDate: '2026-03-31',
+          hardSkills: ['Playwright', 'React'],
+          softSkills: ['문제해결'],
+          mainResponsibilities: '사용자 경험 개선\n프론트엔드 품질 관리',
+          requiredQualifications: 'React 경험\n테스트 자동화 경험',
+          preferredQualifications: 'E2E 테스트 운영 경험',
+        },
+        matchResult: {
+          applicationFitScore: 82,
+          experiences: [
+            {
+              experienceId: 1,
+              type: 'ACTIVITY',
+              title: 'E2E 경험 카드',
+              oneLineIntro: 'E2E 한 줄 소개',
+              tags: [
+                { category: 'TECH', field: 'Playwright' },
+                { category: 'COMPETENCY', field: '문제해결' },
+              ],
+              usageFitScore: 91,
+            },
+          ],
+        },
+      });
+      return;
+    }
+
+    await fulfillUnmockedApi(route);
+  });
+
+  await page.route('**/api/v1/resume/jd/**', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+
+    if (request.method() !== 'GET') {
+      throwUnexpectedApiMethod(route);
+    }
+
+    if (url.pathname === '/api/v1/resume/jd/1/questions/1/experiences') {
+      await fulfillApiSuccess(route, {
+        experiences: [
+          {
+            experienceId: 1,
+            type: 'ACTIVITY',
+            title: 'E2E 경험 카드',
+            oneLineIntro: 'E2E 한 줄 소개',
+            startDate: '2026-01-01',
+            endDate: '2026-02-01',
+            usageFitScore: 91,
+          },
+        ],
+      });
+      return;
+    }
+
+    await fulfillUnmockedApi(route);
+  });
+}

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -43,6 +43,10 @@ function throwUnexpectedApiMethod(route: Route): never {
   throw new Error(`Unexpected E2E API method: ${request.method()} ${request.url()}`);
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 const experienceCards = [
   {
     pieceId: 101,
@@ -183,6 +187,34 @@ export async function mockExperienceApi(page: Page) {
 
     if (experienceDetail) {
       await fulfillApiSuccess(route, experienceDetail);
+      return;
+    }
+
+    await fulfillUnmockedApi(route);
+  });
+}
+
+export async function mockExperienceCreateApi(
+  page: Page,
+  onCreate?: (requestBody: Record<string, unknown>) => void,
+) {
+  await page.route('**/api/v1/experiences', async (route) => {
+    const request = route.request();
+    const url = new URL(request.url());
+
+    if (request.method() !== 'POST') {
+      throwUnexpectedApiMethod(route);
+    }
+
+    if (url.pathname === '/api/v1/experiences') {
+      const requestBody = request.postDataJSON();
+
+      if (!isRecord(requestBody)) {
+        throw new Error(`Unexpected E2E create experience body: ${request.postData() ?? ''}`);
+      }
+
+      onCreate?.(requestBody);
+      await fulfillApiSuccess(route, null);
       return;
     }
 

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -194,10 +194,7 @@ export async function mockExperienceApi(page: Page) {
   });
 }
 
-export async function mockExperienceCreateApi(
-  page: Page,
-  onCreate?: (requestBody: Record<string, unknown>) => void,
-) {
+export async function mockExperienceCreateApi(page: Page) {
   await page.route('**/api/v1/experiences', async (route) => {
     const request = route.request();
     const url = new URL(request.url());
@@ -213,7 +210,6 @@ export async function mockExperienceCreateApi(
         throw new Error(`Unexpected E2E create experience body: ${request.postData() ?? ''}`);
       }
 
-      onCreate?.(requestBody);
       await fulfillApiSuccess(route, null);
       return;
     }

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -20,7 +20,7 @@ test.describe('보호 라우트', () => {
     test(`인증되지 않은 사용자는 ${route}에서 로그인으로 이동한다`, async ({ page }) => {
       await page.goto(route, { waitUntil: 'domcontentloaded' });
 
-      await expect(page).toHaveURL(/\/login\/?$/, { timeout: AUTH_REDIRECT_TIMEOUT });
+      await expect(page).toHaveURL(/\/login\/?(?:\?.*)?$/, { timeout: AUTH_REDIRECT_TIMEOUT });
       await expect(page.getByRole('button', { name: '카카오로 로그인' })).toBeVisible();
     });
   }

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -1,15 +1,26 @@
 import { expect, test } from '@playwright/test';
 
+test.describe.configure({ mode: 'serial' });
+
+const AUTH_REDIRECT_TIMEOUT = 15_000;
+
 test('로그인 페이지에서 OAuth 로그인 버튼을 보여준다', async ({ page }) => {
-  await page.goto('/login');
+  await page.goto('/login', { waitUntil: 'domcontentloaded' });
 
   await expect(page.getByAltText('KKIUM 로고')).toBeVisible();
   await expect(page.getByRole('button', { name: '카카오로 로그인' })).toBeVisible();
   await expect(page.getByRole('button', { name: '구글로 로그인' })).toBeVisible();
 });
 
-test('인증되지 않은 사용자는 보호 라우트에서 로그인으로 이동한다', async ({ page }) => {
-  await page.goto('/experience');
+test.describe('보호 라우트', () => {
+  const protectedRoutes = ['/experience', '/experience/add', '/apply/list', '/apply'] as const;
 
-  await expect(page).toHaveURL(/\/login\/?$/);
+  for (const route of protectedRoutes) {
+    test(`인증되지 않은 사용자는 ${route}에서 로그인으로 이동한다`, async ({ page }) => {
+      await page.goto(route, { waitUntil: 'domcontentloaded' });
+
+      await expect(page).toHaveURL(/\/login\/?$/, { timeout: AUTH_REDIRECT_TIMEOUT });
+      await expect(page.getByRole('button', { name: '카카오로 로그인' })).toBeVisible();
+    });
+  }
 });

--- a/e2e/login.spec.ts
+++ b/e2e/login.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '@playwright/test';
 
+// dev 서버 병렬 부하에서 로그인 화면 로딩과 보호 라우트 리다이렉트가 불안정해 순차 실행한다.
 test.describe.configure({ mode: 'serial' });
 
 const AUTH_REDIRECT_TIMEOUT = 15_000;


### PR DESCRIPTION
## #️⃣연관된 이슈

#206 

## 📝작업 내용

- 경험 관리 E2E 테스트를 확장했습니다.
  - 경험 목록 조회
  - 상세 패널 열기/닫기
  - 카테고리 필터
  - 검색
  - 상세 페이지 이동
  - 잘못된 상세 URL 404 처리

- 경험 추가 E2E 테스트를 확장했습니다.
  - 기본 정보 단계 이동
  - 자료 없이 직접 입력 후 저장 완료

- 지원 관리 E2E 테스트를 확장했습니다.
  - 지원 목록 조회
  - 자기소개서 작성 화면 이동

- 로그인/인증 E2E 테스트를 확장했습니다.
  - 로그인 페이지 OAuth 버튼 노출
  - 비인증 사용자의 보호 라우트 접근 시 로그인 이동

- 위 테스트 흐름에 필요한 mock API fixture를 보강했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced end-to-end test coverage for apply and experience workflows, including navigation flows, filtering, and form submissions
  * Refactored test setup with reusable authenticated helpers to improve maintainability
  * Added parameterized protected route testing for better coverage across multiple pages
  * Expanded mock API fixtures to support richer test data and experience creation flows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->