### PR TITLE
fix: 로컬 OAuth 로그인 redirectType 전달

### DIFF
--- a/src/app/_utils/authFetch.test.ts
+++ b/src/app/_utils/authFetch.test.ts
@@ -1,0 +1,47 @@
+describe('requestSocialLogin', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  test('adds local redirect type when kakao redirect uri is localhost', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'https://api.kkium.com';
+    process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI =
+      'http://localhost:3000/oauth/kakao/callback';
+
+    const fetchMock = jest.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          status: 200,
+          code: 'SUCCESS',
+          message: 'OK',
+          data: {
+            accessToken: 'access-token',
+          },
+        }),
+        {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        },
+      ),
+    );
+    global.fetch = fetchMock;
+
+    const { requestSocialLogin } = await import('./authFetch');
+
+    await requestSocialLogin('kakao', 'authorization-code');
+
+    const requestUrl = new URL(fetchMock.mock.calls[0][0]);
+
+    expect(requestUrl.searchParams.get('redirectType')).toBe('LOCAL');
+  });
+});

--- a/src/app/_utils/authFetch.ts
+++ b/src/app/_utils/authFetch.ts
@@ -43,6 +43,15 @@ interface SocialLoginResponse {
   data?: SocialLoginData;
 }
 
+type OAuthRedirectType = 'LOCAL' | 'PROD';
+
+const LOCAL_OAUTH_REDIRECT_HOSTNAMES = new Set([
+  'localhost',
+  '127.0.0.1',
+  '::1',
+  '[::1]',
+]);
+
 function buildApiUrl(path: string) {
   if (!API_BASE_URL) {
     throw new Error('NEXT_PUBLIC_API_BASE_URL is not set.');
@@ -117,6 +126,17 @@ export function resolveOAuthRedirectUri(provider: 'google' | 'kakao'): string {
   return `${window.location.origin}/oauth/${provider}/callback`;
 }
 
+function resolveOAuthRedirectType(provider: 'google' | 'kakao'): OAuthRedirectType {
+  try {
+    const redirectUri = resolveOAuthRedirectUri(provider);
+    const hostname = new URL(redirectUri).hostname;
+
+    return LOCAL_OAUTH_REDIRECT_HOSTNAMES.has(hostname) ? 'LOCAL' : 'PROD';
+  } catch {
+    return 'PROD';
+  }
+}
+
 const inflightSocialLogins = new Map<string, Promise<SocialLoginResult>>();
 
 export function requestSocialLoginOnce(provider: 'google' | 'kakao', code: string) {
@@ -142,6 +162,7 @@ export async function requestSocialLogin(provider: 'google' | 'kakao', code: str
   }
 
   loginUrl.searchParams.set('code', normalizedCode);
+  loginUrl.searchParams.set('redirectType', resolveOAuthRedirectType(provider));
 
   const response = await fetch(loginUrl.toString(), {
     method: 'POST',


### PR DESCRIPTION
## #️⃣연관된 이슈

#223 

## 📝작업 내용

- 소셜 로그인 API 요청 시 OAuth redirect URI 기준으로 `redirectType`을 함께 전달하도록 수정했습니다.
- 로컬 redirect URI(`localhost`, `127.0.0.1`, `::1`)인 경우 `redirectType=LOCAL`, 그 외에는 `redirectType=PROD`로 요청합니다.
- 카카오 로컬 redirect URI에서 `redirectType=LOCAL`이 붙는 단위 테스트를 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced social login to support environment-specific redirect handling.

* **Tests**
  * Added test suite for social login flow with environment validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->