### PR TITLE
[Feat] 토큰 재발급 및 서버 로그아웃 연동

### DIFF
--- a/src/app/_utils/authFetch.test.ts
+++ b/src/app/_utils/authFetch.test.ts
@@ -1,3 +1,55 @@
+function createSessionStorage() {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: jest.fn((key: string) => store.get(key) ?? null),
+    setItem: jest.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: jest.fn((key: string) => {
+      store.delete(key);
+    }),
+  };
+}
+
+function mockBrowserSession() {
+  const sessionStorage = createSessionStorage();
+  const replace = jest.fn();
+
+  Object.defineProperty(globalThis, 'window', {
+    value: {
+      sessionStorage,
+      location: {
+        pathname: '/experience',
+        replace,
+      },
+    },
+    configurable: true,
+  });
+
+  return {
+    replace,
+    sessionStorage,
+  };
+}
+
+function createApiResponse(data: unknown, status = 200) {
+  return new Response(
+    JSON.stringify({
+      status,
+      code: 'SUCCESS',
+      message: 'OK',
+      data,
+    }),
+    {
+      status,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    },
+  );
+}
+
 describe('requestSocialLogin', () => {
   const originalEnv = process.env;
 
@@ -9,6 +61,10 @@ describe('requestSocialLogin', () => {
   afterEach(() => {
     process.env = originalEnv;
     jest.restoreAllMocks();
+    Object.defineProperty(globalThis, 'window', {
+      value: undefined,
+      configurable: true,
+    });
   });
 
   test('adds local redirect type when kakao redirect uri is localhost', async () => {
@@ -43,5 +99,177 @@ describe('requestSocialLogin', () => {
     const requestUrl = new URL(fetchMock.mock.calls[0][0]);
 
     expect(requestUrl.searchParams.get('redirectType')).toBe('LOCAL');
+  });
+
+  test('includes credentials so refresh token cookie can be stored', async () => {
+    process.env.NEXT_PUBLIC_API_BASE_URL = 'https://api.kkium.com';
+    process.env.NEXT_PUBLIC_GOOGLE_REDIRECT_URI =
+      'http://localhost:3000/oauth/google/callback';
+
+    const fetchMock = jest.fn().mockResolvedValue(createApiResponse({ accessToken: 'access-token' }));
+    global.fetch = fetchMock;
+
+    const { requestSocialLogin } = await import('./authFetch');
+
+    await requestSocialLogin('google', 'authorization-code');
+
+    expect(fetchMock.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        credentials: 'include',
+      }),
+    );
+  });
+});
+
+describe('authFetch token reissue', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_API_BASE_URL: 'https://api.kkium.com/api/v1',
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+    Object.defineProperty(globalThis, 'window', {
+      value: undefined,
+      configurable: true,
+    });
+  });
+
+  test('reissues access token and retries original request once after 401', async () => {
+    const { sessionStorage } = mockBrowserSession();
+    sessionStorage.setItem('mg_access_token', 'expired-token');
+
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(createApiResponse({ accessToken: 'new-token' }))
+      .mockResolvedValueOnce(new Response('ok', { status: 200 }));
+    global.fetch = fetchMock;
+
+    const { authFetch, getAccessTokenFromSession } = await import('./authFetch');
+
+    const response = await authFetch('experiences');
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(new URL(fetchMock.mock.calls[1][0]).pathname).toBe('/api/v1/auth/reissue');
+    expect(fetchMock.mock.calls[1][1]).toEqual(
+      expect.objectContaining({
+        credentials: 'include',
+        method: 'POST',
+      }),
+    );
+    expect((fetchMock.mock.calls[2][1].headers as Headers).get('Authorization')).toBe(
+      'Bearer new-token',
+    );
+    expect(getAccessTokenFromSession()).toBe('new-token');
+  });
+
+  test('redirects to login when token reissue fails', async () => {
+    const { replace, sessionStorage } = mockBrowserSession();
+    sessionStorage.setItem('mg_access_token', 'expired-token');
+
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce(new Response(null, { status: 401 }))
+      .mockResolvedValueOnce(new Response(null, { status: 401 }));
+    global.fetch = fetchMock;
+
+    const { authFetch, getAccessTokenFromSession } = await import('./authFetch');
+
+    await expect(authFetch('experiences')).rejects.toThrow('Unauthorized');
+
+    expect(getAccessTokenFromSession()).toBeNull();
+    expect(replace).toHaveBeenCalledWith('/login');
+  });
+
+  test('shares one token reissue request across concurrent 401 responses', async () => {
+    const { sessionStorage } = mockBrowserSession();
+    sessionStorage.setItem('mg_access_token', 'expired-token');
+
+    const fetchMock = jest.fn((input: string) => {
+      const url = new URL(input);
+      if (url.pathname === '/api/v1/auth/reissue') {
+        return Promise.resolve(createApiResponse({ accessToken: 'new-token' }));
+      }
+      const headers = fetchMock.mock.calls.at(-1)?.[1]?.headers as Headers | undefined;
+      if (headers?.get('Authorization') === 'Bearer new-token') {
+        return Promise.resolve(new Response('ok', { status: 200 }));
+      }
+      return Promise.resolve(new Response(null, { status: 401 }));
+    });
+    global.fetch = fetchMock;
+
+    const { authFetch } = await import('./authFetch');
+
+    await Promise.all([authFetch('experiences'), authFetch('users/me')]);
+
+    const reissueCallCount = fetchMock.mock.calls.filter(
+      ([input]) => new URL(input).pathname === '/api/v1/auth/reissue',
+    ).length;
+
+    expect(reissueCallCount).toBe(1);
+  });
+});
+
+describe('requestLogout', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_API_BASE_URL: 'https://api.kkium.com/api/v1',
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+    Object.defineProperty(globalThis, 'window', {
+      value: undefined,
+      configurable: true,
+    });
+  });
+
+  test('calls logout api with credentials and clears local access token', async () => {
+    const { sessionStorage } = mockBrowserSession();
+    sessionStorage.setItem('mg_access_token', 'access-token');
+
+    const fetchMock = jest.fn().mockResolvedValue(new Response(null, { status: 200 }));
+    global.fetch = fetchMock;
+
+    const { getAccessTokenFromSession, requestLogout } = await import('./authFetch');
+
+    await requestLogout();
+
+    expect(new URL(fetchMock.mock.calls[0][0]).pathname).toBe('/api/v1/auth/logout');
+    expect(fetchMock.mock.calls[0][1]).toEqual(
+      expect.objectContaining({
+        credentials: 'include',
+        method: 'POST',
+      }),
+    );
+    expect(getAccessTokenFromSession()).toBeNull();
+  });
+
+  test('clears local access token even when logout api fails', async () => {
+    const { sessionStorage } = mockBrowserSession();
+    sessionStorage.setItem('mg_access_token', 'access-token');
+
+    const fetchMock = jest.fn().mockRejectedValue(new Error('network error'));
+    global.fetch = fetchMock;
+
+    const { getAccessTokenFromSession, requestLogout } = await import('./authFetch');
+
+    await expect(requestLogout()).rejects.toThrow('network error');
+
+    expect(getAccessTokenFromSession()).toBeNull();
   });
 });

--- a/src/app/_utils/authFetch.ts
+++ b/src/app/_utils/authFetch.ts
@@ -43,6 +43,18 @@ interface SocialLoginResponse {
   data?: SocialLoginData;
 }
 
+interface AccessTokenReissueData {
+  accessToken?: string;
+  access_token?: string;
+}
+
+interface AccessTokenReissueResponse {
+  status: number;
+  code: string;
+  message: string;
+  data?: AccessTokenReissueData;
+}
+
 type OAuthRedirectType = 'LOCAL' | 'PROD';
 
 const LOCAL_OAUTH_REDIRECT_HOSTNAMES = new Set([
@@ -61,6 +73,13 @@ function buildApiUrl(path: string) {
   const normalizedPath = path.startsWith('/') ? path.slice(1) : path;
 
   return new URL(normalizedPath, baseWithSlash);
+}
+
+async function readJsonResponse<T>(response: Response): Promise<T | null> {
+  const contentType = response.headers.get('Content-Type') ?? '';
+  if (!contentType.includes('application/json')) return null;
+
+  return (await response.json()) as T;
 }
 
 function getStorage() {
@@ -138,6 +157,7 @@ function resolveOAuthRedirectType(provider: 'google' | 'kakao'): OAuthRedirectTy
 }
 
 const inflightSocialLogins = new Map<string, Promise<SocialLoginResult>>();
+let inflightAccessTokenReissue: Promise<string> | null = null;
 
 export function requestSocialLoginOnce(provider: 'google' | 'kakao', code: string) {
   const normalizedCode = code.trim();
@@ -169,15 +189,11 @@ export async function requestSocialLogin(provider: 'google' | 'kakao', code: str
     headers: {
       Accept: 'application/json',
     },
+    credentials: 'include',
     cache: 'no-store',
   });
 
-  const contentType = response.headers.get('Content-Type') ?? '';
-  let payload: SocialLoginResponse | null = null;
-
-  if (contentType.includes('application/json')) {
-    payload = (await response.json()) as SocialLoginResponse;
-  }
+  const payload = await readJsonResponse<SocialLoginResponse>(response);
 
   if (response.status === 401) {
     redirectToLoginOnUnauthorized();
@@ -206,6 +222,66 @@ export async function requestSocialLogin(provider: 'google' | 'kakao', code: str
     accessToken,
     termsAgreed: isExplicitTermsAgreed(payload.data),
   };
+}
+
+export async function requestAccessTokenReissue() {
+  const reissueUrl = buildApiUrl('/auth/reissue');
+
+  const response = await fetch(reissueUrl.toString(), {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+    },
+    credentials: 'include',
+    cache: 'no-store',
+  });
+
+  const payload = await readJsonResponse<AccessTokenReissueResponse>(response);
+
+  if (!response.ok) {
+    const message = payload?.message ?? `Access token reissue failed (${response.status})`;
+    throw new Error(message);
+  }
+
+  if (!payload) {
+    throw new Error('Invalid access token reissue response format.');
+  }
+
+  const accessToken = payload.data?.accessToken ?? payload.data?.access_token;
+
+  if (!accessToken) {
+    throw new Error('Access token is missing in reissue response.');
+  }
+
+  saveAuthTokensToSession(accessToken);
+  return accessToken;
+}
+
+function requestAccessTokenReissueOnce() {
+  if (inflightAccessTokenReissue) return inflightAccessTokenReissue;
+
+  inflightAccessTokenReissue = requestAccessTokenReissue().finally(() => {
+    inflightAccessTokenReissue = null;
+  });
+
+  return inflightAccessTokenReissue;
+}
+
+export async function requestLogout() {
+  const logoutUrl = buildApiUrl('/auth/logout');
+
+  try {
+    await fetch(logoutUrl.toString(), {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+      },
+      credentials: 'include',
+      cache: 'no-store',
+    });
+  } finally {
+    clearAccessTokenFromSession();
+  }
 }
 
 export async function requestTermsAgreement(termsAgreed: boolean) {
@@ -263,13 +339,7 @@ export function consumeOAuthState(provider: 'google' | 'kakao') {
   return state;
 }
 
-export async function authFetch(path: string, init: AuthFetchInit = {}) {
-  const accessToken = getAccessTokenFromSession();
-
-  if (!accessToken) {
-    throw new Error('Access token session is missing.');
-  }
-
+function buildAuthenticatedRequest(path: string, init: AuthFetchInit, accessToken: string) {
   const url = buildApiUrl(path);
   const headers = new Headers(init.headers);
 
@@ -279,16 +349,53 @@ export async function authFetch(path: string, init: AuthFetchInit = {}) {
     headers.set('Content-Type', 'application/json');
   }
 
+  return {
+    requestInit: {
+      ...init,
+      headers,
+      cache: init.cache ?? 'no-store',
+    },
+    url,
+  };
+}
+
+export async function authFetch(path: string, init: AuthFetchInit = {}) {
+  const accessToken = getAccessTokenFromSession();
+
+  if (!accessToken) {
+    throw new Error('Access token session is missing.');
+  }
+
+  const { requestInit, url } = buildAuthenticatedRequest(path, init, accessToken);
   const response = await fetch(url.toString(), {
-    ...init,
-    headers,
-    cache: init.cache ?? 'no-store',
+    ...requestInit,
   });
 
-  if (response.status === 401) {
+  if (response.status !== 401) {
+    return response;
+  }
+
+  let reissuedAccessToken: string;
+  try {
+    reissuedAccessToken = await requestAccessTokenReissueOnce();
+  } catch {
     redirectToLoginOnUnauthorized();
     throw new Error('Unauthorized');
   }
 
-  return response;
+  const { requestInit: retryRequestInit, url: retryUrl } = buildAuthenticatedRequest(
+    path,
+    init,
+    reissuedAccessToken,
+  );
+  const retryResponse = await fetch(retryUrl.toString(), {
+    ...retryRequestInit,
+  });
+
+  if (retryResponse.status === 401) {
+    redirectToLoginOnUnauthorized();
+    throw new Error('Unauthorized');
+  }
+
+  return retryResponse;
 }

--- a/src/components/common/Sidebar.tsx
+++ b/src/components/common/Sidebar.tsx
@@ -5,11 +5,8 @@ import Link from 'next/link';
 import * as React from 'react';
 import { usePathname, useRouter } from 'next/navigation';
 
-import { clearAccessTokenFromSession } from '@/app/_utils/authFetch';
-import {
-  AccountDialog,
-  getProfileOptionByIllustrateId,
-} from '@/components/common/AccountDialog';
+import { clearAccessTokenFromSession, requestLogout } from '@/app/_utils/authFetch';
+import { AccountDialog, getProfileOptionByIllustrateId } from '@/components/common/AccountDialog';
 import { ApplicationIcon } from '@/components/common/icons/ApplicationIcon';
 import { ExperienceIcon } from '@/components/common/icons/ExperienceIcon';
 import { HomeIcon } from '@/components/common/icons/HomeIcon';
@@ -102,9 +99,10 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
   };
 
   const handleLogoutClick = () => {
-    clearAccessTokenFromSession();
     setIsProfileMenuOpen(false);
-    router.replace('/login');
+    void requestLogout().finally(() => {
+      router.replace('/login');
+    });
   };
 
   const handleProfileColorChange = async (illustrateId: number) => {
@@ -165,7 +163,11 @@ export function Sidebar({ collapsed = false }: SidebarProps) {
             )}
           >
             <SidebarProfileMenuItem label="계정" icon={SettingsIcon} onClick={handleAccountClick} />
-            <SidebarProfileMenuItem label="로그아웃" icon={LogoutIcon} onClick={handleLogoutClick} />
+            <SidebarProfileMenuItem
+              label="로그아웃"
+              icon={LogoutIcon}
+              onClick={handleLogoutClick}
+            />
           </div>
         )}
 
@@ -229,7 +231,7 @@ function SidebarProfileMenuItem({
   return (
     <button
       type="button"
-      className="flex h-12 w-full cursor-pointer items-center gap-4 rounded-md px-2.5 py-2 text-left body-1-bold text-primary outline-none transition-colors hover:bg-gray-200 focus-visible:shadow-focus-ring"
+      className="flex h-12 w-full cursor-pointer items-center gap-4 rounded-md px-2.5 py-2 text-left body-1-bold text-primary transition-colors outline-none hover:bg-gray-200 focus-visible:shadow-focus-ring"
       onClick={onClick}
     >
       <span className="flex size-8 shrink-0 items-center justify-center">


### PR DESCRIPTION
## #️⃣연관된 이슈

#225 

## 📝작업 내용

- 소셜 로그인 요청에 `credentials: 'include'`를 추가하여 백엔드에서 내려주는 refresh token 쿠키가 저장될 수 있도록 수정했습니다.
- access token 만료로 API 요청이 401을 반환하면 `POST /auth/reissue`를 호출해 access token을 재발급받고, 기존 요청을 1회 재시도하도록 구현했습니다.
- 동시에 여러 요청이 401을 반환하는 경우 재발급 요청이 중복 호출되지 않도록 진행 중인 재발급 Promise를 공유하도록 처리했습니다.
- 재발급 실패 시 access token을 제거하고 로그인 화면으로 이동하도록 처리했습니다.
- 로그아웃 시 `POST /auth/logout` API를 호출하여 서버 refresh token 삭제 및 쿠키 만료 흐름을 연동했습니다.
- 로그아웃 API 실패 여부와 관계없이 클라이언트 access token은 제거되도록 보장했습니다.
- 인증 재발급 및 로그아웃 흐름에 대한 단위 테스트를 추가했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
