### PR TITLE
[Perf] 경험 페이지 초기 렌더링 성능 개선

### DIFF
--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -16,9 +16,9 @@ import { useExperienceBoardReorder } from '@/app/(pages)/experience/_hooks/useEx
 import { useExperienceBoardSelection } from '@/app/(pages)/experience/_hooks/useExperienceBoardSelection';
 import { mapExperienceCardToItem } from '@/app/(pages)/experience/_utils/mapExperienceResponse';
 import type { PieceType } from '@/app/api/experience/types';
-import { ConfirmDialog } from '@/components/common/ConfirmDialog';
+import type { ConfirmDialogProps } from '@/components/common/ConfirmDialog';
 import { EmptyState } from '@/components/common/EmptyState';
-import { ErrorDialog } from '@/components/common/ErrorDialog';
+import type { ErrorDialogProps } from '@/components/common/ErrorDialog';
 import { useInfiniteExperiences } from '@/hooks/experience/useExperiences';
 import { cn } from '@/lib/utils';
 
@@ -37,6 +37,16 @@ const filterPieceTypeByCategory: Record<
   education: 'EDUCATION',
   etc: 'ETC',
 };
+
+const ConfirmDialog = dynamic<ConfirmDialogProps>(
+  () => import('@/components/common/ConfirmDialog').then((mod) => mod.ConfirmDialog),
+  { ssr: false },
+);
+
+const ErrorDialog = dynamic<ErrorDialogProps>(
+  () => import('@/components/common/ErrorDialog').then((mod) => mod.ErrorDialog),
+  { ssr: false },
+);
 
 const ExperienceDetailPanel = dynamic<ExperienceDetailPanelProps>(
   () =>
@@ -156,9 +166,7 @@ export function ExperienceBoard({
       />
       {/* TODO: 로딩/에러 상태 전용 UI가 확정되면 임시 EmptyState를 교체한다. */}
       {showListLoading ? (
-        <div className="flex flex-1 items-center justify-center">
-          <EmptyState title="경험을 불러오는 중이에요" illustrationLabel="경험 목록 로딩 중" />
-        </div>
+        <ExperienceCardGridSkeleton />
       ) : isError ? (
         <div className="flex flex-1 items-center justify-center">
           <EmptyState
@@ -204,26 +212,53 @@ export function ExperienceBoard({
           onClose={handlePanelClose}
         />
       )}
-      <ConfirmDialog
-        open={Boolean(deleteTargetExperience)}
-        title="정말로 삭제하시겠습니까?"
-        description="삭제시 모든 기록과 분석 내용이 소멸됩니다."
-        confirmLabel="삭제하기"
-        confirming={isDeletingExperience}
-        destructive
-        onOpenChange={handleDeleteDialogOpenChange}
-        onConfirm={() => {
-          if (deleteTargetExperience) {
-            void handleExperienceDeleteConfirm(deleteTargetExperience);
-          }
-        }}
-      />
-      <ErrorDialog
-        open={errorMessage.length > 0}
-        message={errorMessage}
-        onOpenChange={handleErrorDialogOpenChange}
-      />
+      {deleteTargetExperience && (
+        <ConfirmDialog
+          open
+          title="정말로 삭제하시겠습니까?"
+          description="삭제시 모든 기록과 분석 내용이 소멸됩니다."
+          confirmLabel="삭제하기"
+          confirming={isDeletingExperience}
+          destructive
+          onOpenChange={handleDeleteDialogOpenChange}
+          onConfirm={() => void handleExperienceDeleteConfirm(deleteTargetExperience)}
+        />
+      )}
+      {errorMessage.length > 0 && (
+        <ErrorDialog open message={errorMessage} onOpenChange={handleErrorDialogOpenChange} />
+      )}
     </section>
+  );
+}
+
+function ExperienceCardGridSkeleton() {
+  return (
+    <div
+      aria-label="경험 목록 로딩 중"
+      className="grid w-full grid-cols-2 gap-x-4 gap-y-5 min-[1720px]:grid-cols-3"
+    >
+      {Array.from({ length: 6 }).map((_, index) => (
+        <div
+          key={index}
+          className="flex min-h-[214px] w-full animate-pulse flex-col justify-between gap-2 rounded-xl border border-border-default bg-background-w px-[18px] py-5"
+        >
+          <div className="flex w-full items-start justify-between">
+            <div className="size-[72px] rounded-full bg-gray-100" />
+            <div className="size-8 rounded bg-gray-100" />
+          </div>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <div className="h-7 w-3/4 rounded bg-gray-200" />
+              <div className="h-4 w-1/2 rounded bg-gray-100" />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <div className="h-6 w-40 rounded-full bg-gray-100" />
+              <div className="h-6 w-28 rounded-full bg-gray-100" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
   );
 }
 

--- a/src/app/(pages)/experience/_components/ExperienceBoard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceBoard.tsx
@@ -153,6 +153,20 @@ export function ExperienceBoard({
     experienceOrderMap,
     setExperienceOrderMap,
   });
+  const [shouldRenderDeleteDialog, setShouldRenderDeleteDialog] = React.useState(false);
+  const [shouldRenderErrorDialog, setShouldRenderErrorDialog] = React.useState(false);
+
+  React.useEffect(() => {
+    if (deleteTargetExperience) {
+      setShouldRenderDeleteDialog(true);
+    }
+  }, [deleteTargetExperience]);
+
+  React.useEffect(() => {
+    if (errorMessage.length > 0) {
+      setShouldRenderErrorDialog(true);
+    }
+  }, [errorMessage]);
 
   return (
     <section
@@ -212,20 +226,28 @@ export function ExperienceBoard({
           onClose={handlePanelClose}
         />
       )}
-      {deleteTargetExperience && (
+      {shouldRenderDeleteDialog && (
         <ConfirmDialog
-          open
+          open={Boolean(deleteTargetExperience)}
           title="정말로 삭제하시겠습니까?"
           description="삭제시 모든 기록과 분석 내용이 소멸됩니다."
           confirmLabel="삭제하기"
           confirming={isDeletingExperience}
           destructive
           onOpenChange={handleDeleteDialogOpenChange}
-          onConfirm={() => void handleExperienceDeleteConfirm(deleteTargetExperience)}
+          onConfirm={() => {
+            if (deleteTargetExperience) {
+              void handleExperienceDeleteConfirm(deleteTargetExperience);
+            }
+          }}
         />
       )}
-      {errorMessage.length > 0 && (
-        <ErrorDialog open message={errorMessage} onOpenChange={handleErrorDialogOpenChange} />
+      {shouldRenderErrorDialog && (
+        <ErrorDialog
+          open={errorMessage.length > 0}
+          message={errorMessage}
+          onOpenChange={handleErrorDialogOpenChange}
+        />
       )}
     </section>
   );

--- a/src/app/(pages)/experience/_components/ExperienceCard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCard.tsx
@@ -1,14 +1,32 @@
+'use client';
+
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
 
-import { ErrorDialog } from '@/components/common/ErrorDialog';
+import type { ErrorDialogProps } from '@/components/common/ErrorDialog';
 import { Tag } from '@/components/common/Tag';
 import { getExperienceCategoryIconSrc } from '@/app/(pages)/experience/_utils/ExperienceCategory';
 import { EXPERIENCE_FIELD_MAX_LENGTHS } from '@/app/(pages)/experience/_utils/experienceFieldLimits';
+import { MoreVerticalIcon } from '@/components/common/icons/MoreVerticalIcon';
 import { cn } from '@/lib/utils';
-import { ExperienceCardDropdownMenu } from './ExperienceCardDropdownMenu';
+import type { ExperienceCardDropdownMenuProps } from './ExperienceCardDropdownMenu';
 import type { ExperienceCategory } from './ExperienceCategoryTab';
+
+const ErrorDialog = dynamic<ErrorDialogProps>(
+  () => import('@/components/common/ErrorDialog').then((mod) => mod.ErrorDialog),
+  { ssr: false },
+);
+
+const ExperienceCardDropdownMenu = dynamic<ExperienceCardDropdownMenuProps>(
+  () =>
+    import('./ExperienceCardDropdownMenu').then((mod) => mod.ExperienceCardDropdownMenu),
+  {
+    ssr: false,
+    loading: ExperienceCardDropdownMenuLoading,
+  },
+);
 
 const experienceCardVariants = cva(
   'flex w-full flex-col justify-between gap-2 overflow-hidden rounded-xl border border-border-default bg-background-w px-[18px] py-5 transition-shadow focus-visible:shadow-focus-ring focus-visible:outline-none',
@@ -225,19 +243,35 @@ export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>
             </div>
           </div>
         </article>
-        <ErrorDialog
-          open={errorMessage.length > 0}
-          message={errorMessage}
-          onOpenChange={(open) => {
-            if (!open) {
-              setErrorMessage('');
-            }
-          }}
-        />
+        {errorMessage.length > 0 && (
+          <ErrorDialog
+            open
+            message={errorMessage}
+            onOpenChange={(open) => {
+              if (!open) {
+                setErrorMessage('');
+              }
+            }}
+          />
+        )}
       </>
     );
   },
 );
+
+function ExperienceCardDropdownMenuLoading() {
+  return (
+    <button
+      type="button"
+      aria-label="경험 카드 메뉴 불러오는 중"
+      aria-disabled="true"
+      tabIndex={-1}
+      className="flex size-8 shrink-0 items-center justify-center text-gray-main"
+    >
+      <MoreVerticalIcon className="size-6" />
+    </button>
+  );
+}
 
 function TagRow({
   tags,

--- a/src/app/(pages)/experience/_components/ExperienceCard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCard.tsx
@@ -9,23 +9,13 @@ import type { ErrorDialogProps } from '@/components/common/ErrorDialog';
 import { Tag } from '@/components/common/Tag';
 import { getExperienceCategoryIconSrc } from '@/app/(pages)/experience/_utils/ExperienceCategory';
 import { EXPERIENCE_FIELD_MAX_LENGTHS } from '@/app/(pages)/experience/_utils/experienceFieldLimits';
-import { MoreVerticalIcon } from '@/components/common/icons/MoreVerticalIcon';
 import { cn } from '@/lib/utils';
-import type { ExperienceCardDropdownMenuProps } from './ExperienceCardDropdownMenu';
+import { ExperienceCardDropdownMenu } from './ExperienceCardDropdownMenu';
 import type { ExperienceCategory } from './ExperienceCategoryTab';
 
 const ErrorDialog = dynamic<ErrorDialogProps>(
   () => import('@/components/common/ErrorDialog').then((mod) => mod.ErrorDialog),
   { ssr: false },
-);
-
-const ExperienceCardDropdownMenu = dynamic<ExperienceCardDropdownMenuProps>(
-  () =>
-    import('./ExperienceCardDropdownMenu').then((mod) => mod.ExperienceCardDropdownMenu),
-  {
-    ssr: false,
-    loading: ExperienceCardDropdownMenuLoading,
-  },
 );
 
 const experienceCardVariants = cva(
@@ -265,20 +255,6 @@ export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>
     );
   },
 );
-
-function ExperienceCardDropdownMenuLoading() {
-  return (
-    <button
-      type="button"
-      aria-label="경험 카드 메뉴 불러오는 중"
-      aria-disabled="true"
-      tabIndex={-1}
-      className="flex size-8 shrink-0 items-center justify-center text-gray-main"
-    >
-      <MoreVerticalIcon className="size-6" />
-    </button>
-  );
-}
 
 function TagRow({
   tags,

--- a/src/app/(pages)/experience/_components/ExperienceCard.tsx
+++ b/src/app/(pages)/experience/_components/ExperienceCard.tsx
@@ -94,6 +94,7 @@ export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>
     const [isEditingTitle, setIsEditingTitle] = React.useState(false);
     const [isTitleSaving, setIsTitleSaving] = React.useState(false);
     const [errorMessage, setErrorMessage] = React.useState('');
+    const [shouldRenderErrorDialog, setShouldRenderErrorDialog] = React.useState(false);
     const titleInputRef = React.useRef<HTMLInputElement>(null);
     const isCommittingTitleRef = React.useRef(false);
 
@@ -112,6 +113,12 @@ export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>
       titleInput?.focus();
       titleInput?.setSelectionRange(titleInput.value.length, titleInput.value.length);
     }, [isEditingTitle]);
+
+    React.useEffect(() => {
+      if (errorMessage.length > 0) {
+        setShouldRenderErrorDialog(true);
+      }
+    }, [errorMessage]);
 
     const handleKeyDown: React.KeyboardEventHandler<HTMLElement> = (event) => {
       onKeyDown?.(event);
@@ -243,9 +250,9 @@ export const ExperienceCard = React.forwardRef<HTMLElement, ExperienceCardProps>
             </div>
           </div>
         </article>
-        {errorMessage.length > 0 && (
+        {shouldRenderErrorDialog && (
           <ErrorDialog
-            open
+            open={errorMessage.length > 0}
             message={errorMessage}
             onOpenChange={(open) => {
               if (!open) {

--- a/src/app/fonts.ts
+++ b/src/app/fonts.ts
@@ -24,7 +24,7 @@ export const nanumSquare = localFont({
     },
   ],
   display: 'swap',
-  preload: true,
+  preload: false,
   fallback: ['system-ui', 'Apple SD Gothic Neo', 'Malgun Gothic', 'sans-serif'],
   adjustFontFallback: 'Arial',
 });

--- a/src/components/common/ConfirmDialog.tsx
+++ b/src/components/common/ConfirmDialog.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 
-interface ConfirmDialogProps {
+export interface ConfirmDialogProps {
   open: boolean;
   title: string;
   description: string;

--- a/src/components/common/ErrorDialog.tsx
+++ b/src/components/common/ErrorDialog.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from '@/components/ui/button';
 import { WarningTriangleIcon } from '@/components/common/icons/WarningTriangleIcon';
 
-interface ErrorDialogProps {
+export interface ErrorDialogProps {
   open: boolean;
   message: React.ReactNode;
   title?: string;


### PR DESCRIPTION
## #️⃣연관된 이슈

#220 

## 📝작업 내용

- 경험 목록 로딩 상태를 기존 EmptyState에서 카드 그리드 형태의 스켈레톤 UI로 변경했습니다.
- 경험 카드의 드롭다운 메뉴와 에러 다이얼로그를 동적 로딩하도록 변경했습니다.
- 경험 삭제 확인 모달과 에러 모달을 실제로 필요한 시점에만 렌더링하도록 변경했습니다.
- NanumSquare 폰트 preload를 비활성화하여 사용되지 않는 font preload warning을 제거했습니다.
- dynamic import 타입 지정을 위해 `ConfirmDialogProps`, `ErrorDialogProps`를 export하도록 변경했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual loading placeholder with skeleton layout during experience data fetching

* **Bug Fixes**
  * Fixed dialogs appearing unexpectedly when not needed
  * Improved conditional rendering of error messages
  * Enhanced error handling and display behavior

* **Performance**
  * Optimized component loading efficiency
  * Improved font resource management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->